### PR TITLE
use webpack with "library" options for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 coverage/
 dist/
 node_modules/

--- a/package.config.js
+++ b/package.config.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const baseConfig = require('./webpack.config');
+
+const packageConfig = _.cloneDeep(baseConfig);
+
+packageConfig.output.libraryTarget = 'commonjs';
+
+packageConfig.externals = {
+  classnames: 'classnames',
+  'd3-array': 'd3-array',
+  'd3-format': 'd3-format',
+  'd3-scale': 'd3-scale',
+  'd3-shape': 'd3-shape',
+  'd3-time': 'd3-time',
+  lodash: 'lodash',
+  'moment-timezone': 'moment-timezone',
+  'react-addons-update': 'react-addons-update',
+  'react-motion': 'react-motion',
+  'react-redux': 'react-redux',
+  redux: 'redux',
+  react: 'react',
+  'simple-statistics': 'simple-statistics',
+};
+
+module.exports = packageConfig;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
     "babel-plugin-istanbul": "2.0.0",
+    "babel-polyfill": "6.13.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-0": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "main": "dist/index.js",
   "scripts": {
     "browser-tests": "NODE_ENV=test ./node_modules/.bin/karma start --browsers Chrome",
-    "build": "npm test && npm run clean && ./node_modules/.bin/babel src --out-dir dist --copy-files",
+    "build": "NODE_ENV=production npm test && npm run clean && ./node_modules/.bin/webpack --config package.config.js",
     "clean": "./node_modules/.bin/rimraf ./dist/*",
     "test-watch": "NODE_ENV=test ./node_modules/.bin/karma start --no-single-run --reporters=mocha,notification",
     "lint": "./node_modules/.bin/eslint .storybook/ src/ stories/ test/ *.js",
     "pretest": "npm run lint",
-    "start": "./node_modules/.bin/babel src --out-dir dist --copy-files --watch",
+    "start": "./node_modules/.bin/webpack --config package.config.js --watch",
     "storybook": "./node_modules/.bin/start-storybook -c storybook -p 8081",
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start"
   },


### PR DESCRIPTION
OK, here it is @krystophv 

I created a separate config that just builds on the main one a little to keep it cleaner for making changes in the main config as far as loaders. We *do* use the main config for React Storybook.

The main thing that's confusing me a bit is that two copies of React problem is still an issue. I would have that defining React as an `external` would have solved that, but I guess when webpack resolves the dependency, it still looks in the "closest" `node_modules` dir? Not an issue since you may have found another solution to that, just adds to my lack of confidence that I got things right here...

In terms of merge order, this should be merged along with [tideline #283](https://github.com/tidepool-org/tideline/pull/283) and [blip #318](https://github.com/tidepool-org/blip/pull/318), but in terms of testing it out locally, you should try it with branches that actually _use_ the viz repo, which means [tideline jebeck/cgm-trends-iteration.2](https://github.com/tidepool-org/tideline/pull/286), [blip jebeck/cgm-trends-iteration.2](https://github.com/tidepool-org/blip/pull/320) and here [jebeck/cgm-trends-RC](https://github.com/tidepool-org/viz/tree/jebeck/cgm-trends-RC).

Hope this make sense, LMK if there are questions...