### PR TITLE
ensure time binning is >= start and < end for each slice

### DIFF
--- a/src/containers/trends/CBGSlicesAnimationContainer.js
+++ b/src/containers/trends/CBGSlicesAnimationContainer.js
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import React, { PropTypes } from 'react';
 import { TransitionMotion, spring } from 'react-motion';
 
-import { findTimeOfDayBin, calculateStatsForBin } from '../../utils/trends/data';
+import { findBinForTimeOfDay, calculateStatsForBin } from '../../utils/trends/data';
 
 import CBGSlice from '../../components/trends/cbg/CBGSlice';
 
@@ -103,7 +103,7 @@ export default class CBGSlicesAnimationContainer extends React.Component {
   }
 
   mungeData(binSize, data) {
-    const binned = _.groupBy(data, (d) => (findTimeOfDayBin(binSize, d.msPer24)));
+    const binned = _.groupBy(data, (d) => (findBinForTimeOfDay(binSize, d.msPer24)));
     const binKeys = _.keys(binned);
 
     const valueExtractor = (d) => (d.value);

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -21,13 +21,13 @@ import { max, median, min, quantile } from 'd3-array';
 import { TWENTY_FOUR_HRS } from '../datetime';
 
 /**
- * findTimeOfDayBin
+ * findBinForTimeOfDay
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Number} msPer24 - natural number milliseconds into a twenty-four hour day
  *
  * @return {Number} bin
  */
-export function findTimeOfDayBin(binSize, msPer24) {
+export function findBinForTimeOfDay(binSize, msPer24) {
   if (msPer24 < 0 || msPer24 >= TWENTY_FOUR_HRS) {
     throw new Error('`msPer24` < 0 or >= 86400000 is invalid!');
   }

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -31,10 +31,8 @@ export function findTimeOfDayBin(binSize, msPer24) {
   if (msPer24 < 0 || msPer24 >= TWENTY_FOUR_HRS) {
     throw new Error('`msPer24` < 0 or >= 86400000 is invalid!');
   }
-  if (msPer24 === 0) {
-    return binSize / 2;
-  }
-  return Math.ceil(msPer24 / binSize) * binSize - (binSize / 2);
+
+  return Math.floor(msPer24 / binSize) * binSize + (binSize / 2);
 }
 
 /**

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -49,12 +49,12 @@ describe('[trends] data utils', () => {
         expect(utils.findTimeOfDayBin(binSize, 0)).to.equal(1800000);
       });
 
-      it('should assign a bin of `1800000` to a datum at time 3600000', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3600000)).to.equal(1800000);
+      it('should assign a bin of `1800000` to a datum at time 3599999', () => {
+        expect(utils.findTimeOfDayBin(binSize, 3599999)).to.equal(1800000);
       });
 
-      it('should assign a bin of `5400000` to a datum at time 3600001', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3600001)).to.equal(5400000);
+      it('should assign a bin of `5400000` to a datum at time 3600000', () => {
+        expect(utils.findTimeOfDayBin(binSize, 3600000)).to.equal(5400000);
       });
 
       it('should assign a bin of `5400000` to a datum at time 7199999', () => {
@@ -69,12 +69,12 @@ describe('[trends] data utils', () => {
         expect(utils.findTimeOfDayBin(binSize, 0)).to.equal(900000);
       });
 
-      it('should assign a bin of `2700000` to a datum at time 3600000', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3600000)).to.equal(2700000);
+      it('should assign a bin of `2700000` to a datum at time 3599999', () => {
+        expect(utils.findTimeOfDayBin(binSize, 3599999)).to.equal(2700000);
       });
 
-      it('should assign a bin of `4500000` to a datum at time 3600001', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3600001)).to.equal(4500000);
+      it('should assign a bin of `4500000` to a datum at time 3600000', () => {
+        expect(utils.findTimeOfDayBin(binSize, 3600000)).to.equal(4500000);
       });
 
       it('should assign a bin of `6300000` to a datum at time 7199999', () => {

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -20,24 +20,24 @@ import { range, shuffle } from 'd3-array';
 import * as utils from '../../../src/utils/trends/data';
 
 describe('[trends] data utils', () => {
-  describe('findTimeOfDayBin', () => {
+  describe('findBinForTimeOfDay', () => {
     it('should be a function', () => {
-      assert.isFunction(utils.findTimeOfDayBin);
+      assert.isFunction(utils.findBinForTimeOfDay);
     });
 
     describe('error conditions', () => {
       it('should error on a negative msPer24', () => {
-        const fn = () => (utils.findTimeOfDayBin(1, -1));
+        const fn = () => (utils.findBinForTimeOfDay(1, -1));
         expect(fn).to.throw('`msPer24` < 0 or >= 86400000 is invalid!');
       });
 
       it('should error on a msPer24 = 864e5', () => {
-        const fn = () => (utils.findTimeOfDayBin(1, 86400000));
+        const fn = () => (utils.findBinForTimeOfDay(1, 86400000));
         expect(fn).to.throw('`msPer24` < 0 or >= 86400000 is invalid!');
       });
 
       it('should error on a msPer24 > 864e5', () => {
-        const fn = () => (utils.findTimeOfDayBin(1, 86400001));
+        const fn = () => (utils.findBinForTimeOfDay(1, 86400001));
         expect(fn).to.throw('`msPer24` < 0 or >= 86400000 is invalid!');
       });
     });
@@ -46,19 +46,19 @@ describe('[trends] data utils', () => {
       const binSize = 1000 * 60 * 60;
 
       it('should assign a bin of `1800000` to a datum at time 0', () => {
-        expect(utils.findTimeOfDayBin(binSize, 0)).to.equal(1800000);
+        expect(utils.findBinForTimeOfDay(binSize, 0)).to.equal(1800000);
       });
 
       it('should assign a bin of `1800000` to a datum at time 3599999', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3599999)).to.equal(1800000);
+        expect(utils.findBinForTimeOfDay(binSize, 3599999)).to.equal(1800000);
       });
 
       it('should assign a bin of `5400000` to a datum at time 3600000', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3600000)).to.equal(5400000);
+        expect(utils.findBinForTimeOfDay(binSize, 3600000)).to.equal(5400000);
       });
 
       it('should assign a bin of `5400000` to a datum at time 7199999', () => {
-        expect(utils.findTimeOfDayBin(binSize, 7199999)).to.equal(5400000);
+        expect(utils.findBinForTimeOfDay(binSize, 7199999)).to.equal(5400000);
       });
     });
 
@@ -66,19 +66,19 @@ describe('[trends] data utils', () => {
       const binSize = 1000 * 60 * 30;
 
       it('should assign a bin of `900000` to a datum at time 0', () => {
-        expect(utils.findTimeOfDayBin(binSize, 0)).to.equal(900000);
+        expect(utils.findBinForTimeOfDay(binSize, 0)).to.equal(900000);
       });
 
       it('should assign a bin of `2700000` to a datum at time 3599999', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3599999)).to.equal(2700000);
+        expect(utils.findBinForTimeOfDay(binSize, 3599999)).to.equal(2700000);
       });
 
       it('should assign a bin of `4500000` to a datum at time 3600000', () => {
-        expect(utils.findTimeOfDayBin(binSize, 3600000)).to.equal(4500000);
+        expect(utils.findBinForTimeOfDay(binSize, 3600000)).to.equal(4500000);
       });
 
       it('should assign a bin of `6300000` to a datum at time 7199999', () => {
-        expect(utils.findTimeOfDayBin(binSize, 7199999)).to.equal(6300000);
+        expect(utils.findBinForTimeOfDay(binSize, 7199999)).to.equal(6300000);
       });
     });
   });


### PR DESCRIPTION
What it says on the tin. (Before slicing was > start and <= end which is a bit unintuitive although it usually doesn't matter, but for Animas data with only minute resolution where you actually get data points on the border between slices, it matters.)

For your reviewing pleasure, @jh-bate or @krystophv 