### PR TITLE
more specific body css selector

### DIFF
--- a/src/components/settings/animas/Animas.css
+++ b/src/components/settings/animas/Animas.css
@@ -42,6 +42,6 @@
   composes: lightText from '../../../styles/typography.css';
 }
 
-:global(body) {
+:global(html > body) {
   overflow-y: scroll;
 }

--- a/src/components/settings/medtronic/Medtronic.css
+++ b/src/components/settings/medtronic/Medtronic.css
@@ -42,6 +42,6 @@
   composes: lightText from '../../../styles/typography.css';
 }
 
-:global(body) {
+:global(html > body) {
   overflow-y: scroll;
 }

--- a/src/components/settings/omnipod/Omnipod.css
+++ b/src/components/settings/omnipod/Omnipod.css
@@ -42,6 +42,6 @@
   composes: lightText from '../../../styles/typography.css';
 }
 
-:global(body) {
+:global(html > body) {
   overflow-y: scroll;
 }

--- a/src/components/settings/tandem/Tandem.css
+++ b/src/components/settings/tandem/Tandem.css
@@ -121,6 +121,6 @@
   font-weight: bold;
 }
 
-:global(body) {
+:global(html > body) {
   overflow-y: scroll;
 }


### PR DESCRIPTION
because, ya know, you only want the one body tag, not the other ones.

This prevents the scrollbar enforcement from bleeding over into the annotation tooltips in blip due to the foreignObject having a `body` tag, which of course is not a direct descendent of an `html` tag.