### PR TITLE
Tooltip component updates

### DIFF
--- a/src/components/common/tooltips/Tooltip.css
+++ b/src/components/common/tooltips/Tooltip.css
@@ -20,6 +20,7 @@
   composes: defaultSize from '../../../styles/typography.css';
   background-color: #FFFFFF;
   border: solid;
+  pointer-events: none;
   position: absolute;
   border-radius: 4px;
   opacity: 0.75;

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -27,11 +27,15 @@ class Tooltip extends React.Component {
   }
 
   componentDidMount() {
-    this.calculateOffset();
+    this.calculateOffset(this.props);
   }
 
-  calculateOffset() {
-    const { offset: propOffset, tail } = this.props;
+  componentWillReceiveProps(nextProps) {
+    this.calculateOffset(nextProps);
+  }
+
+  calculateOffset(currentProps) {
+    const { offset: propOffset, tail } = currentProps;
     const offset = {};
     const tooltipRect = this.element.getBoundingClientRect();
     if (tail) {

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -35,9 +35,14 @@ class Tooltip extends React.Component {
   }
 
   calculateOffset(currentProps) {
-    const { offset: propOffset, tail } = currentProps;
+    const { offset: propOffset, side, tail } = currentProps;
     const offset = {};
     const tooltipRect = this.element.getBoundingClientRect();
+    let horizontalOffset = (propOffset.left != null) ?
+      propOffset.left : (propOffset.horizontal || 0);
+    if (side === 'left') {
+      horizontalOffset = -horizontalOffset;
+    }
     if (tail) {
       const tailRect = this.tailElem.getBoundingClientRect();
       const tailCenter = {
@@ -45,11 +50,11 @@ class Tooltip extends React.Component {
         left: tailRect.left + (tailRect.width / 2),
       };
       offset.top = -tailCenter.top + tooltipRect.top + propOffset.top;
-      offset.left = -tailCenter.left + tooltipRect.left + propOffset.left;
+      offset.left = -tailCenter.left + tooltipRect.left + horizontalOffset;
     } else {
       let leftOffset;
       let topOffset;
-      switch (this.props.side) {
+      switch (side) {
         case 'top':
           leftOffset = -tooltipRect.width / 2;
           topOffset = -tooltipRect.height;
@@ -108,7 +113,8 @@ class Tooltip extends React.Component {
             marginTop: `-${tailHeight}px`,
             marginLeft: marginInnerValue,
             borderWidth: `${tailHeight}px ${2 * tailWidth}px`,
-            [`border${_.capitalize(borderSide)}Color`]: this.props.backgroundColor || backgroundColor,
+            [`border${_.capitalize(borderSide)}Color`]:
+              this.props.backgroundColor || backgroundColor,
           }}
         ></div>
       </div>
@@ -171,13 +177,14 @@ Tooltip.propTypes = {
   }).isRequired,
   offset: PropTypes.shape({
     top: PropTypes.number.isRequired,
-    left: PropTypes.number.isRequired,
+    left: PropTypes.number,
+    horizontal: PropTypes.number,
   }).isRequired,
   tail: PropTypes.bool.isRequired,
   side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']).isRequired,
   tailWidth: PropTypes.number.isRequired,
   tailHeight: PropTypes.number.isRequired,
-  backgroundColor: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string,
   borderColor: PropTypes.string.isRequired,
   borderWidth: PropTypes.number.isRequired,
 };

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -74,8 +74,8 @@ class Tooltip extends React.Component {
     this.setState({ offset });
   }
 
-  renderTail(color = 'white') {
-    const { tailWidth, tailHeight, borderWidth, borderColor, side } = this.props;
+  renderTail() {
+    const { tailWidth, tailHeight, backgroundColor, borderWidth, borderColor, side } = this.props;
     const tailSide = (side === 'left') ? 'right' : 'left';
     const padding = 10;
     let marginOuterValue;
@@ -108,7 +108,7 @@ class Tooltip extends React.Component {
             marginTop: `-${tailHeight}px`,
             marginLeft: marginInnerValue,
             borderWidth: `${tailHeight}px ${2 * tailWidth}px`,
-            [`border${_.capitalize(borderSide)}Color`]: color,
+            [`border${_.capitalize(borderSide)}Color`]: backgroundColor,
           }}
         ></div>
       </div>
@@ -144,7 +144,7 @@ class Tooltip extends React.Component {
   }
 
   render() {
-    const { title, content, position, borderColor, borderWidth } = this.props;
+    const { title, content, position, backgroundColor, borderColor, borderWidth } = this.props;
     const { offset } = this.state;
     const top = position.top + offset.top;
     const left = position.left + offset.left;
@@ -152,7 +152,7 @@ class Tooltip extends React.Component {
     return (
       <div
         className={styles.tooltip}
-        style={{ top, left, borderColor, borderWidth: `${borderWidth}px` }}
+        style={{ top, left, backgroundColor, borderColor, borderWidth: `${borderWidth}px` }}
         ref={(ref) => { this.element = ref; }}
       >
         {title && this.renderTitle(title)}
@@ -177,6 +177,7 @@ Tooltip.propTypes = {
   side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']).isRequired,
   tailWidth: PropTypes.number.isRequired,
   tailHeight: PropTypes.number.isRequired,
+  backgroundColor: PropTypes.string.isRequired,
   borderColor: PropTypes.string.isRequired,
   borderWidth: PropTypes.number.isRequired,
 };
@@ -186,6 +187,7 @@ Tooltip.defaultProps = {
   side: 'left',
   tailWidth: 7,
   tailHeight: 8,
+  backgroundColor: 'white',
   borderColor: 'black',
   borderWidth: 2,
   offset: { top: 0, left: 0 },

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -68,14 +68,14 @@ class Tooltip extends React.Component {
           topOffset = -tooltipRect.height / 2;
       }
       offset.top = topOffset + propOffset.top;
-      offset.left = leftOffset + propOffset.left;
+      offset.left = leftOffset + horizontalOffset;
     }
 
     this.setState({ offset });
   }
 
-  renderTail() {
-    const { tailWidth, tailHeight, backgroundColor, borderWidth, borderColor, side } = this.props;
+  renderTail(backgroundColor = 'white') {
+    const { tailWidth, tailHeight, borderWidth, borderColor, side } = this.props;
     const tailSide = (side === 'left') ? 'right' : 'left';
     const padding = 10;
     let marginOuterValue;
@@ -108,7 +108,7 @@ class Tooltip extends React.Component {
             marginTop: `-${tailHeight}px`,
             marginLeft: marginInnerValue,
             borderWidth: `${tailHeight}px ${2 * tailWidth}px`,
-            [`border${_.capitalize(borderSide)}Color`]: backgroundColor,
+            [`border${_.capitalize(borderSide)}Color`]: this.props.backgroundColor || backgroundColor,
           }}
         ></div>
       </div>
@@ -187,7 +187,6 @@ Tooltip.defaultProps = {
   side: 'left',
   tailWidth: 7,
   tailHeight: 8,
-  backgroundColor: 'white',
   borderColor: 'black',
   borderWidth: 2,
   offset: { top: 0, left: 0 },

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -29,8 +29,8 @@ import styles from './FocusedSMBGPointLabel.css';
 // tooltip offsets
 const SIMPLE_VALUE_TOP_OFFSET = 10;
 const SIMPLE_DAY_TOP_OFFSET = 10;
-const SIMPLE_DAY_LEFT_OFFSET = 30;
-const DETAILED_DAY_LEFT_OFFSET = 10;
+const SIMPLE_DAY_HORIZ_OFFSET = 30;
+const DETAILED_DAY_HORIZ_OFFSET = 10;
 
 const FocusedSMBGPointLabel = (props) => {
   const { focusedPoint } = props;
@@ -73,7 +73,7 @@ const FocusedSMBGPointLabel = (props) => {
         side={side}
         offset={{
           top: SIMPLE_DAY_TOP_OFFSET,
-          left: position.tooltipLeft ? -SIMPLE_DAY_LEFT_OFFSET : SIMPLE_DAY_LEFT_OFFSET,
+          horizontal: SIMPLE_DAY_HORIZ_OFFSET,
         }}
       />
     );
@@ -94,7 +94,7 @@ const FocusedSMBGPointLabel = (props) => {
         side={side}
         offset={{
           top: 0,
-          left: position.tooltipLeft ? -DETAILED_DAY_LEFT_OFFSET : DETAILED_DAY_LEFT_OFFSET,
+          horizontal: DETAILED_DAY_HORIZ_OFFSET,
         }}
       />
     );

--- a/src/components/trends/smbg/FocusedSMBGRangeLabels.js
+++ b/src/components/trends/smbg/FocusedSMBGRangeLabels.js
@@ -55,7 +55,7 @@ const FocusedSMBGRangeLabels = (props) => {
         }
         side={meanSide}
         position={meanPosition}
-        offset={{ top: 0, left: position.tooltipLeft ? -10 : 10 }}
+        offset={{ top: 0, horizontal: 10 }}
       />
       <Tooltip
         content={<span className={styles.number}>{displayBgValue(data.min, bgUnits)}</span>}

--- a/stories/components/common/tooltips/Tooltip.js
+++ b/stories/components/common/tooltips/Tooltip.js
@@ -74,10 +74,10 @@ storiesOf('Tooltip', module)
       />
     </div>
   ))
-  .add('transparent backgroundColor, tail, no title', () => (
+  .add('[KNOWN ISSUE] transparent backgroundColor with tail', () => (
     <div>
       {refDiv}
-      <Tooltip {...props} title={null} backgroundColor={'transparent'} />
+      <Tooltip {...props} backgroundColor={'transparent'} />
     </div>
   ))
   .add('borderWidth', () => (
@@ -98,10 +98,16 @@ storiesOf('Tooltip', module)
       <Tooltip {...props} tailHeight={4} />
     </div>
   ))
-  .add('no content', () => (
+  .add('tail, no content', () => (
     <div>
       {refDiv}
       <Tooltip {...props} content={null} />
+    </div>
+  ))
+  .add('no tail, no content', () => (
+    <div>
+      {refDiv}
+      <Tooltip {...props} content={null} tail={false} />
     </div>
   ))
   .add('no title', () => (

--- a/stories/components/common/tooltips/Tooltip.js
+++ b/stories/components/common/tooltips/Tooltip.js
@@ -37,6 +37,12 @@ storiesOf('Tooltip', module)
       <Tooltip {...props} offset={{ top: -5, left: -5 }} />
     </div>
   ))
+  .add('backgroundColor', () => (
+    <div>
+      {refDiv}
+      <Tooltip {...props} backgroundColor={'papayawhip'} />
+    </div>
+  ))
   .add('borderColor', () => (
     <div>
       {refDiv}

--- a/stories/components/common/tooltips/Tooltip.js
+++ b/stories/components/common/tooltips/Tooltip.js
@@ -10,21 +10,29 @@ const props = {
   position: { top: 200, left: 200 },
 };
 
+const BackgroundDecorator = (story) => (
+  <div style={{ backgroundColor: 'FloralWhite', width: '100%', height: '96vh' }}>
+    {story()}
+  </div>
+);
+
 const refDiv = (
   <div
     style={{
       position: 'absolute',
-      width: '3px',
-      height: '3px',
+      width: '10px',
+      height: '10px',
       top: '199px',
       left: '199px',
-      backgroundColor: 'red',
+      backgroundColor: 'FireBrick',
+      opacity: 0.50,
       zIndex: '1',
     }}
   />
 );
 
 storiesOf('Tooltip', module)
+  .addDecorator(BackgroundDecorator)
   .add('defaults', () => (
     <div>
       {refDiv}
@@ -47,6 +55,29 @@ storiesOf('Tooltip', module)
     <div>
       {refDiv}
       <Tooltip {...props} borderColor={'blue'} />
+    </div>
+  ))
+  .add('transparent backgroundColor, no tail', () => (
+    <div>
+      {refDiv}
+      <Tooltip {...props} tail={false} backgroundColor={'transparent'} />
+    </div>
+  ))
+  .add('transparent, no tail, no title', () => (
+    <div>
+      {refDiv}
+      <Tooltip
+        {...props}
+        title={null}
+        backgroundColor={'transparent'}
+        borderColor={'transparent'}
+      />
+    </div>
+  ))
+  .add('transparent backgroundColor, tail, no title', () => (
+    <div>
+      {refDiv}
+      <Tooltip {...props} title={null} backgroundColor={'transparent'} />
     </div>
   ))
   .add('borderWidth', () => (

--- a/test/components/common/tooltip/Tooltip.test.js
+++ b/test/components/common/tooltip/Tooltip.test.js
@@ -73,7 +73,7 @@ describe('Tooltip', () => {
     const tooltipElem = wrapper.node.element;
     const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
     tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
-    wrapper.instance().calculateOffset();
+    wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: -5, left: -5 } });
   });
 
@@ -92,7 +92,7 @@ describe('Tooltip', () => {
     const tooltipElem = wrapper.node.element;
     const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
     tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
-    wrapper.instance().calculateOffset();
+    wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: -5, left: -105 } });
   });
 
@@ -109,7 +109,7 @@ describe('Tooltip', () => {
     const tooltipElem = wrapper.node.element;
     const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
     tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
-    wrapper.instance().calculateOffset();
+    wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: -50, left: -100 } });
   });
 
@@ -126,7 +126,7 @@ describe('Tooltip', () => {
     const tooltipElem = wrapper.node.element;
     const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
     tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
-    wrapper.instance().calculateOffset();
+    wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: -50, left: 0 } });
   });
 
@@ -143,7 +143,7 @@ describe('Tooltip', () => {
     const tooltipElem = wrapper.node.element;
     const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
     tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
-    wrapper.instance().calculateOffset();
+    wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: -100, left: -50 } });
   });
 
@@ -160,7 +160,7 @@ describe('Tooltip', () => {
     const tooltipElem = wrapper.node.element;
     const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
     tooltipgetBoundingClientRect.returns({ top: 0, left: 50, height: 100, width: 100 });
-    wrapper.instance().calculateOffset();
+    wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: 0, left: -50 } });
   });
 });

--- a/test/components/common/tooltip/Tooltip.test.js
+++ b/test/components/common/tooltip/Tooltip.test.js
@@ -235,8 +235,9 @@ describe('Tooltip', () => {
   });
 
   describe('lifecycle methods', () => {
-    it('calls componentDidMount', () => {
+    it('calls componentDidMount (which calls calculateOffset)', () => {
       sinon.spy(Tooltip.prototype, 'componentDidMount');
+      sinon.spy(Tooltip.prototype, 'calculateOffset');
       mount(
         <Tooltip
           position={position}
@@ -245,21 +246,9 @@ describe('Tooltip', () => {
         />
       );
       expect(Tooltip.prototype.componentDidMount.calledOnce).to.be.true;
-    });
-
-    it('componentDidMount in turn calls calculateOffset', () => {
-      const wrapper = mount(
-        <Tooltip
-          position={position}
-          title={title}
-          content={content}
-        />
-      );
-      const instance = wrapper.instance();
-      const calcSpy = sinon.spy(instance, 'calculateOffset');
-      expect(calcSpy.callCount).to.equal(0);
-      instance.componentDidMount();
-      expect(calcSpy.calledOnce).to.be.true;
+      expect(Tooltip.prototype.calculateOffset.calledOnce).to.be.true;
+      Tooltip.prototype.componentDidMount.restore();
+      Tooltip.prototype.calculateOffset.restore();
     });
 
     it('calls componentWillReceiveProps (which calls calculateOffset) on props update', () => {
@@ -279,6 +268,8 @@ describe('Tooltip', () => {
       expect(Tooltip.prototype.componentWillReceiveProps.calledOnce).to.be.true;
       expect(calcSpy.calledOnce).to.be.true;
       expect(calcSpy.args[0][0]).to.deep.equal(wrapper.props());
+      Tooltip.prototype.componentWillReceiveProps.restore();
+      instance.calculateOffset.restore();
     });
   });
 });

--- a/test/components/common/tooltip/Tooltip.test.js
+++ b/test/components/common/tooltip/Tooltip.test.js
@@ -164,6 +164,76 @@ describe('Tooltip', () => {
     expect(wrapper.state()).to.deep.equal({ offset: { top: 0, left: -50 } });
   });
 
+  describe('an additional `offset` provided in props', () => {
+    it('should be added to the calculated offset', () => {
+      const top = 7;
+      const left = 7;
+      const wrapper = mount(
+        <Tooltip
+          offset={{ top, left }}
+          position={position}
+          title={title}
+          content={content}
+          side={'right'}
+        />
+      );
+      const tailElem = wrapper.node.tailElem;
+      const tailgetBoundingClientRect = sinon.stub(tailElem, 'getBoundingClientRect');
+      tailgetBoundingClientRect.returns({ top: 50, left: 150, height: 10, width: 10 });
+      const tooltipElem = wrapper.node.element;
+      const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
+      tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
+      wrapper.instance().calculateOffset(wrapper.props());
+      expect(wrapper.state()).to.deep.equal({ offset: { top: 2, left: -98 } });
+    });
+
+    describe('`horizontal` instead of `left` provided in `offset` in props', () => {
+      it('should be used as-is in the offset computation for a tooltip on the right', () => {
+        const top = 7;
+        const horizontal = 7;
+        const wrapper = mount(
+          <Tooltip
+            offset={{ top, horizontal }}
+            position={position}
+            title={title}
+            content={content}
+            side={'right'}
+          />
+        );
+        const tailElem = wrapper.node.tailElem;
+        const tailgetBoundingClientRect = sinon.stub(tailElem, 'getBoundingClientRect');
+        tailgetBoundingClientRect.returns({ top: 50, left: 150, height: 10, width: 10 });
+        const tooltipElem = wrapper.node.element;
+        const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
+        tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
+        wrapper.instance().calculateOffset(wrapper.props());
+        expect(wrapper.state()).to.deep.equal({ offset: { top: 2, left: -98 } });
+      });
+
+      it('should be subtracted from the offset computation for a tooltip on the left', () => {
+        const top = 7;
+        const horizontal = 7;
+        const wrapper = mount(
+          <Tooltip
+            offset={{ top, horizontal }}
+            position={position}
+            title={title}
+            content={content}
+            side={'left'}
+          />
+        );
+        const tailElem = wrapper.node.tailElem;
+        const tailgetBoundingClientRect = sinon.stub(tailElem, 'getBoundingClientRect');
+        tailgetBoundingClientRect.returns({ top: 50, left: 50, height: 10, width: 10 });
+        const tooltipElem = wrapper.node.element;
+        const tooltipgetBoundingClientRect = sinon.stub(tooltipElem, 'getBoundingClientRect');
+        tooltipgetBoundingClientRect.returns({ top: 50, left: 50, height: 100, width: 100 });
+        wrapper.instance().calculateOffset(wrapper.props());
+        expect(wrapper.state()).to.deep.equal({ offset: { top: 2, left: -12 } });
+      });
+    });
+  });
+
   describe('lifecycle methods', () => {
     it('calls componentDidMount', () => {
       sinon.spy(Tooltip.prototype, 'componentDidMount');

--- a/test/components/common/tooltip/Tooltip.test.js
+++ b/test/components/common/tooltip/Tooltip.test.js
@@ -163,4 +163,52 @@ describe('Tooltip', () => {
     wrapper.instance().calculateOffset(wrapper.props());
     expect(wrapper.state()).to.deep.equal({ offset: { top: 0, left: -50 } });
   });
+
+  describe('lifecycle methods', () => {
+    it('calls componentDidMount', () => {
+      sinon.spy(Tooltip.prototype, 'componentDidMount');
+      mount(
+        <Tooltip
+          position={position}
+          title={title}
+          content={content}
+        />
+      );
+      expect(Tooltip.prototype.componentDidMount.calledOnce).to.be.true;
+    });
+
+    it('componentDidMount in turn calls calculateOffset', () => {
+      const wrapper = mount(
+        <Tooltip
+          position={position}
+          title={title}
+          content={content}
+        />
+      );
+      const instance = wrapper.instance();
+      const calcSpy = sinon.spy(instance, 'calculateOffset');
+      expect(calcSpy.callCount).to.equal(0);
+      instance.componentDidMount();
+      expect(calcSpy.calledOnce).to.be.true;
+    });
+
+    it('calls componentWillReceiveProps (which calls calculateOffset) on props update', () => {
+      sinon.spy(Tooltip.prototype, 'componentWillReceiveProps');
+      const wrapper = mount(
+        <Tooltip
+          position={position}
+          title={title}
+          content={content}
+        />
+      );
+      const instance = wrapper.instance();
+      const calcSpy = sinon.spy(instance, 'calculateOffset');
+      expect(Tooltip.prototype.componentWillReceiveProps.callCount).to.equal(0);
+      expect(calcSpy.callCount).to.equal(0);
+      wrapper.setProps({ title: 'New title!' });
+      expect(Tooltip.prototype.componentWillReceiveProps.calledOnce).to.be.true;
+      expect(calcSpy.calledOnce).to.be.true;
+      expect(calcSpy.args[0][0]).to.deep.equal(wrapper.props());
+    });
+  });
 });

--- a/test/components/trends/cbg/RangeSelect.test.js
+++ b/test/components/trends/cbg/RangeSelect.test.js
@@ -25,6 +25,7 @@ import { RangeSelect, mapDispatchToProps }
 describe('RangeSelect', () => {
   describe('RangeSelect (w/o redux connect()ion)', () => {
     const props = {
+      currentPatientInViewId: 'a1b2c3',
       displayFlags: {
         cbg100Enabled: false,
         cbg80Enabled: true,


### PR DESCRIPTION
The changes here add four main features to the Tooltip component:
- the Tooltips are now invisible to pointer events, to avoid "stuttering" if connection between the original hover target and the pointer is broken due to hovering on a bit of the tooltip itself!
- the total offset gets recalculated from new props if the component is updated (via the `componentWillReceiveProps` lifecycle hook)
- ability to pass in a `backgroundColor` in props
- ability to pass in a `horizontal` instead of `left` in the `offset` prop: if/when you do this, the calculated total offset will flip the sign of the value specified in `horizontal` when the tooltip is on the left...this avoids repeating [logic such as found here](https://github.com/tidepool-org/viz/blob/master/src/components/trends/smbg/FocusedSMBGPointLabel.js#L76) all over the damn place

The `horizontal` option is an *add* and the behavior of passing in `left` remains unchanged (i.e., backwards-compatible) but I did update the components that currently passed in a `left` where they would benefit from `horizontal` because of the sign-flipping logic.

Added tests for all of the above, of course. Had a bit of trouble with the lifecycle hooks tests and will comment inline about what I did.