### PR TITLE
updates to Trends view chart background

### DIFF
--- a/src/components/trends/common/Background.css
+++ b/src/components/trends/common/Background.css
@@ -15,15 +15,11 @@
  * == BSD2 LICENSE ==
  */
 
-.nonTargetBackground {
-  fill: var(--bkgrnd-darkest);
-}
-
-.targetBackground {
-  fill: var(--bkgrnd-dark);
+.background {
+  fill: var(--bkgrnd);
 }
 
 .threeHrLine {
-  stroke: white;
+  stroke: var(--bkgrnd-lines);
   stroke-width: 1px;
 }

--- a/src/components/trends/common/Background.js
+++ b/src/components/trends/common/Background.js
@@ -21,12 +21,13 @@ import React, { PropTypes } from 'react';
 
 import * as datetime from '../../../utils/datetime';
 
-import styles from './BackgroundWithTargetRange.css';
+import styles from './Background.css';
 
-const BackgroundWithTargetRange = (props) => {
-  const { bgBounds, data, margins, svgDimensions, xScale, yScale } = props;
+const Background = (props) => {
+  const { data, margins, svgDimensions, xScale } = props;
 
   const width = svgDimensions.width - margins.left - margins.right;
+  const height = svgDimensions.height - margins.top - margins.bottom;
 
   const lines = props.linesAtThreeHrs ? _.map(data, (val, i) => (
     <line
@@ -42,43 +43,23 @@ const BackgroundWithTargetRange = (props) => {
   return (
     <g id="background">
       <rect
-        className={styles.nonTargetBackground}
+        className={styles.background}
         x={margins.left}
         y={margins.top}
         width={width}
-        height={yScale(bgBounds.targetUpperBound) - margins.top}
-      />
-      <rect
-        className={styles.targetBackground}
-        x={margins.left}
-        y={yScale(bgBounds.targetUpperBound)}
-        width={width}
-        height={yScale(bgBounds.targetLowerBound) - yScale(bgBounds.targetUpperBound)}
-      />
-      <rect
-        className={styles.nonTargetBackground}
-        x={margins.left}
-        y={yScale(bgBounds.targetLowerBound)}
-        width={width}
-        height={svgDimensions.height - margins.bottom - yScale(bgBounds.targetLowerBound)}
+        height={height}
       />
       {lines}
     </g>
   );
 };
 
-BackgroundWithTargetRange.defaultProps = {
+Background.defaultProps = {
   data: _.map(range(1, 8), (i) => (i * datetime.THREE_HRS)),
   linesAtThreeHrs: false,
 };
 
-BackgroundWithTargetRange.propTypes = {
-  bgBounds: PropTypes.shape({
-    veryHighThreshold: PropTypes.number.isRequired,
-    targetUpperBound: PropTypes.number.isRequired,
-    targetLowerBound: PropTypes.number.isRequired,
-    veryLowThreshold: PropTypes.number.isRequired,
-  }).isRequired,
+Background.propTypes = {
   data: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired,
   linesAtThreeHrs: PropTypes.bool.isRequired,
   margins: PropTypes.shape({
@@ -92,7 +73,6 @@ BackgroundWithTargetRange.propTypes = {
     height: PropTypes.number.isRequired,
   }).isRequired,
   xScale: PropTypes.func.isRequired,
-  yScale: PropTypes.func.isRequired,
 };
 
-export default BackgroundWithTargetRange;
+export default Background;

--- a/src/containers/trends/TrendsSVGContainer.js
+++ b/src/containers/trends/TrendsSVGContainer.js
@@ -45,7 +45,7 @@ import _ from 'lodash';
 
 import { MGDL_UNITS, MMOLL_UNITS } from '../../utils/constants';
 import { THREE_HRS } from '../../utils/datetime';
-import BackgroundWithTargetRange from '../../components/trends/common/BackgroundWithTargetRange';
+import Background from '../../components/trends/common/Background';
 import CBGSlicesAnimationContainer from './CBGSlicesAnimationContainer';
 import SMBGsByDateContainer from './SMBGsByDateContainer';
 import SMBGRangeAvgAnimationContainer from './SMBGRangeAvgAnimationContainer';
@@ -186,14 +186,12 @@ export class TrendsSVGContainer extends React.Component {
     const { containerHeight: height, containerWidth: width } = this.props;
     return (
       <svg height={height} width={width}>
-        <BackgroundWithTargetRange
-          bgBounds={this.props.bgBounds}
+        <Background
           linesAtThreeHrs
           margins={this.props.margins}
           smbgOpts={this.props.smbgOpts}
           svgDimensions={{ height, width }}
           xScale={this.props.xScale}
-          yScale={this.props.yScale}
         />
         <XAxisLabels
           margins={this.props.margins}

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -27,14 +27,10 @@
   --data-purple--medium: #617CFC; /* was #627CFF */
   --data-purple--dark: #291A45; /* was #281746 */
 
-  --axis-tick: #B9C8D0;
+  --axis-tick: #E7E7E7;
 
-  --bkgrnd-darkest: #D3DBDD;
-  --bkgrnd-darker: #DCE4E7;
-  --bkgrnd-dark: #E3EAED;
-  --bkgrnd-light: #F2F4F6;
-  --bkgrnd-lighter: #E9EFF1;
-  --bkgrnd-lightest: #F8F9FA;
+  --bkgrnd: #F8F8F8;
+  --bkgrnd-lines: #E7E7E7;
 
   --tooltip-title-bg: #EAEAEE;
 

--- a/stories/components/trends/common/Background.js
+++ b/stories/components/trends/common/Background.js
@@ -4,17 +4,11 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 
 // eslint-disable-next-line max-len
-import BackgroundWithTargetRange from '../../../../src/components/trends/common/BackgroundWithTargetRange';
+import Background from '../../../../src/components/trends/common/Background';
 
 const w = 800;
 const h = 450;
 const props = {
-  bgBounds: {
-    veryHighThreshold: 300,
-    targetUpperBound: 180,
-    targetLowerBound: 80,
-    veryLowThreshold: 60,
-  },
   margins: {
     left: 0,
     right: 0,
@@ -26,17 +20,16 @@ const props = {
     height: h,
   },
   xScale: scaleLinear().domain([0, 864e5]).range([0, w]),
-  yScale: scaleLinear().domain([27, 400]).range([h, 0]),
 };
 
-storiesOf('BackgroundWithTargetRange', module)
+storiesOf('Background', module)
   .add('without lines', () => (
     <svg width={w} height={h}>
-      <BackgroundWithTargetRange {...props} />
+      <Background {...props} />
     </svg>
   ))
   .add('with lines at three-hour intervals', () => (
     <svg width={w} height={h}>
-      <BackgroundWithTargetRange {...props} linesAtThreeHrs />
+      <Background {...props} linesAtThreeHrs />
     </svg>
   ));

--- a/test/components/trends/common/Background.test.js
+++ b/test/components/trends/common/Background.test.js
@@ -32,12 +32,12 @@ import SVGContainer from '../../../helpers/SVGContainer';
 
 import { TWENTY_FOUR_HRS } from '../../../../src/utils/datetime';
 
-import BackgroundWithTargetRange
-  from '../../../../src/components/trends/common/BackgroundWithTargetRange';
+import Background
+  from '../../../../src/components/trends/common/Background';
 import styles
-  from '../../../../src/components/trends/common/BackgroundWithTargetRange.css';
+  from '../../../../src/components/trends/common/Background.css';
 
-describe('BackgroundWithTargetRange', () => {
+describe('Background', () => {
   let wrapper;
   const props = {
     bgBounds: {
@@ -63,29 +63,14 @@ describe('BackgroundWithTargetRange', () => {
   before(() => {
     wrapper = mount(
       <SVGContainer dimensions={{ width: trendsWidth, height: trendsHeight }}>
-        <BackgroundWithTargetRange {...props} />
+        <Background {...props} />
       </SVGContainer>
     );
   });
 
-  it('should render two rects above and below target range', () => {
-    const nonTargetRects = wrapper.find(formatClassesAsSelector(styles.nonTargetBackground));
-    expect(nonTargetRects).to.have.length(2);
-    // Enzyme forEach cannot be replaced by _.forEach
-    // eslint-disable-next-line lodash/prefer-lodash-method
-    nonTargetRects.forEach((rect) => {
-      expect(rect.is('rect')).to.be.true;
-    });
-  });
-
-  it('should render one rect for the target range', () => {
-    const { bgBounds: { targetUpperBound, targetLowerBound } } = props;
-    const targetRect = wrapper.find(formatClassesAsSelector(styles.targetBackground));
-    expect(targetRect).to.have.length(1);
-    expect(targetRect.is('rect')).to.be.true;
-    expect(targetRect.prop('y')).to.equal(yScale(targetUpperBound));
-    const expectedHeight = yScale(targetLowerBound) - yScale(targetUpperBound);
-    expect(targetRect.prop('height')).to.equal(expectedHeight);
+  it('should render one rect for the chart background', () => {
+    expect(wrapper.find('rect').length).to.equal(1);
+    expect(wrapper.find('rect').hasClass((styles.background))).to.be.true;
   });
 
   it('should NOT render 3-hr dividing lines by default', () => {
@@ -99,7 +84,7 @@ describe('BackgroundWithTargetRange', () => {
     before(() => {
       withLinesWrapper = mount(
         <SVGContainer dimensions={{ width: trendsWidth, height: trendsHeight }}>
-          <BackgroundWithTargetRange {...props} linesAtThreeHrs />
+          <Background {...props} linesAtThreeHrs />
         </SVGContainer>
       );
     });

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -23,8 +23,8 @@ import { mount } from 'enzyme';
 import { TrendsSVGContainer } from '../../../src/containers/trends/TrendsSVGContainer';
 
 import { MGDL_UNITS } from '../../../src/utils/constants';
-import BackgroundWithTargetRange
-  from '../../../src/components/trends/common/BackgroundWithTargetRange';
+import Background
+  from '../../../src/components/trends/common/Background';
 import CBGSlicesAnimationContainer
   from '../../../src/containers/trends/CBGSlicesAnimationContainer';
 import SMBGRangeAvgAnimationContainer
@@ -110,8 +110,8 @@ describe('TrendsSVGContainer', () => {
       wrapper = mount(<TrendsSVGContainer {...props} />);
     });
 
-    it('should render a BackgroundWithTargetRange', () => {
-      expect(wrapper.find(BackgroundWithTargetRange)).to.have.length(1);
+    it('should render a Background', () => {
+      expect(wrapper.find(Background)).to.have.length(1);
     });
 
     it('should render a XAxisLabels', () => {


### PR DESCRIPTION
Here's a very small PR just containing the styling changes to the chart background for Trends view—that is, new colors and removal of the lighter target range area.

This is quite independent of #38 (thought I suppose both make changes to the TrendsSVGContainer, but the conflicts should be small if present as all) so can be reviewed and merged into the feature branch (merge target) in any order.