### PR TITLE
deps cleanup

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+coverage/
 data/
 src/
 stories/

--- a/.npmignore
+++ b/.npmignore
@@ -11,4 +11,5 @@ test/
 .travis.yml
 karma.conf.js
 loadtests.js
+package.config.js
 webpack.config.js

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We publish this repository as a package to the npm registry for use as a depende
 **dependencies**:
 - dependencies that do *not* exist in blip
 
-**In addition**, the webpack build for the npm package specifies *all* of the `peerDependencies` (i.e., those shared with blip from the `devDependencies`) as `externals` in `package.config.js`. When you add a dependency of this kind, be sure to add it there as well, or the production build will be affected/bloated/potentially break! (You'll be fine in local development with all deps & devDeps installed, so consider yourself warned.)
+**In addition**, the webpack build for the npm package specifies *all* of the `dependencies` and `peerDependencies` (i.e., those shared with blip from the `devDependencies`) as `externals` in `package.config.js`. (This keeps the size of the @tidepool/viz library bundle as small as possible and prevents duplicated bundled external dependencies.) When you add a dependency of either kind, be sure to add it there as well, or the production build will be affected/bloated/potentially break! (You'll be fine in local development with all deps & devDeps installed, so consider yourself warned.)
 
 ## Directory structure
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ Then, install the dependencies:
 $ npm install
 ```
 
+### A note on dependencies
+
+The division between `devDependencies`, `dependencies`, and `peerDependencies` in this repository requires a bit of explanation.
+
+We publish this repository as a package to the npm registry for use as a dependency in [blip](https://github.com/tidepool-org/blip). Some of the dependencies here are *also* dependencies of blip, but some of the added non-tooling (i.e., production) dependencies are unique to the visualization code. In general, we group the dependencies as follows:
+
+**devDependencies**:
+- dependencies for tooling and building
+- dependencies for linting and testing
+- dependencies that exist in blip
+
+**peerDependencies**:
+- dependencies that exist in blip
+
+**dependencies**:
+- dependencies that do *not* exist in blip
+
+**In addition**, the webpack build for the npm package specifies *all* of the `peerDependencies` (i.e., those shared with blip from the `devDependencies`) as `externals` in `package.config.js`. When you add a dependency of this kind, be sure to add it there as well, or the production build will be affected/bloated/potentially break! (You'll be fine in local development with all deps & devDeps installed, so consider yourself warned.)
+
 ## Directory structure
 
 As of September, 2016, the directory structure is as follows (although this may change as we continue to develop new code in this repository):

--- a/package.config.js
+++ b/package.config.js
@@ -7,10 +7,19 @@ packageConfig.output.libraryTarget = 'commonjs';
 
 packageConfig.externals = {
   classnames: 'classnames',
+  'd3-array': 'd3-array',
+  'd3-format': 'd3-format',
+  'd3-scale': 'd3-scale',
+  'd3-shape': 'd3-shape',
+  'd3-time': 'd3-array',
   lodash: 'lodash',
   'moment-timezone': 'moment-timezone',
   react: 'react',
   'react-addons-update': 'react-addons-update',
+  'react-collapse': 'react-collapse',
+  'react-dimensions': 'react-dimensions',
+  'react-height': 'react-height',
+  'react-motion': 'react-motion',
   'react-redux': 'react-redux',
   redux: 'redux',
 };

--- a/package.config.js
+++ b/package.config.js
@@ -7,19 +7,12 @@ packageConfig.output.libraryTarget = 'commonjs';
 
 packageConfig.externals = {
   classnames: 'classnames',
-  'd3-array': 'd3-array',
-  'd3-format': 'd3-format',
-  'd3-scale': 'd3-scale',
-  'd3-shape': 'd3-shape',
-  'd3-time': 'd3-time',
   lodash: 'lodash',
   'moment-timezone': 'moment-timezone',
+  react: 'react',
   'react-addons-update': 'react-addons-update',
-  'react-motion': 'react-motion',
   'react-redux': 'react-redux',
   redux: 'redux',
-  react: 'react',
-  'simple-statistics': 'simple-statistics',
 };
 
 module.exports = packageConfig;

--- a/package.config.js
+++ b/package.config.js
@@ -11,7 +11,7 @@ packageConfig.externals = {
   'd3-format': 'd3-format',
   'd3-scale': 'd3-scale',
   'd3-shape': 'd3-shape',
-  'd3-time': 'd3-array',
+  'd3-time': 'd3-time',
   lodash: 'lodash',
   'moment-timezone': 'moment-timezone',
   react: 'react',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.2.9",
+  "version": "0.2.10-alpha",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "d3-shape": "1.0.3",
     "d3-time": "1.0.2",
     "react-collapse": "2.3.1",
+    "react-dimensions": "2.0.0-alpha1",
     "react-height": "2.1.1",
     "react-motion": "0.4.4"
   },
@@ -107,14 +108,5 @@
     "react-addons-update": "15.x",
     "react-redux": "4.x",
     "redux": "3.x"
-  },
-  "dependencies": {
-    "d3-array": "1.0.1",
-    "d3-format": "1.0.2",
-    "d3-scale": "1.0.3",
-    "d3-shape": "1.0.3",
-    "d3-time": "1.0.2",
-    "react-dimensions": "2.0.0-alpha1",
-    "react-motion": "0.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.2.11-alpha",
+  "version": "0.2.12-alpha",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.2.10-alpha",
+  "version": "0.2.11-alpha",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"


### PR DESCRIPTION
My borking of the merge conflicts on package.json when I was trying to do some simple branch updating clued me in to some mis-categorized dependencies added for the settings work, so that is fixed here.

The tl;dr is: whenever you add a dependency that is used in actual viz code (not tests or tooling), ask yourself: "Is this also a dependency of blip?" (e.g., React)
- YES -> it goes in `devDependencies` **and** `peerDependencies` **and** gets added as an "external" in package.config.js
- NO -> it goes in `dependencies` **and** gets added as an "external" in package.config.js

I have also tried to explain this a bit in the README and would like it if everyone could take a look and LMK if it's clear and if we all understand: ping @krystophv @hntrdglss @jh-bate 

I could go into a lot more detail in the README, as I learned a lot more about how webpack externals and `npm install --production` works today, but I kept it pretty brief/concise for now. 😉