### PR TITLE
fix MedT active at upload regression

### DIFF
--- a/data/pumpSettings/animas/flatrate.json
+++ b/data/pumpSettings/animas/flatrate.json
@@ -1,9 +1,9 @@
 {
   "type": "pumpSettings",
-  "activeSchedule": "Normal",
+  "activeSchedule": "normal",
   "basalSchedules": [
     {
-      "name": "Normal",
+      "name": "normal",
       "value": [
         {
           "start": 0,
@@ -12,7 +12,7 @@
       ]
     },
     {
-      "name": "Stress",
+      "name": "stress",
       "value" : [
         {
           "start": 0,

--- a/data/pumpSettings/animas/multirate.json
+++ b/data/pumpSettings/animas/multirate.json
@@ -1,9 +1,9 @@
 {
   "type": "pumpSettings",
-  "activeSchedule": "Normal",
+  "activeSchedule": "Stress",
   "basalSchedules": [
     {
-      "name": "Normal",
+      "name": "At home",
       "value": [
         {
           "start": 0,

--- a/data/pumpSettings/medtronic/flatrate.json
+++ b/data/pumpSettings/medtronic/flatrate.json
@@ -1,15 +1,23 @@
 {
   "type": "pumpSettings",
-  "activeSchedule": "Normal",
+  "activeSchedule": "standard",
   "basalSchedules": [
     {
-      "name": "Normal",
+      "name": "standard",
       "value": [
         {
           "start": 0,
           "rate": 0.75
         }
       ]
+    },
+    {
+      "name": "pattern a",
+      "value": []
+    },
+    {
+      "name": "pattern b",
+      "value": []
     }
   ],
   "units": {

--- a/data/pumpSettings/medtronic/multirate.json
+++ b/data/pumpSettings/medtronic/multirate.json
@@ -1,9 +1,9 @@
 {
   "type": "pumpSettings",
-  "activeSchedule": "Normal",
+  "activeSchedule": "standard",
   "basalSchedules": [
     {
-      "name": "Normal",
+      "name": "standard",
       "value": [
         {
           "rate": 0.75,
@@ -24,13 +24,17 @@
       ]
     },
     {
-      "name": "schedule a",
+      "name": "pattern a",
       "value": [
         {
           "rate": 0,
           "start": 0
         }
       ]
+    },
+    {
+      "name": "pattern b",
+      "value": []
     }
   ],
   "units": {

--- a/data/pumpSettings/omnipod/flatrate.json
+++ b/data/pumpSettings/omnipod/flatrate.json
@@ -1,9 +1,9 @@
 {
   "type": "pumpSettings",
-  "activeSchedule": "Normal",
+  "activeSchedule": "normal",
   "basalSchedules": [
     {
-      "name": "Normal",
+      "name": "normal",
       "value": [
         {
           "rate": 0.325,

--- a/data/pumpSettings/tandem/flatrate.json
+++ b/data/pumpSettings/tandem/flatrate.json
@@ -1,6 +1,6 @@
 {
   "type": "pumpSettings",
-  "activeSchedule": "Normal",
+  "activeSchedule": "sick",
   "basalSchedules": [
     {
       "name": "Normal",
@@ -12,7 +12,7 @@
       ]
     },
     {
-      "name": "Sick",
+      "name": "sick",
       "value": [
         {
           "rate": 0.675,
@@ -32,7 +32,7 @@
         "target": 4.9956731919409805
       }
     ],
-    "Sick": [
+    "sick": [
       {
         "start": 0,
         "target": 5.273210591493257
@@ -46,7 +46,7 @@
         "start": 0
       }
     ],
-    "Sick": [
+    "sick": [
       {
         "amount": 7,
         "start": 0
@@ -60,7 +60,7 @@
         "start": 0
       }
     ],
-    "Sick": [
+    "sick": [
       {
         "amount": 2.608851555791401,
         "start": 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/settings/common/Header.js
+++ b/src/components/settings/common/Header.js
@@ -38,7 +38,7 @@ class Header extends React.Component {
       <div>
         <ul className={`${styles.header} ${headerClass}`} onClick={this.handleClick}>
           <li className={styles.headerOuter}>
-            <span className={styles.headerInner}>{this.props.deviceType}</span>
+            <span className={styles.headerInner}>{this.props.deviceDisplayName}</span>
           </li>
           <li className={styles.headerOuter}>
             <span className={styles.headerInner}>Uploaded on {this.props.deviceMeta.uploaded}</span>
@@ -55,7 +55,7 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  deviceType: React.PropTypes.string.isRequired,
+  deviceDisplayName: React.PropTypes.string.isRequired,
   deviceMeta: React.PropTypes.object.isRequired,
 };
 

--- a/src/components/settings/nontandem/NonTandem.js
+++ b/src/components/settings/nontandem/NonTandem.js
@@ -34,9 +34,9 @@ const NonTandem = (props) => {
     bgUnits,
     bolusSettingsLabel,
     carbRatioLabel,
-    deviceType,
+    deviceDisplayName,
+    deviceKey,
     insulinSensitivityLabel,
-    manufacturerKey,
     pumpSettings,
     timePrefs,
   } = props;
@@ -173,7 +173,7 @@ const NonTandem = (props) => {
   return (
     <div>
       <Header
-        deviceType={deviceType}
+        deviceDisplayName={deviceDisplayName}
         deviceMeta={data.getDeviceMeta(pumpSettings, timePrefs)}
       />
       <div className={styles.settingsContainer}>
@@ -203,9 +203,9 @@ NonTandem.propTypes = {
   bgUnits: PropTypes.oneOf([MMOLL_UNITS, MGDL_UNITS]).isRequired,
   bolusSettingsLabel: PropTypes.string.isRequired,
   carbRatioLabel: PropTypes.string.isRequired,
-  deviceType: PropTypes.string.isRequired,
+  deviceKey: PropTypes.oneOf(['animas', 'carelink', 'insulet', 'medtronic']).isRequired,
+  deviceDisplayName: PropTypes.oneOf(['Animas', 'Medtronic', 'OmniPod']).isRequired,
   insulinSensitivityLabel: PropTypes.string.isRequired,
-  manufacturerKey: PropTypes.oneOf(['animas', 'carelink', 'insulet']),
   timePrefs: PropTypes.shape({
     timezoneAware: PropTypes.bool.isRequired,
     timezoneName: PropTypes.oneOfType([PropTypes.string, null]),

--- a/src/components/settings/nontandem/NonTandem.js
+++ b/src/components/settings/nontandem/NonTandem.js
@@ -45,16 +45,14 @@ const NonTandem = (props) => {
     const schedules = data.getScheduleNames(pumpSettings.basalSchedules);
 
     const tables = _.map(schedules, (schedule) => {
-      let scheduleName = pumpSettings.basalSchedules[schedule].name;
-      if (manufacturerKey === 'carelink') {
-        scheduleName = _.map(scheduleName.split(' '), (part) => (_.capitalize(part))).join(' ');
-      }
+      const scheduleName = pumpSettings.basalSchedules[schedule].name;
       const label = data.getScheduleLabel(
         scheduleName,
         pumpSettings.activeSchedule,
+        deviceKey
       );
 
-      if (pumpSettings.basalSchedules[schedule].name === pumpSettings.activeSchedule) {
+      if (scheduleName === pumpSettings.activeSchedule) {
         return (
           <div className={styles.categoryContainer} key={schedule}>
             <CollapsibleContainer

--- a/src/components/settings/tandem/Tandem.js
+++ b/src/components/settings/tandem/Tandem.js
@@ -63,7 +63,7 @@ const Tandem = (props) => {
   const tables = _.map(schedules, (schedule) => (
     <div key={schedule.name}>
       <CollapsibleContainer
-        label={data.getScheduleLabel(schedule.name, pumpSettings.activeSchedule, true)}
+        label={data.getScheduleLabel(schedule.name, pumpSettings.activeSchedule, deviceKey, true)}
         labelClass={styles.collapsibleLabel}
         openByDefault={schedule.name === pumpSettings.activeSchedule}
         twoLineLabel={false}

--- a/src/components/settings/tandem/Tandem.js
+++ b/src/components/settings/tandem/Tandem.js
@@ -28,7 +28,7 @@ import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
 import * as data from '../../../utils/settings/data';
 
 const Tandem = (props) => {
-  const { bgUnits, pumpSettings, timePrefs } = props;
+  const { bgUnits, deviceDisplayName, deviceKey, pumpSettings, timePrefs } = props;
   const schedules = data.getTimedSchedules(pumpSettings.basalSchedules);
 
   const COLUMNS = [
@@ -79,7 +79,7 @@ const Tandem = (props) => {
   return (
     <div>
       <Header
-        deviceType="Tandem"
+        deviceDisplayName={deviceDisplayName}
         deviceMeta={data.getDeviceMeta(pumpSettings, timePrefs)}
       />
       <div>
@@ -92,10 +92,8 @@ const Tandem = (props) => {
 
 Tandem.propTypes = {
   bgUnits: PropTypes.oneOf([MMOLL_UNITS, MGDL_UNITS]).isRequired,
-  timePrefs: PropTypes.shape({
-    timezoneAware: React.PropTypes.bool.isRequired,
-    timezoneName: React.PropTypes.oneOfType([React.PropTypes.string, null]),
-  }).isRequired,
+  deviceDisplayName: PropTypes.oneOf(['Tandem']).isRequired,
+  deviceKey: PropTypes.oneOf(['tandem']).isRequired,
   pumpSettings: React.PropTypes.shape({
     activeSchedule: React.PropTypes.string.isRequired,
     units: React.PropTypes.object.isRequired,
@@ -135,6 +133,10 @@ Tandem.propTypes = {
         })
       ).isRequired,
     ).isRequired,
+  }).isRequired,
+  timePrefs: PropTypes.shape({
+    timezoneAware: React.PropTypes.bool.isRequired,
+    timezoneName: React.PropTypes.oneOfType([React.PropTypes.string, null]),
   }).isRequired,
 };
 

--- a/src/utils/settings/data.js
+++ b/src/utils/settings/data.js
@@ -127,14 +127,21 @@ export function getTotalBasalRates(scheduleData) {
 
 /**
  * getScheduleLabel
- * @param  {String} scheduleName basal schedule name
- * @param  {String} activeName   basal name active at upload timestamp
+ * @param  {String} scheduleName  basal schedule name
+ * @param  {String} activeName    name of active basal schedule at time of upload
+ * @param  {String} deviceKey    one of: animas, carelink, insulet, medtronic, tandem
+ * @param  {Boolean} noUnits      whether units should be included in label object
  *
  * @return {Object}              object representing basal schedule label
  */
-export function getScheduleLabel(scheduleName, activeName, noUnits) {
+export function getScheduleLabel(scheduleName, activeName, deviceKey, noUnits) {
+  const CAPITALIZED = ['carelink', 'medtronic'];
+  let displayName = scheduleName;
+  if (_.includes(CAPITALIZED, deviceKey)) {
+    displayName = _.map(scheduleName.split(' '), (part) => (_.capitalize(part))).join(' ');
+  }
   return {
-    main: scheduleName,
+    main: displayName,
     secondary: scheduleName === activeName ? 'Active at upload' : '',
     units: noUnits ? '' : 'U/hr',
   };

--- a/src/utils/settings/factory.js
+++ b/src/utils/settings/factory.js
@@ -64,7 +64,7 @@ export function injectManufacturerSpecificInfo(manufacturer, Component) {
     carelink: 'Bolus Wizard',
     insulet: 'Bolus Calculator',
   };
-  const deviceTypesByManufacturer = {
+  const deviceDisplayNamesByManufacturer = {
     animas: 'Animas',
     carelink: 'Medtronic',
     insulet: 'OmniPod',
@@ -75,9 +75,9 @@ export function injectManufacturerSpecificInfo(manufacturer, Component) {
       bgTargetLabel={bgTargetByManufacturer[manufacturer]}
       bolusSettingsLabel={bolusSettingsLabelsByManufacturer[manufacturer]}
       carbRatioLabel={carbRatioByManufacturer[manufacturer]}
-      deviceType={deviceTypesByManufacturer[manufacturer]}
+      deviceDisplayName={deviceDisplayNamesByManufacturer[manufacturer]}
+      deviceKey={manufacturer}
       insulinSensitivityLabel={insulinSensitivityByManufacturer[manufacturer]}
-      manufacturerKey={manufacturer}
       {...props}
     />
   );

--- a/test/components/settings/common/Header.test.js
+++ b/test/components/settings/common/Header.test.js
@@ -24,7 +24,7 @@ describe('Header', () => {
   it('should expand to show serial number on click of device name', () => {
     const wrapper = shallow(
       <Header
-        deviceType="Testing"
+        deviceDisplayName="Testing"
         deviceMeta={{ name: 'SN123', uploaded: 'Jul 12th 2016' }}
       />
     );

--- a/test/components/settings/nontandem/NonTandem.test.js
+++ b/test/components/settings/nontandem/NonTandem.test.js
@@ -24,7 +24,9 @@ import { mount } from 'enzyme';
 import { getChart } from '../../../../src/utils/settings/factory';
 import { MGDL_UNITS } from '../../../../src/utils/constants';
 
+const animasFlatRateData = require('../../../../data/pumpSettings/animas/flatrate.json');
 const animasMultiRateData = require('../../../../data/pumpSettings/animas/multirate.json');
+const omnipodFlatRateData = require('../../../../data/pumpSettings/omnipod/flatrate.json');
 const omnipodMultiRateData = require('../../../../data/pumpSettings/omnipod/multirate.json');
 const medtronicMultiRateData = require('../../../../data/pumpSettings/medtronic/multirate.json');
 
@@ -39,8 +41,8 @@ describe('NonTandem', () => {
       console.error = sinon.stub();
       mount(
         <Animas
-          pumpSettings={animasMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={animasMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -50,30 +52,30 @@ describe('NonTandem', () => {
     it('should have a header', () => {
       const wrapper = mount(
         <Animas
-          pumpSettings={animasMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={animasMultiRateData}
           timePrefs={timePrefs}
         />
       );
       expect(wrapper.find('Header')).to.have.length(1);
     });
 
-    it('should have Animas as the Header deviceType', () => {
+    it('should have Animas as the Header deviceDisplayName', () => {
       const wrapper = mount(
         <Animas
-          pumpSettings={animasMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={animasMultiRateData}
           timePrefs={timePrefs}
         />
       );
-      expect(wrapper.find('Header').props().deviceType).to.equal('Animas');
+      expect(wrapper.find('Header').props().deviceDisplayName).to.equal('Animas');
     });
 
     it('should have four Tables', () => {
       const wrapper = mount(
         <Animas
-          pumpSettings={animasMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={animasMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -83,19 +85,33 @@ describe('NonTandem', () => {
     it('should have three CollapsibleContainers', () => {
       const wrapper = mount(
         <Animas
-          pumpSettings={animasMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={animasMultiRateData}
           timePrefs={timePrefs}
         />
       );
       expect(wrapper.find('CollapsibleContainer')).to.have.length(3);
     });
 
+    it('should preserve user capitalization of schedule name', () => {
+      const wrapper = mount(
+        <Animas
+          bgUnits={MGDL_UNITS}
+          pumpSettings={animasFlatRateData}
+          timePrefs={timePrefs}
+        />
+      );
+      expect(wrapper.find('.label').someWhere(n => (n.text().search('normal') !== -1)))
+        .to.be.true;
+      expect(wrapper.find('.label').someWhere(n => (n.text().search('Weekday') !== -1)))
+        .to.be.true;
+    });
+
     it('should have `Active at Upload` text somewhere', () => {
       const wrapper = mount(
         <Animas
-          pumpSettings={animasMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={animasMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -110,8 +126,8 @@ describe('NonTandem', () => {
       console.error = sinon.stub();
       mount(
         <Insulet
-          pumpSettings={omnipodMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -121,30 +137,30 @@ describe('NonTandem', () => {
     it('should have a header', () => {
       const wrapper = mount(
         <Insulet
-          pumpSettings={omnipodMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodMultiRateData}
           timePrefs={timePrefs}
         />
       );
       expect(wrapper.find('Header')).to.have.length(1);
     });
 
-    it('should have OmniPod as the Header deviceType', () => {
+    it('should have OmniPod as the Header deviceDisplayName', () => {
       const wrapper = mount(
         <Insulet
-          pumpSettings={omnipodMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodMultiRateData}
           timePrefs={timePrefs}
         />
       );
-      expect(wrapper.find('Header').props().deviceType).to.equal('OmniPod');
+      expect(wrapper.find('Header').props().deviceDisplayName).to.equal('OmniPod');
     });
 
     it('should have four Tables', () => {
       const wrapper = mount(
         <Insulet
-          pumpSettings={omnipodMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -154,19 +170,31 @@ describe('NonTandem', () => {
     it('should have two CollapsibleContainers', () => {
       const wrapper = mount(
         <Insulet
-          pumpSettings={omnipodMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodMultiRateData}
           timePrefs={timePrefs}
         />
       );
       expect(wrapper.find('CollapsibleContainer')).to.have.length(2);
     });
 
+    it('should preserve user capitalization of schedule name', () => {
+      const wrapper = mount(
+        <Insulet
+          bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodFlatRateData}
+          timePrefs={timePrefs}
+        />
+      );
+      expect(wrapper.find('.label').someWhere(n => (n.text().search('normal') !== -1)))
+        .to.be.true;
+    });
+
     it('should have `Active at Upload` text somewhere', () => {
       const wrapper = mount(
         <Insulet
-          pumpSettings={omnipodMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={omnipodMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -181,8 +209,8 @@ describe('NonTandem', () => {
       console.error = sinon.stub();
       mount(
         <Medtronic
-          pumpSettings={medtronicMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={medtronicMultiRateData}
           timePrefs={timePrefs}
         />
       );
@@ -192,30 +220,46 @@ describe('NonTandem', () => {
     it('should have a header', () => {
       const wrapper = mount(
         <Medtronic
-          pumpSettings={medtronicMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={medtronicMultiRateData}
           timePrefs={timePrefs}
         />
       );
       expect(wrapper.find('Header')).to.have.length(1);
     });
 
-    it('should have Medtronic as the Header deviceType', () => {
+    it('should have Medtronic as the Header deviceDisplayName', () => {
       const wrapper = mount(
         <Medtronic
-          pumpSettings={medtronicMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={medtronicMultiRateData}
           timePrefs={timePrefs}
         />
       );
-      expect(wrapper.find('Header').props().deviceType).to.equal('Medtronic');
+      expect(wrapper.find('Header').props().deviceDisplayName).to.equal('Medtronic');
+    });
+
+    it('should capitalize all basal schedule names', () => {
+      const wrapper = mount(
+        <Medtronic
+          bgUnits={MGDL_UNITS}
+          pumpSettings={medtronicMultiRateData}
+          timePrefs={timePrefs}
+        />
+      );
+      expect(wrapper.find('.label').someWhere(n => (n.text().search('Standard') !== -1)))
+        .to.be.true;
+      expect(wrapper.find('.label').someWhere(n => (n.text().search('Pattern A') !== -1)))
+        .to.be.true;
+      expect(wrapper.find('.label').someWhere(n => (n.text().search('Pattern B') !== -1)))
+        .to.be.true;
     });
 
     it('should have `Active at Upload` text somewhere', () => {
       const wrapper = mount(
         <Medtronic
-          pumpSettings={medtronicMultiRateData}
           bgUnits={MGDL_UNITS}
+          pumpSettings={medtronicMultiRateData}
           timePrefs={timePrefs}
         />
       );

--- a/test/components/settings/tandem/Tandem.test.js
+++ b/test/components/settings/tandem/Tandem.test.js
@@ -23,78 +23,76 @@ import { mount, shallow } from 'enzyme';
 import Tandem from '../../../../src/components/settings/tandem/Tandem';
 import { MGDL_UNITS } from '../../../../src/utils/constants';
 
+const flatrateData = require('../../../../data/pumpSettings/tandem/flatrate.json');
 const multirateData = require('../../../../data/pumpSettings/tandem/multirate.json');
 
 const timePrefs = { timezoneAware: false, timezoneName: null };
 
 describe('Tandem', () => {
-  it('should render without problems when bgUnits and pumpSettings provided', () => {
-    console.error = sinon.stub();
-    shallow(
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(
       <Tandem
-        pumpSettings={multirateData}
         bgUnits={MGDL_UNITS}
+        deviceDisplayName={'Tandem'}
+        deviceKey={'tandem'}
+        pumpSettings={multirateData}
         timePrefs={timePrefs}
       />
     );
+  });
+
+  it('should render without problems when bgUnits and pumpSettings provided', () => {
+    console.error = sinon.stub();
     expect(console.error.callCount).to.equal(0);
   });
 
   it('should have a header', () => {
-    const wrapper = shallow(
-      <Tandem
-        pumpSettings={multirateData}
-        bgUnits={MGDL_UNITS}
-        timePrefs={timePrefs}
-      />
-    );
     expect(wrapper.find('Header')).to.have.length(1);
   });
 
-  it('should have Tandem as the Header deviceType', () => {
-    const wrapper = shallow(
-      <Tandem
-        pumpSettings={multirateData}
-        bgUnits={MGDL_UNITS}
-        timePrefs={timePrefs}
-      />
-    );
-    expect(wrapper.find('Header').props().deviceType).to.equal('Tandem');
+  it('should have Tandem as the Header deviceDisplayName', () => {
+    expect(wrapper.find('Header').props().deviceDisplayName).to.equal('Tandem');
   });
 
   it('should have three Tables', () => {
-    const wrapper = shallow(
-      <Tandem
-        pumpSettings={multirateData}
-        bgUnits={MGDL_UNITS}
-        timePrefs={timePrefs}
-      />
-    );
     expect(wrapper.find('Table')).to.have.length(3);
   });
 
   it('should have three CollapsibleContainers', () => {
-    const wrapper = shallow(
+    expect(wrapper.find('CollapsibleContainer')).to.have.length(3);
+  });
+
+  it('should preserve user capitalization of profile names', () => {
+    // must use mount to search far enough down in tree!
+    const mounted = mount(
       <Tandem
-        pumpSettings={multirateData}
         bgUnits={MGDL_UNITS}
+        deviceDisplayName={'Tandem'}
+        deviceKey={'tandem'}
+        pumpSettings={flatrateData}
         timePrefs={timePrefs}
       />
     );
-    expect(wrapper.find('CollapsibleContainer')).to.have.length(3);
+    expect(mounted.find('.label').someWhere(n => (n.text().search('Normal') !== -1)))
+      .to.be.true;
+    expect(mounted.find('.label').someWhere(n => (n.text().search('sick') !== -1)))
+      .to.be.true;
   });
 
   it('should have `Active at Upload` text somewhere', () => {
     const activeAtUploadText = 'Active at upload';
     // must use mount to search far enough down in tree!
-    const wrapper = mount(
+    const mounted = mount(
       <Tandem
-        pumpSettings={multirateData}
         bgUnits={MGDL_UNITS}
+        deviceDisplayName={'Tandem'}
+        deviceKey={'tandem'}
+        pumpSettings={multirateData}
         timePrefs={timePrefs}
       />
     );
-    expect(wrapper.find('.label').someWhere(n => (n.text().search(activeAtUploadText) !== -1)))
+    expect(mounted.find('.label').someWhere(n => (n.text().search(activeAtUploadText) !== -1)))
       .to.be.true;
   });
 });

--- a/test/utils/settings/data.test.js
+++ b/test/utils/settings/data.test.js
@@ -168,8 +168,24 @@ describe('data', () => {
       });
     });
 
+    it('should capitalize schedule name if deviceType is `carelink`', () => {
+      expect(data.getScheduleLabel('pattern a', 'pattern a', 'carelink')).to.deep.equal({
+        main: 'Pattern A',
+        secondary: 'Active at upload',
+        units: 'U/hr',
+      });
+    });
+
+    it('should capitalize schedule name if deviceType is `medtronic`', () => {
+      expect(data.getScheduleLabel('pattern a', 'pattern a', 'medtronic')).to.deep.equal({
+        main: 'Pattern A',
+        secondary: 'Active at upload',
+        units: 'U/hr',
+      });
+    });
+
     it('should return an empty string for `units` if given `noUnits` option', () => {
-      expect(data.getScheduleLabel('one', 'one', true)).to.deep.equal({
+      expect(data.getScheduleLabel('one', 'one', 'tandem', true)).to.deep.equal({
         main: 'one',
         secondary: 'Active at upload',
         units: '',
@@ -184,7 +200,7 @@ describe('data', () => {
       )
       .to.have.length(2)
       .to.contain({ name: 'Normal', position: 0 })
-      .and.contain({ name: 'Sick', position: 1 });
+      .and.contain({ name: 'sick', position: 1 });
     });
   });
 
@@ -217,7 +233,7 @@ describe('data', () => {
       ).to.have.property('serial').equal('0987654321');
       expect(
         data.getDeviceMeta(settingsData, timePrefs)
-      ).to.have.property('schedule').equal('Normal');
+      ).to.have.property('schedule').equal('sick');
       expect(
         data.getDeviceMeta(settingsData, timePrefs)
       ).to.have.property('uploaded').equal('Jul 12, 2016');
@@ -233,7 +249,7 @@ describe('data', () => {
       ).to.have.property('serial').equal('0987654321');
       expect(
         data.getDeviceMeta(settingsData, timezoneAwarePrefs)
-      ).to.have.property('schedule').equal('Normal');
+      ).to.have.property('schedule').equal('sick');
       expect(
         data.getDeviceMeta(settingsData, timezoneAwarePrefs)
       ).to.have.property('uploaded').equal('Jul 13, 2016');


### PR DESCRIPTION
Discovered a regression (missing 'Active at upload' text for MedT) after briefly deploying blip v0.14.11 to prd before the offsite. (Rolled back to v0.14.8 after discovering it.)

The root cause of the dropped 'Active at upload' text was basically some incorrect fixture data for `pumpSettings` with capitalized basal schedule names (which **never** happens with MedT pumps in the wild because basal schedule names are not under user control). This masked how adding capitalization to MedT broke the logic to detect matching between each schedule name at the active schedule. So this PR fixes the underlying data fixtures and (after consultation with BA) only capitalizes MedT basal schedule names and preserves user-controlled capitalization on other pumps (tests have been added to prove this).

@hntrdglss could you review ASAP so we can clear the way for other changes that are almost ready for testing?