### PR TITLE
device settings bgTarget data regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/settings/nontandem/NonTandem.js
+++ b/src/components/settings/nontandem/NonTandem.js
@@ -30,6 +30,7 @@ import styles from './NonTandem.css';
 const NonTandem = (props) => {
   const {
     bgTargetColumns,
+    bgTargetDataAccessor,
     bgTargetLabel,
     bgUnits,
     bolusSettingsLabel,
@@ -158,7 +159,7 @@ const NonTandem = (props) => {
             data.processBgTargetData(
               pumpSettings.bgTarget,
               bgUnits,
-              { columnTwo: 'target', columnThree: 'high' },
+              bgTargetDataAccessor,
             )
           }
           columns={bgTargetColumns}
@@ -197,6 +198,10 @@ NonTandem.propTypes = {
     key: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
   }).isRequired).isRequired,
+  bgTargetDataAccessor: PropTypes.shape({
+    columnTwo: PropTypes.oneOf(['high', 'low', 'range', 'target']).isRequired,
+    columnThree: PropTypes.oneOf(['high', 'low', 'range', 'target']).isRequired,
+  }).isRequired,
   bgTargetLabel: PropTypes.string.isRequired,
   bgUnits: PropTypes.oneOf([MMOLL_UNITS, MGDL_UNITS]).isRequired,
   bolusSettingsLabel: PropTypes.string.isRequired,

--- a/src/components/settings/tandem/Tandem.js
+++ b/src/components/settings/tandem/Tandem.js
@@ -140,4 +140,9 @@ Tandem.propTypes = {
   }).isRequired,
 };
 
+Tandem.defaultProps = {
+  deviceDisplayName: 'Tandem',
+  deviceKey: 'tandem',
+};
+
 export default Tandem;

--- a/src/utils/settings/factory.js
+++ b/src/utils/settings/factory.js
@@ -27,6 +27,11 @@ import Tandem from '../../components/settings/tandem/Tandem';
  * @return {Component} NonTandem React component with bolusSettingsColumns injected
  */
 export function injectManufacturerSpecificInfo(manufacturer, Component) {
+  const bgTargetDataAccessorsByManufacturer = {
+    animas: { columnTwo: 'target', columnThree: 'range' },
+    carelink: { columnTwo: 'low', columnThree: 'high' },
+    insulet: { columnTwo: 'target', columnThree: 'high' },
+  };
   const bgTargetsByManufacturer = {
     animas: [
       { key: 'start', label: 'Start time' },
@@ -72,6 +77,7 @@ export function injectManufacturerSpecificInfo(manufacturer, Component) {
   return (props) => (
     <Component
       bgTargetColumns={bgTargetsByManufacturer[manufacturer]}
+      bgTargetDataAccessor={bgTargetDataAccessorsByManufacturer[manufacturer]}
       bgTargetLabel={bgTargetByManufacturer[manufacturer]}
       bolusSettingsLabel={bolusSettingsLabelsByManufacturer[manufacturer]}
       carbRatioLabel={carbRatioByManufacturer[manufacturer]}


### PR DESCRIPTION
Here's the fix for the latest regression on the device settings work - just failed to factor out one piece of device-specific information, which is how the data is accessed for each of the different non-Tandem varieties of BG target.