### PR TITLE
test cleanup

### DIFF
--- a/src/components/trends/cbg/FocusedCBGSliceHTMLLabels.js
+++ b/src/components/trends/cbg/FocusedCBGSliceHTMLLabels.js
@@ -30,7 +30,7 @@ const FocusedCBGSliceHTMLLabels = (props) => {
     return null;
   }
 
-  const { bgUnits, focusedKeys: keys, focusedSlice: { slice, position } } = props;
+  const { bgUnits, focusedKeys: keys, focusedSlice: { data, position } } = props;
   const medPos = { left: position.left, top: position.topOptions.median };
 
   function renderLabels(focusedKeys) {
@@ -43,7 +43,7 @@ const FocusedCBGSliceHTMLLabels = (props) => {
       });
       return (
         <div className={valueClasses} key={key} style={absPos}>
-          <span className={styles.number}>{displayBgValue(slice[key], bgUnits)}</span>
+          <span className={styles.number}>{displayBgValue(data[key], bgUnits)}</span>
         </div>
       );
     });
@@ -77,7 +77,7 @@ const FocusedCBGSliceHTMLLabels = (props) => {
     return (
       <div>
         <div className={`${styles.container} ${styles.medianValue}`} style={medPos}>
-          <span className={styles.number}>{displayBgValue(slice.median, bgUnits)}</span>
+          <span className={styles.number}>{displayBgValue(data.median, bgUnits)}</span>
         </div>
         <div className={explainerClasses} style={medPos}>
           <span className={styles.explainerText}>{props.explainers.median}</span>
@@ -88,7 +88,7 @@ const FocusedCBGSliceHTMLLabels = (props) => {
     return (
       <div>
         <div className={`${styles.container} ${styles.medianUnfocused}`} style={medPos}>
-          <span className={styles.plainNumber}>{displayBgValue(slice.median, bgUnits)}</span>
+          <span className={styles.plainNumber}>{displayBgValue(data.median, bgUnits)}</span>
         </div>
         {renderLabels(keys)}
         {_.map(['tenthQuantile', 'ninetiethQuantile'], (key) => {
@@ -100,7 +100,7 @@ const FocusedCBGSliceHTMLLabels = (props) => {
           });
           return (
             <div className={valueClasses} key={key} style={absPos}>
-              <span className={styles.number}>{displayBgValue(slice[key], bgUnits)}</span>
+              <span className={styles.number}>{displayBgValue(data[key], bgUnits)}</span>
             </div>
           );
         })}
@@ -111,7 +111,7 @@ const FocusedCBGSliceHTMLLabels = (props) => {
   return (
     <div>
       <div className={`${styles.container} ${styles.medianUnfocused}`} style={medPos}>
-        <span className={styles.plainNumber}>{displayBgValue(slice.median, bgUnits)}</span>
+        <span className={styles.plainNumber}>{displayBgValue(data.median, bgUnits)}</span>
       </div>
       {renderLabels(keys)}
       {renderExplainers(keys)}

--- a/src/components/trends/cbg/FocusedCBGSliceTime.js
+++ b/src/components/trends/cbg/FocusedCBGSliceTime.js
@@ -26,7 +26,7 @@ const FocusedCBGSliceTime = (props) => {
   if (!focusedSlice) {
     return null;
   }
-  const { slice: { msFrom, msTo } } = focusedSlice;
+  const { data: { msFrom, msTo } } = focusedSlice;
   const { position: { left, topOptions: { max: top } } } = focusedSlice;
   const displayFrom = millisecondsAsTimeOfDay(msFrom, 'h:mm');
   const displayTo = millisecondsAsTimeOfDay(msTo, 'h:mm');

--- a/test/components/trends/cbg/FocusedCBGSliceHTMLLabels.test.js
+++ b/test/components/trends/cbg/FocusedCBGSliceHTMLLabels.test.js
@@ -32,7 +32,7 @@ import styles
 
 describe('FocusedCBGSliceHTMLLabels', () => {
   const focusedSlice = {
-    slice: {
+    data: {
       firstQuartile: 25,
       id: 'a1b2c3',
       max: 421,

--- a/test/components/trends/cbg/FocusedCBGSliceHTMLLabels.test.js
+++ b/test/components/trends/cbg/FocusedCBGSliceHTMLLabels.test.js
@@ -21,6 +21,7 @@ import { shallow } from 'enzyme';
 
 import { formatClassesAsSelector } from '../../../helpers/cssmodules';
 
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../../src/utils/constants';
 import FocusedCBGSliceHTMLLabels
   from '../../../../src/components/trends/cbg/FocusedCBGSliceHTMLLabels';
 import styles
@@ -63,7 +64,7 @@ describe('FocusedCBGSliceHTMLLabels', () => {
   describe('when no focused slice', () => {
     it('should render nothing', () => {
       const minimalProps = {
-        bgUnits: 'mmol/L',
+        bgUnits: MMOLL_UNITS,
       };
       const wrapper = shallow(
         <FocusedCBGSliceHTMLLabels {...minimalProps} />
@@ -78,7 +79,7 @@ describe('FocusedCBGSliceHTMLLabels', () => {
     before(() => {
       wrapper = shallow(
         <FocusedCBGSliceHTMLLabels
-          bgUnits={'mg/dL'}
+          bgUnits={MGDL_UNITS}
           focusedKeys={['median']}
           focusedSlice={focusedSlice}
         />
@@ -102,7 +103,7 @@ describe('FocusedCBGSliceHTMLLabels', () => {
     before(() => {
       wrapper = shallow(
         <FocusedCBGSliceHTMLLabels
-          bgUnits={'mg/dL'}
+          bgUnits={MGDL_UNITS}
           focusedKeys={['min', 'max']}
           focusedSlice={focusedSlice}
         />
@@ -140,7 +141,7 @@ describe('FocusedCBGSliceHTMLLabels', () => {
     before(() => {
       wrapper = shallow(
         <FocusedCBGSliceHTMLLabels
-          bgUnits={'mg/dL'}
+          bgUnits={MGDL_UNITS}
           focusedKeys={['tenthQuantile', 'ninetiethQuantile']}
           focusedSlice={focusedSlice}
         />
@@ -173,7 +174,7 @@ describe('FocusedCBGSliceHTMLLabels', () => {
     before(() => {
       wrapper = shallow(
         <FocusedCBGSliceHTMLLabels
-          bgUnits={'mg/dL'}
+          bgUnits={MGDL_UNITS}
           focusedKeys={['firstQuartile', 'thirdQuartile']}
           focusedSlice={focusedSlice}
         />

--- a/test/components/trends/cbg/FocusedCBGSliceTime.test.js
+++ b/test/components/trends/cbg/FocusedCBGSliceTime.test.js
@@ -26,7 +26,7 @@ import styles from '../../../../src/components/trends/cbg/FocusedCBGSliceTime.cs
 
 describe('FocusedCBGSliceTime', () => {
   const focusedSlice = {
-    slice: {
+    data: {
       firstQuartile: 25,
       id: 'a1b2c3',
       max: 421,

--- a/test/components/trends/common/YAxisLabelsAndTicks.test.js
+++ b/test/components/trends/common/YAxisLabelsAndTicks.test.js
@@ -27,6 +27,7 @@ const {
 } = scales.trends;
 import SVGContainer from '../../../helpers/SVGContainer';
 
+import { MGDL_UNITS } from '../../../../src/utils/constants';
 import YAxisLabelsAndTicks from '../../../../src/components/trends/common/YAxisLabelsAndTicks';
 
 describe('YAxisLabelsAndTicks', () => {
@@ -38,7 +39,7 @@ describe('YAxisLabelsAndTicks', () => {
       targetLowerBound: 80,
       veryLowThreshold: 55,
     },
-    bgUnits: 'mg/dL',
+    bgUnits: MGDL_UNITS,
     margins: {
       top: 0,
       right: 0,

--- a/test/containers/trends/CBGSlicesAnimationContainer.test.js
+++ b/test/containers/trends/CBGSlicesAnimationContainer.test.js
@@ -27,6 +27,7 @@ const {
   trendsYScale: yScale,
 } = scales.trends;
 
+import { THREE_HRS } from '../../../src/utils/datetime';
 import CBGSlicesAnimationContainer
   from '../../../src/containers/trends/CBGSlicesAnimationContainer';
 
@@ -34,7 +35,7 @@ describe('CBGSlicesAnimationContainer', () => {
   let wrapper;
 
   // six-hour bins for testing
-  const binSize = 1000 * 60 * 60 * 6;
+  const binSize = THREE_HRS * 2;
 
   const props = {
     binSize,

--- a/test/containers/trends/SMBGRangeAvgAnimationContainer.test.js
+++ b/test/containers/trends/SMBGRangeAvgAnimationContainer.test.js
@@ -25,6 +25,7 @@ const {
   trendsYScale: yScale,
 } = scales.trends;
 
+import { THREE_HRS } from '../../../src/utils/datetime';
 import SMBGRangeAvgAnimationContainer
   from '../../../src/containers/trends/SMBGRangeAvgAnimationContainer';
 
@@ -32,7 +33,7 @@ describe('SMBGRangeAvgAnimationContainer', () => {
   let wrapper;
 
   // six-hour bins for testing
-  const binSize = 1000 * 60 * 60 * 6;
+  const binSize = THREE_HRS * 2;
 
   const props = {
     binSize,

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -126,8 +126,10 @@ describe('TrendsContainer', () => {
         touched: false,
       },
       focusTrendsCbgSlice: sinon.stub(),
+      focusTrendsSmbgRangeAvg: sinon.stub(),
       markTrendsViewed,
       unfocusTrendsCbgSlice: sinon.stub(),
+      unfocusTrendsSmbgRangeAvg: sinon.stub(),
     };
 
     const mgdl = {

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -24,6 +24,7 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../src/utils/constants';
 import { timezoneAwareCeiling } from '../../../src/utils/datetime';
 import DummyComponent from '../../helpers/DummyComponent';
 
@@ -121,8 +122,8 @@ describe('TrendsContainer', () => {
         timezoneName: timezone,
       },
       yScaleClampTop: {
-        'mg/dL': 300,
-        'mmol/L': 25,
+        [MGDL_UNITS]: 300,
+        [MMOLL_UNITS]: 25,
       },
       onDatetimeLocationChange,
       onSelectDay: sinon.stub(),
@@ -138,7 +139,7 @@ describe('TrendsContainer', () => {
     };
 
     const mgdl = {
-      bgUnits: 'mg/dL',
+      bgUnits: MGDL_UNITS,
       bgBounds: {
         veryHighThreshold: 300,
         targetUpperBound: 180,
@@ -154,7 +155,7 @@ describe('TrendsContainer', () => {
       },
     };
     const mmoll = {
-      bgUnits: 'mmol/L',
+      bgUnits: MMOLL_UNITS,
       bgBounds: {
         veryHighThreshold: 30,
         targetUpperBound: 10,
@@ -332,13 +333,13 @@ describe('TrendsContainer', () => {
         it('should have a minimum yScale domain: [targetLowerBound, yScaleClampTop]', () => {
           const { yScale } = minimalData.state();
           expect(yScale.domain())
-            .to.deep.equal([mgdl.bgBounds.targetLowerBound, props.yScaleClampTop['mg/dL']]);
+            .to.deep.equal([mgdl.bgBounds.targetLowerBound, props.yScaleClampTop[MGDL_UNITS]]);
         });
 
         it('should have a maximum yScale domain: [lowest generated value, yScaleClampTop]', () => {
           const { yScale } = enoughCbgData.state();
           expect(yScale.domain())
-            .to.deep.equal([lowestBg, props.yScaleClampTop['mg/dL']]);
+            .to.deep.equal([lowestBg, props.yScaleClampTop[MGDL_UNITS]]);
         });
       });
 
@@ -351,13 +352,13 @@ describe('TrendsContainer', () => {
         it('should have a minimum yScale domain: [targetLowerBound, yScaleClampTop]', () => {
           const { yScale } = minimalDataMmol.state();
           expect(yScale.domain())
-            .to.deep.equal([mmoll.bgBounds.targetLowerBound, props.yScaleClampTop['mmol/L']]);
+            .to.deep.equal([mmoll.bgBounds.targetLowerBound, props.yScaleClampTop[MMOLL_UNITS]]);
         });
 
         it('should have a maximum yScale domain: [lowest generated value, yScaleClampTop]', () => {
           const { yScale } = enoughCbgDataMmol.state();
           expect(yScale.domain())
-            .to.deep.equal([lowestBgMmol, props.yScaleClampTop['mmol/L']]);
+            .to.deep.equal([lowestBgMmol, props.yScaleClampTop[MMOLL_UNITS]]);
         });
       });
     });

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -32,6 +32,11 @@ import { TrendsContainer, mapStateToProps, mapDispatchToProps }
 import TrendsSVGContainer from '../../../src/containers/trends/TrendsSVGContainer';
 
 describe('TrendsContainer', () => {
+  // stubbing console.warn gets rid of the annoying warnings from react-dimensions
+  // due to not rendering TrendsContainer within a real app like blip
+  // eslint-disable-next-line no-console
+  console.warn = sinon.stub();
+
   describe('TrendsContainer (w/o redux connect()ion)', () => {
     let minimalData;
     let enoughCbgData;

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -22,6 +22,7 @@ import { mount } from 'enzyme';
 
 import { TrendsSVGContainer } from '../../../src/containers/trends/TrendsSVGContainer';
 
+import { MGDL_UNITS } from '../../../src/utils/constants';
 import BackgroundWithTargetRange
   from '../../../src/components/trends/common/BackgroundWithTargetRange';
 import CBGSlicesAnimationContainer
@@ -47,7 +48,7 @@ describe('TrendsSVGContainer', () => {
       targetLowerBound: 80,
       veryLowThreshold: 60,
     },
-    bgUnits: 'mg/dL',
+    bgUnits: MGDL_UNITS,
     // normally provided by react-dimensions wrapper but we test w/o that
     containerHeight: 520,
     // normally provided by react-dimensions wrapper but we test w/o that

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -52,7 +52,8 @@ describe('TrendsSVGContainer', () => {
     containerHeight: 520,
     // normally provided by react-dimensions wrapper but we test w/o that
     containerWidth: 960,
-    data: [],
+    cbgData: [],
+    smbgData: [],
     focusRange: () => {},
     focusSlice: () => {},
     showingCbg: true,

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -15,6 +15,8 @@
  * == BSD2 LICENSE ==
  */
 
+import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
+
 import * as format from '../../src/utils/format';
 
 describe('format', () => {
@@ -29,11 +31,11 @@ describe('format', () => {
     });
 
     it('should return a String integer if `units` are `mg/dL`', () => {
-      expect(format.displayBgValue(120.5, 'mg/dL')).to.equal('121');
+      expect(format.displayBgValue(120.5, MGDL_UNITS)).to.equal('121');
     });
 
     it('should return a String number w/one decimal point precision (`units` are `mmol/L`)', () => {
-      expect(format.displayBgValue(6.6886513292098675, 'mmol/L')).to.equal('6.7');
+      expect(format.displayBgValue(6.6886513292098675, MMOLL_UNITS)).to.equal('6.7');
     });
   });
 });


### PR DESCRIPTION
A small PR that shouldn't need much review. I saw some warnings in the tests (on one of my other branches) and went to investigate. The most serious were places where the renaming from `slice` to `data` in focused things had been skipped. Others were test fixtures that hadn't been updated to match updated code, and react-dimensions was spewing all over the place and obscuring the important ones.

Also tried to add constants back into my tests as we discussed a while ago.

Ping @jh-bate 