### PR TITLE
render a different no data message when all days unselected

### DIFF
--- a/src/components/trends/common/NoData.js
+++ b/src/components/trends/common/NoData.js
@@ -21,8 +21,15 @@ import _ from 'lodash';
 import styles from './NoData.css';
 
 const NoData = (props) => {
-  const { position, dataType, displayTypes, messageString } = props;
-  const noDataMessage = _.template(messageString);
+  const {
+    dataType,
+    displayTypes,
+    messageString,
+    position,
+    unselectedAllData,
+    unselectedAllDataString,
+  } = props;
+  const noDataMessage = _.template(unselectedAllData ? unselectedAllDataString : messageString);
 
   if (!position) {
     return null;
@@ -43,6 +50,7 @@ const NoData = (props) => {
 NoData.defaultProps = {
   displayTypes: { cbg: 'CGM', smbg: 'fingerstick' },
   messageString: 'There is no <%= displayType %> data for this time period :(',
+  unselectedAllDataString: 'Hang on there, skippy! You unselected all of the data!',
 };
 
 NoData.propTypes = {
@@ -53,6 +61,8 @@ NoData.propTypes = {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
   }).isRequired,
+  unselectedAllData: PropTypes.bool.isRequired,
+  unselectedAllDataString: PropTypes.string.isRequired,
 };
 
 export default NoData;

--- a/src/containers/trends/TrendsContainer.js
+++ b/src/containers/trends/TrendsContainer.js
@@ -365,6 +365,7 @@ export class TrendsContainer extends React.Component {
     }
     return (
       <TrendsSVGContainer
+        activeDays={this.props.activeDays}
         bgBounds={this.props.bgBounds}
         bgUnits={this.props.bgUnits}
         smbgData={this.state.currentSmbgData}

--- a/src/containers/trends/TrendsSVGContainer.js
+++ b/src/containers/trends/TrendsSVGContainer.js
@@ -72,16 +72,18 @@ export class TrendsSVGContainer extends React.Component {
   }
 
   renderNoDataMessage(dataType) {
-    const { containerHeight: height, containerWidth: width, margins } = this.props;
+    const { activeDays, containerHeight: height, containerWidth: width, margins } = this.props;
     const xPos = (width / 2) + margins.right;
     const yPos = (height / 2) + margins.bottom;
     const messagePosition = { x: xPos, y: yPos };
+    const unselectedAll = _.every(activeDays, (flag) => (!flag));
     if ((this.props.showingCbg && _.isEmpty(this.props.cbgData)) ||
       (this.props.showingSmbg && _.isEmpty(this.props.smbgData))) {
       return (
         <NoData
           dataType={dataType}
           position={messagePosition}
+          unselectedAllData={unselectedAll}
         />
       );
     }
@@ -230,6 +232,15 @@ TrendsSVGContainer.defaultProps = {
 };
 
 TrendsSVGContainer.propTypes = {
+  activeDays: PropTypes.shape({
+    monday: PropTypes.bool.isRequired,
+    tuesday: PropTypes.bool.isRequired,
+    wednesday: PropTypes.bool.isRequired,
+    thursday: PropTypes.bool.isRequired,
+    friday: PropTypes.bool.isRequired,
+    saturday: PropTypes.bool.isRequired,
+    sunday: PropTypes.bool.isRequired,
+  }).isRequired,
   bgBounds: PropTypes.shape({
     veryHighThreshold: PropTypes.number.isRequired,
     targetUpperBound: PropTypes.number.isRequired,

--- a/test/components/trends/common/NoData.test.js
+++ b/test/components/trends/common/NoData.test.js
@@ -32,6 +32,7 @@ describe('NoData', () => {
     );
     expect(wrapper.find('text')).to.have.length(1);
   });
+
   it('should render given with x and y position', () => {
     const wrapper = shallow(
       <NoData
@@ -41,12 +42,14 @@ describe('NoData', () => {
     expect(wrapper.find('text[x=10]')).to.have.length(1);
     expect(wrapper.find('text[y=50]')).to.have.length(1);
   });
+
   it('should not render when position not provided', () => {
     const wrapper = shallow(
       <NoData />
     );
     expect(wrapper.find('text')).to.have.length(0);
   });
+
   it('should render with the provided data type in the message', () => {
     const wrapper = shallow(
       <NoData
@@ -57,6 +60,7 @@ describe('NoData', () => {
     expect(wrapper.find('text').text())
       .to.equal('There is no fingerstick data for this time period :(');
   });
+
   it('should not specify a default data type', () => {
     const wrapper = shallow(
       <NoData
@@ -66,6 +70,7 @@ describe('NoData', () => {
     expect(wrapper.find('text').text())
       .to.equal('There is no  data for this time period :(');
   });
+
   it('should be able to override the message with a templated string', () => {
     const wrapper = shallow(
       <NoData
@@ -77,6 +82,7 @@ describe('NoData', () => {
     );
     expect(wrapper.find('text').text()).to.equal('Whoops no fingerstick data!');
   });
+
   it('should be able to override the message with own displayTypes', () => {
     const wrapper = shallow(
       <NoData
@@ -88,6 +94,7 @@ describe('NoData', () => {
     );
     expect(wrapper.find('text').text()).to.equal('Whoops no BGM data!');
   });
+
   it('should be able to override the message and without a templated string', () => {
     const wrapper = shallow(
       <NoData
@@ -96,5 +103,29 @@ describe('NoData', () => {
       />
     );
     expect(wrapper.find('text').text()).to.equal('Whoops no data!');
+  });
+
+  it('should render the unselected all data msg if unselectedAllData prop is true', () => {
+    const wrapper = shallow(
+      <NoData
+        position={position}
+        unselectedAllData
+      />
+    );
+    expect(wrapper.find('text').text())
+      .to.equal('Hang on there, skippy! You unselected all of the data!');
+  });
+
+  it('should be able to override the unselected all data message string', () => {
+    const customized = 'Dude, you unselected everything!';
+    const wrapper = shallow(
+      <NoData
+        position={position}
+        unselectedAllData
+        unselectedAllDataString={customized}
+      />
+    );
+    expect(wrapper.find('text').text())
+      .to.equal(customized);
   });
 });

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -45,6 +45,15 @@ function makeScale(scale) {
 
 describe('TrendsSVGContainer', () => {
   const props = {
+    activeDays: {
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: false,
+      sunday: false,
+    },
     bgBounds,
     bgUnits: MGDL_UNITS,
     // normally provided by react-dimensions wrapper but we test w/o that
@@ -142,6 +151,13 @@ describe('TrendsSVGContainer', () => {
         expect(wrapper.find(CBGSlicesContainer)).to.have.length(1);
       });
 
+      it('should render a unselected all data message when all days unselected', () => {
+        const unselectedProps = _.assign({}, props, { cbgData: [], activeDays: { monday: false } });
+        const unselectedWrapper = shallow(<TrendsSVGContainer {...unselectedProps} />);
+        expect(unselectedWrapper.find(NoData)).to.have.length(1);
+        expect(unselectedWrapper.find(NoData).prop('unselectedAllData')).to.be.true;
+      });
+
       describe('when showingSmbg is false', () => {
         it('should not render an SMBGRangeAvgContainer', () => {
           expect(wrapper.find(SMBGRangeAvgContainer)).to.have.length(0);
@@ -157,6 +173,17 @@ describe('TrendsSVGContainer', () => {
     });
 
     describe('showing BGM data', () => {
+      it('should render a unselected all data message when all days unselected', () => {
+        const unselectedProps = _.assign(
+          {},
+          props,
+          { showingCbg: false, showingSmbg: true, smbgData: [], activeDays: { monday: false } }
+        );
+        const unselectedWrapper = shallow(<TrendsSVGContainer {...unselectedProps} />);
+        expect(unselectedWrapper.find(NoData)).to.have.length(1);
+        expect(unselectedWrapper.find(NoData).prop('unselectedAllData')).to.be.true;
+      });
+
       describe('when smbgRangeOverlay is true', () => {
         it('should render an SMBGRangeAvgContainer for range', () => {
           const smbgRangeProps = _.assign(


### PR DESCRIPTION
A small addition to the Trends work. I noticed that if the user unselected all days of the week, the no data message didn't make a lot of sense (since it talks about no data in the time period). At our meeting yesterday, new language was proposed for this case.

I thought this would be a nice small one for @hntrdglss to look at, and I've targeted it to the branch for #40 to keep the diff limited to the new changes. (It builds on the reorg of rendering the `NoData` component in that earlier work.)