### PR TITLE
restore 'Active on upload' text for Tandem + regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/settings/common/SingleLineCollapsibleContainerLabel.js
+++ b/src/components/settings/common/SingleLineCollapsibleContainerLabel.js
@@ -23,7 +23,7 @@ import norgie from './norgie.css';
 import styles from './SingleLineCollapsibleContainerLabel.css';
 
 const SingleLineCollapsibleContainerLabel = (props) => {
-  const { className, isOpened, label: { main, units }, onClick } = props;
+  const { className, isOpened, label: { main, secondary, units }, onClick } = props;
   const containerClasses = cx({
     label: true, // for testing
     [styles.collapsibleLabel]: !Boolean(className),
@@ -35,6 +35,8 @@ const SingleLineCollapsibleContainerLabel = (props) => {
     <div className={containerClasses} onClick={onClick}>
       <div>
         <span className={styles.mainText}>{main}</span>
+        {_.isEmpty(secondary) ?
+          null : (<span className={styles.secondaryText}>{secondary}</span>)}
         {_.isEmpty(units) ?
           null : (<span className={styles.secondaryText}>{units}</span>)}
       </div>

--- a/test/components/settings/nontandem/NonTandem.test.js
+++ b/test/components/settings/nontandem/NonTandem.test.js
@@ -31,6 +31,8 @@ const medtronicMultiRateData = require('../../../../data/pumpSettings/medtronic/
 const timePrefs = { timezoneAware: false, timezoneName: null };
 
 describe('NonTandem', () => {
+  const activeAtUploadText = 'Active at upload';
+
   describe('Animas', () => {
     const Animas = getChart('Animas');
     it('should render without problems when bgUnits and pumpSettings provided', () => {
@@ -87,6 +89,18 @@ describe('NonTandem', () => {
         />
       );
       expect(wrapper.find('CollapsibleContainer')).to.have.length(3);
+    });
+
+    it('should have `Active at Upload` text somewhere', () => {
+      const wrapper = mount(
+        <Animas
+          pumpSettings={animasMultiRateData}
+          bgUnits={MGDL_UNITS}
+          timePrefs={timePrefs}
+        />
+      );
+      expect(wrapper.find('.label').someWhere(n => (n.text().search(activeAtUploadText) !== -1)))
+        .to.be.true;
     });
   });
 
@@ -147,6 +161,18 @@ describe('NonTandem', () => {
       );
       expect(wrapper.find('CollapsibleContainer')).to.have.length(2);
     });
+
+    it('should have `Active at Upload` text somewhere', () => {
+      const wrapper = mount(
+        <Insulet
+          pumpSettings={omnipodMultiRateData}
+          bgUnits={MGDL_UNITS}
+          timePrefs={timePrefs}
+        />
+      );
+      expect(wrapper.find('.label').someWhere(n => (n.text().search(activeAtUploadText) !== -1)))
+        .to.be.true;
+    });
   });
 
   describe('Medtronic', () => {
@@ -183,6 +209,18 @@ describe('NonTandem', () => {
         />
       );
       expect(wrapper.find('Header').props().deviceType).to.equal('Medtronic');
+    });
+
+    it('should have `Active at Upload` text somewhere', () => {
+      const wrapper = mount(
+        <Medtronic
+          pumpSettings={medtronicMultiRateData}
+          bgUnits={MGDL_UNITS}
+          timePrefs={timePrefs}
+        />
+      );
+      expect(wrapper.find('.label').someWhere(n => (n.text().search(activeAtUploadText) !== -1)))
+        .to.be.true;
     });
   });
 });

--- a/test/components/settings/tandem/Tandem.test.js
+++ b/test/components/settings/tandem/Tandem.test.js
@@ -18,7 +18,7 @@
 /* eslint no-console:0 */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import Tandem from '../../../../src/components/settings/tandem/Tandem';
 import { MGDL_UNITS } from '../../../../src/utils/constants';
@@ -82,5 +82,19 @@ describe('Tandem', () => {
       />
     );
     expect(wrapper.find('CollapsibleContainer')).to.have.length(3);
+  });
+
+  it('should have `Active at Upload` text somewhere', () => {
+    const activeAtUploadText = 'Active at upload';
+    // must use mount to search far enough down in tree!
+    const wrapper = mount(
+      <Tandem
+        pumpSettings={multirateData}
+        bgUnits={MGDL_UNITS}
+        timePrefs={timePrefs}
+      />
+    );
+    expect(wrapper.find('.label').someWhere(n => (n.text().search(activeAtUploadText) !== -1)))
+      .to.be.true;
   });
 });


### PR DESCRIPTION
Another thing I noticed while working on my next device settings task - the 'Active on upload' text got dropped by accident for Tandem.

Review first thing if you can @hntrdglss?