### PR TITLE
test tooling updates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  },
   "plugins": [
     "react-hot-loader/babel"
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage/
 dist/
 node_modules/
 web/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function karmaConfig(config) {
     browserNoActivityTimeout: 60000,
     singleRun: true,
     colors: true,
-    frameworks: ['mocha', 'chai'],
+    frameworks: ['mocha', 'chai', 'sinon'],
     files: [
       'loadtests.js',
     ],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,16 @@
+const path = require('path');
 const webpackConf = require('./webpack.config.js');
+
+webpackConf.module.preLoaders = [
+  {
+    test: /\.(js)$/,
+    loader: 'isparta-loader',
+    include: [
+      path.join(__dirname, '/../src'),
+    ],
+  },
+];
+
 webpackConf.externals = {
   cheerio: 'window',
   'react/addons': true,
@@ -20,10 +32,17 @@ module.exports = function karmaConfig(config) {
     preprocessors: {
       'loadtests.js': ['webpack'],
     },
-    reporters: ['mocha'],
+    reporters: ['mocha', 'coverage'],
     webpack: webpackConf,
     webpackServer: {
       noInfo: true,
+    },
+    coverageReporter: {
+      dir: 'coverage/',
+      reporters: [
+        { type: 'html' },
+        { type: 'text' },
+      ],
     },
   });
 };

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
   ],
   "main": "dist/index.js",
   "scripts": {
-    "browser-tests": "./node_modules/.bin/karma start --browsers Chrome",
+    "browser-tests": "NODE_ENV=test ./node_modules/.bin/karma start --browsers Chrome",
     "build": "npm test && npm run clean && ./node_modules/.bin/babel src --out-dir dist --copy-files",
     "clean": "./node_modules/.bin/rimraf ./dist/*",
-    "karma-watch": "./node_modules/.bin/karma start --no-single-run --reporters=mocha,notification",
+    "karma-watch": "NODE_ENV=test ./node_modules/.bin/karma start --no-single-run --reporters=mocha,notification",
     "lint": "./node_modules/.bin/eslint .storybook/ src/ stories/ test/ *.js",
     "pretest": "npm run lint",
     "start": "./node_modules/.bin/babel src --out-dir dist --copy-files --watch",
     "storybook": "./node_modules/.bin/start-storybook -c storybook -p 8081",
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "NODE_ENV=test ./node_modules/karma/bin/karma start"
   },
   "repository": {
     "type": "git",
@@ -36,6 +36,7 @@
     "babel-core": "6.11.4",
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
+    "babel-plugin-istanbul": "2.0.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-0": "6.5.0",
@@ -55,6 +56,7 @@
     "karma": "1.1.1",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "1.0.1",
+    "karma-coverage": "1.1.1",
     "karma-mocha": "1.1.1",
     "karma-mocha-reporter": "2.0.4",
     "karma-notification-reporter": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-mocha-reporter": "2.0.4",
     "karma-notification-reporter": "0.1.1",
     "karma-phantomjs-launcher": "1.0.1",
+    "karma-sinon": "1.0.5",
     "karma-webpack": "1.7.0",
     "lodash": "3.10.1",
     "mocha": "2.5.3",
@@ -75,6 +76,7 @@
     "react-redux": "4.4.5",
     "redux": "3.5.2",
     "rimraf": "2.5.4",
+    "sinon": "1.17.5",
     "style-loader": "0.13.1",
     "webpack": "1.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "browser-tests": "NODE_ENV=test ./node_modules/.bin/karma start --browsers Chrome",
     "build": "npm test && npm run clean && ./node_modules/.bin/babel src --out-dir dist --copy-files",
     "clean": "./node_modules/.bin/rimraf ./dist/*",
-    "karma-watch": "NODE_ENV=test ./node_modules/.bin/karma start --no-single-run --reporters=mocha,notification",
+    "test-watch": "NODE_ENV=test ./node_modules/.bin/karma start --no-single-run --reporters=mocha,notification",
     "lint": "./node_modules/.bin/eslint .storybook/ src/ stories/ test/ *.js",
     "pretest": "npm run lint",
     "start": "./node_modules/.bin/babel src --out-dir dist --copy-files --watch",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,8 @@
 {
   "globals": {
     "assert": false,
-    "expect": false
+    "expect": false,
+    "sinon": false
   },
   "rules": {
     "no-unused-expressions": 0


### PR DESCRIPTION
Changes:
- add sinon framework for spies, stubs, &c
- add test coverage reporting
- change `npm run karma-watch` command to `npm run test-watch`

Ping @jh-bate 