### PR TITLE
show cbg date traces on segment hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,10 +99,12 @@
     "d3-scale": "1.0.3",
     "d3-shape": "1.0.3",
     "d3-time": "1.0.2",
+    "gsap": "1.19.0",
     "react-collapse": "2.3.1",
     "react-dimensions": "2.0.0-alpha1",
     "react-height": "2.1.1",
-    "react-motion": "0.4.4"
+    "react-motion": "0.4.4",
+    "react-transition-group-plus": "0.4.0"
   },
   "peerDependencies": {
     "classnames": "2.x",

--- a/src/components/trends/cbg/CBGDateTraceAnimated.css
+++ b/src/components/trends/cbg/CBGDateTraceAnimated.css
@@ -1,0 +1,36 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+.border {
+  stroke: white;
+  stroke-width: 0.5px;
+}
+
+.low {
+  composes: border;
+  composes: bgLow from '../../../styles/diabetes.css';
+}
+
+.target {
+  composes: border;
+  composes: bgTarget from '../../../styles/diabetes.css';
+}
+
+.high {
+  composes: border;
+  composes: bgHigh from '../../../styles/diabetes.css';
+}

--- a/src/components/trends/cbg/CBGDateTraceAnimated.js
+++ b/src/components/trends/cbg/CBGDateTraceAnimated.js
@@ -55,6 +55,7 @@ class CBGDateTraceAnimated extends Component {
     t.staggerTo(targets, 0.2, { opacity: 1 }, 0.0015);
   }
 
+  // TransitionGroupPlus gets mad if this isn't defined :(
   componentDidEnter() {}
 
   componentWillLeave(cb) {

--- a/src/components/trends/cbg/CBGDateTraceAnimated.js
+++ b/src/components/trends/cbg/CBGDateTraceAnimated.js
@@ -1,0 +1,89 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import _ from 'lodash';
+import { TimelineMax } from 'gsap';
+import React, { Component, PropTypes } from 'react';
+
+import { classifyBgValue } from '../../../utils/bloodglucose';
+
+import styles from './CBGDateTraceAnimated.css';
+
+class CBGDateTraceAnimated extends Component {
+  static defaultProps = {
+    cbgRadius: 2.5,
+  };
+
+  static propTypes = {
+    bgBounds: PropTypes.shape({
+      veryHighThreshold: PropTypes.number.isRequired,
+      targetUpperBound: PropTypes.number.isRequired,
+      targetLowerBound: PropTypes.number.isRequired,
+      veryLowThreshold: PropTypes.number.isRequired,
+    }).isRequired,
+    cbgRadius: PropTypes.number.isRequired,
+    data: PropTypes.arrayOf(PropTypes.shape({
+      // here only documenting the properties we actually use rather than the *whole* data model!
+      id: PropTypes.string.isRequired,
+      msPer24: PropTypes.number.isRequired,
+      value: PropTypes.number.isRequired,
+    })).isRequired,
+    date: PropTypes.string.isRequired,
+    xScale: PropTypes.func.isRequired,
+    yScale: PropTypes.func.isRequired,
+  };
+
+  componentWillEnter(cb) {
+    const { data } = this.props;
+    const targets = _.map(data, (d) => (this[d.id]));
+    const t = new TimelineMax({ onComplete: cb });
+
+    t.staggerTo(targets, 0.2, { opacity: 1 }, 0.0015);
+  }
+
+  componentDidEnter() {}
+
+  componentWillLeave(cb) {
+    const { data } = this.props;
+    const targets = _.map(data, (d) => (this[d.id]));
+    const t = new TimelineMax({ onComplete: cb });
+
+    t.staggerTo(targets, 0.2, { opacity: 0 }, 0.0015);
+  }
+
+  render() {
+    const { bgBounds, cbgRadius, data, date, xScale, yScale } = this.props;
+    return (
+      <g id={`cbgDateTrace-${date}`}>
+        {_.map(data, (d) => (
+          <circle
+            className={`cbgCircle ${styles[classifyBgValue(bgBounds, d.value)]}`}
+            cx={xScale(d.msPer24)}
+            cy={yScale(d.value)}
+            key={d.id}
+            opacity={0}
+            pointerEvents="none"
+            r={cbgRadius}
+            ref={(node) => { this[d.id] = node; }}
+          />
+        ))}
+      </g>
+    );
+  }
+}
+
+export default CBGDateTraceAnimated;

--- a/src/components/trends/cbg/CBGDateTraceAnimated.js
+++ b/src/components/trends/cbg/CBGDateTraceAnimated.js
@@ -55,7 +55,6 @@ class CBGDateTraceAnimated extends Component {
     t.staggerTo(targets, 0.2, { opacity: 1 }, 0.0015);
   }
 
-  // TransitionGroupPlus gets mad if this isn't defined :(
   componentDidEnter() {}
 
   componentWillLeave(cb) {

--- a/src/components/trends/cbg/CBGSliceAnimated.css
+++ b/src/components/trends/cbg/CBGSliceAnimated.css
@@ -23,6 +23,10 @@
   stroke-width: 2;
 }
 
+.pointAll {
+  pointer-events: all;
+}
+
 .median {
   stroke: white;
   composes: thickStroke;
@@ -47,26 +51,30 @@
 
 .rangeSegment {
   stroke: var(--trends--light);
-  composes: thickStroke;
+  composes: pointAll thickStroke;
   fill: transparent;
+}
+
+.rangeSegment:hover {
+  opacity: 0;
 }
 
 .outerSegment {
   stroke: var(--trends--light);
-  composes: thickStroke;
+  composes: pointAll thickStroke;
   fill: var(--trends--light);
 }
 
 .outerSegment:hover {
-  fill: transparent;
+  opacity: 0;
 }
 
 .innerQuartilesSegment {
   stroke: var(--trends--dark);
-  composes: thickStroke;
+  composes: pointAll thickStroke;
   fill: var(--trends--dark);
 }
 
 .innerQuartilesSegment:hover {
-  fill: transparent;
+  opacity: 0;
 }

--- a/src/components/trends/cbg/FocusedCBGSliceSegment.css
+++ b/src/components/trends/cbg/FocusedCBGSliceSegment.css
@@ -1,0 +1,27 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+:export {
+  stroke: 2;
+}
+
+.segment {
+  stroke: black;
+  stroke-width: 2;
+  pointer-events: none;
+  fill: transparent;
+}

--- a/src/components/trends/cbg/FocusedCBGSliceSegment.js
+++ b/src/components/trends/cbg/FocusedCBGSliceSegment.js
@@ -1,0 +1,76 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React, { PropTypes } from 'react';
+
+import styles from './FocusedCBGSliceSegment.css';
+
+const FocusedCBGSliceSegment = (props) => {
+  const { focusedSlice: { position }, focusedSliceKeys, sliceWidth } = props;
+  return (
+    <rect
+      className={styles.segment}
+      x={position.left - sliceWidth / 2 + styles.stroke / 2}
+      y={position.yPositions[focusedSliceKeys[1]]}
+      width={sliceWidth - styles.stroke}
+      height={position.yPositions[focusedSliceKeys[0]] - position.yPositions[focusedSliceKeys[1]]}
+    />
+  );
+};
+
+FocusedCBGSliceSegment.defaultProps = {
+  sliceWidth: 16,
+};
+
+FocusedCBGSliceSegment.propTypes = {
+  focusedSlice: PropTypes.shape({
+    data: PropTypes.shape({
+      firstQuartile: PropTypes.number.isRequired,
+      max: PropTypes.number.isRequired,
+      median: PropTypes.number.isRequired,
+      min: PropTypes.number.isRequired,
+      ninetiethQuantile: PropTypes.number.isRequired,
+      tenthQuantile: PropTypes.number.isRequired,
+      thirdQuartile: PropTypes.number.isRequired,
+    }).isRequired,
+    position: PropTypes.shape({
+      left: PropTypes.number.isRequired,
+      tooltipLeft: PropTypes.bool.isRequired,
+      yPositions: PropTypes.shape({
+        firstQuartile: PropTypes.number.isRequired,
+        max: PropTypes.number.isRequired,
+        median: PropTypes.number.isRequired,
+        min: PropTypes.number.isRequired,
+        ninetiethQuantile: PropTypes.number.isRequired,
+        tenthQuantile: PropTypes.number.isRequired,
+        thirdQuartile: PropTypes.number.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }),
+  focusedSliceKeys: PropTypes.arrayOf(PropTypes.oneOf([
+    'firstQuartile',
+    'max',
+    'median',
+    'min',
+    'ninetiethQuantile',
+    'tenthQuantile',
+    'thirdQuartile',
+  ])),
+  sliceWidth: PropTypes.number.isRequired,
+};
+
+export default FocusedCBGSliceSegment;

--- a/src/components/trends/cbg/FocusedCBGSliceSegment.js
+++ b/src/components/trends/cbg/FocusedCBGSliceSegment.js
@@ -20,6 +20,9 @@ import React, { PropTypes } from 'react';
 import styles from './FocusedCBGSliceSegment.css';
 
 const FocusedCBGSliceSegment = (props) => {
+  if (!props.focusedSlice || !props.focusedSliceKeys) {
+    return null;
+  }
   const { focusedSlice: { position }, focusedSliceKeys, sliceWidth } = props;
   return (
     <rect

--- a/src/containers/trends/CBGDateTracesAnimationContainer.js
+++ b/src/containers/trends/CBGDateTracesAnimationContainer.js
@@ -1,0 +1,55 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import _ from 'lodash';
+import React, { PropTypes } from 'react';
+import TransitionGroupPlus from 'react-transition-group-plus';
+
+import CBGDateTraceAnimated from '../../components/trends/cbg/CBGDateTraceAnimated';
+
+const CBGDateTracesAnimationContainer = (props) => {
+  const { bgBounds, data, dates, xScale, yScale } = props;
+  return (
+    <TransitionGroupPlus component="g" id="cbgDateTraces" transitionMode="simultaneous">
+      {_.map(dates, (localDate) => (
+        <CBGDateTraceAnimated
+          bgBounds={bgBounds}
+          data={data[localDate]}
+          date={localDate}
+          key={localDate}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      ))}
+    </TransitionGroupPlus>
+  );
+};
+
+CBGDateTracesAnimationContainer.propTypes = {
+  bgBounds: PropTypes.shape({
+    veryHighThreshold: PropTypes.number.isRequired,
+    targetUpperBound: PropTypes.number.isRequired,
+    targetLowerBound: PropTypes.number.isRequired,
+    veryLowThreshold: PropTypes.number.isRequired,
+  }).isRequired,
+  data: PropTypes.object,
+  dates: PropTypes.arrayOf(PropTypes.string),
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+};
+
+export default CBGDateTracesAnimationContainer;

--- a/src/containers/trends/TrendsSVGContainer.js
+++ b/src/containers/trends/TrendsSVGContainer.js
@@ -47,6 +47,7 @@ import { MGDL_UNITS, MMOLL_UNITS } from '../../utils/constants';
 import { THREE_HRS } from '../../utils/datetime';
 import Background from '../../components/trends/common/Background';
 import CBGSlicesContainer from './CBGSlicesContainer';
+import FocusedCBGSliceSegment from '../../components/trends/cbg/FocusedCBGSliceSegment';
 import SMBGsByDateContainer from './SMBGsByDateContainer';
 import SMBGRangeAvgContainer from './SMBGRangeAvgContainer';
 import SMBGRangeAnimated from '../../components/trends/smbg/SMBGRangeAnimated';
@@ -110,7 +111,7 @@ export class TrendsSVGContainer extends React.Component {
 
   renderCbg() {
     if (this.props.showingCbg) {
-      return (
+      const slices = (
         <CBGSlicesContainer
           bgBounds={this.props.bgBounds}
           data={this.props.cbgData}
@@ -123,6 +124,24 @@ export class TrendsSVGContainer extends React.Component {
           xScale={this.props.xScale}
           yScale={this.props.yScale}
         />
+      );
+
+      let focused = null;
+      const { focusedSlice, focusedSliceKeys } = this.props;
+      if (!_.isEmpty(focusedSlice) && !_.isEmpty(focusedSliceKeys)) {
+        focused = (
+          <FocusedCBGSliceSegment
+            focusedSlice={focusedSlice}
+            focusedSliceKeys={focusedSliceKeys}
+          />
+        );
+      }
+
+      return (
+        <g id="cbgTrends">
+          {slices}
+          {focused}
+        </g>
       );
     }
     return null;
@@ -295,6 +314,15 @@ TrendsSVGContainer.propTypes = {
       }).isRequired,
     }).isRequired,
   }),
+  focusedSliceKeys: PropTypes.arrayOf(PropTypes.oneOf([
+    'firstQuartile',
+    'max',
+    'median',
+    'min',
+    'ninetiethQuantile',
+    'tenthQuantile',
+    'thirdQuartile',
+  ])),
   focusedSmbg: PropTypes.shape({
     allPositions: PropTypes.arrayOf(PropTypes.shape({
       top: PropTypes.number.isRequired,

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -34,6 +34,33 @@ export function findBinForTimeOfDay(binSize, msPer24) {
 
   return Math.floor(msPer24 / binSize) * binSize + (binSize / 2);
 }
+/**
+ * findDatesIntersectingWithCbgSliceSegment
+ * @param {Array} cbgData - Array of Tidepool cbg events
+ * @param {Object} focusedSlice - the current focused cbg slice/segment
+ * @param {Array} focusedSliceKeys - Array of 2 keys representing
+ *                                   the top & bottom of focused slice segment
+ *
+ * @return {Array} dates - Array of String dates in YYYY-MM-DD format
+ */
+export function findDatesIntersectingWithCbgSliceSegment(cbgData, focusedSlice, focusedSliceKeys) {
+  const { data } = focusedSlice;
+  return _.uniq(
+    _.pluck(
+      _.filter(
+        cbgData,
+        (d) => {
+          if (d.msPer24 >= data.msFrom && d.msPer24 < data.msTo) {
+            return (d.value >= data[focusedSliceKeys[0]] &&
+              d.value <= data[focusedSliceKeys[1]]);
+          }
+          return false;
+        }
+      ),
+      'localDate',
+    )
+  ).sort();
+}
 
 /**
  * calculateCbgStatsForBin

--- a/test/components/trends/cbg/CBGDateTraceAnimated.test.js
+++ b/test/components/trends/cbg/CBGDateTraceAnimated.test.js
@@ -1,0 +1,94 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import _ from 'lodash';
+import React from 'react';
+import { mount } from 'enzyme';
+
+import * as scales from '../../../helpers/scales';
+const {
+  trendsHeight,
+  trendsWidth,
+  trendsXScale: xScale,
+  trendsYScale: yScale,
+} = scales.trends;
+import bgBounds from '../../../helpers/bgBounds';
+import SVGContainer from '../../../helpers/SVGContainer';
+
+import CBGDateTraceAnimated from '../../../../src/components/trends/cbg/CBGDateTraceAnimated';
+
+describe('CBGDateTraceAnimated', () => {
+  const props = {
+    bgBounds,
+    data: [{
+      id: 'a1b2c3',
+      msPer24: 0,
+      value: 100,
+    }, {
+      id: 'd4e5f6',
+      msPer24: 43200000,
+      value: 200,
+    }],
+    date: '2016-12-25',
+    xScale,
+    yScale,
+  };
+
+  describe('when the `data` is an empty array', () => {
+    let wrapper;
+    before(() => {
+      const noDataProps = _.assign({}, props, { data: [] });
+      wrapper = mount(
+        <SVGContainer dimensions={{ width: trendsWidth, height: trendsHeight }}>
+          <CBGDateTraceAnimated {...noDataProps} />
+        </SVGContainer>
+      );
+    });
+
+    it('should render a <g> with nothing in it', () => {
+      expect(wrapper.find(`#cbgDateTrace-${props.date}`)).to.have.length(1);
+      expect(wrapper.find('circle')).to.have.length(0);
+    });
+  });
+
+  describe('when `data` is not empty', () => {
+    let wrapper;
+    before(() => {
+      wrapper = mount(
+        <SVGContainer dimensions={{ width: trendsWidth, height: trendsHeight }}>
+          <CBGDateTraceAnimated {...props} />
+        </SVGContainer>
+      );
+    });
+
+    it('should render a <g> with two <circle>s in it', () => {
+      expect(wrapper.find(`#cbgDateTrace-${props.date}`)).to.have.length(1);
+      expect(wrapper.find('circle')).to.have.length(2);
+    });
+
+    it('should render each circle centered on (scaled) `msPer24` and `value`', () => {
+      const circles = wrapper.find('circle');
+      const { data } = props;
+      circles.forEach((circle, i) => { // eslint-disable-line lodash/prefer-lodash-method
+        expect(circle.prop('cx')).to.equal(xScale(data[i].msPer24));
+        expect(circle.prop('cy')).to.equal(yScale(data[i].value));
+      });
+    });
+  });
+
+  // TODO: should we test anything re: the GSAP work in the lifecycle methods?
+});

--- a/test/components/trends/cbg/FocusedCBGSliceSegment.test.js
+++ b/test/components/trends/cbg/FocusedCBGSliceSegment.test.js
@@ -1,0 +1,50 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import FocusedCBGSliceSegment from '../../../../src/components/trends/cbg/FocusedCBGSliceSegment';
+
+describe('FocusedCBGSliceSegment', () => {
+  const focusedSlice = {
+    position: {
+      left: 10,
+      yPositions: {
+        ninetiethQuantile: 90,
+        thirdQuartile: 75,
+      },
+    },
+  };
+  const focusedSliceKeys = ['thirdQuartile', 'ninetiethQuantile'];
+
+  it('renders nothing if there\'s no `focusedSlice` in props', () => {
+    const wrapper = shallow(<FocusedCBGSliceSegment focusedSliceKeys={focusedSliceKeys} />);
+    expect(wrapper.html()).to.be.null;
+  });
+
+  it('renders nothing if there\'s no `focusedSliceKeys` in props', () => {
+    const wrapper = shallow(<FocusedCBGSliceSegment focusedSlice={focusedSlice} />);
+    expect(wrapper.html()).to.be.null;
+  });
+
+  it('renders a single rect when `focusedSlice` and `focusedSliceKeys`', () => {
+    const props = { focusedSlice, focusedSliceKeys };
+    const wrapper = shallow(<FocusedCBGSliceSegment {...props} />);
+    expect(wrapper.find('rect').length).to.equal(1);
+  });
+});

--- a/test/containers/trends/CBGDateTracesAnimationContainer.test.js
+++ b/test/containers/trends/CBGDateTracesAnimationContainer.test.js
@@ -1,0 +1,53 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import _ from 'lodash';
+import React from 'react';
+import TransitionGroupPlus from 'react-transition-group-plus';
+import { shallow } from 'enzyme';
+
+import bgBounds from '../../helpers/bgBounds';
+import CBGDateTraceAnimated from '../../../src/components/trends/cbg/CBGDateTraceAnimated';
+
+import CBGDateTracesAnimationContainer
+  from '../../../src/containers/trends/CBGDateTracesAnimationContainer';
+
+describe('CBGDateTracesAnimationContainer', () => {
+  const props = {
+    bgBounds,
+    data: {
+      '2016-12-25': [],
+      '2017-01-01': [],
+    },
+    dates: ['2016-12-25', '2017-01-01'],
+    xScale: sinon.stub(),
+    yScale: sinon.stub(),
+  };
+
+  it('should render a TransitionGroupPlus even if there are no dates or data', () => {
+    const noDataProps = _.assign({}, props, { data: {}, dates: [] });
+    const wrapper = shallow(<CBGDateTracesAnimationContainer {...noDataProps} />);
+    expect(wrapper.find(TransitionGroupPlus)).to.have.length(1);
+    expect(wrapper.find(CBGDateTraceAnimated)).to.have.length(0);
+  });
+
+  it('should render a TransitionGroupPlus and a CBGDateTraceAnimated for each date', () => {
+    const wrapper = shallow(<CBGDateTracesAnimationContainer {...props} />);
+    expect(wrapper.find(TransitionGroupPlus)).to.have.length(1);
+    expect(wrapper.find(CBGDateTraceAnimated)).to.have.length(2);
+  });
+});

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -83,6 +83,75 @@ describe('[trends] data utils', () => {
     });
   });
 
+  describe('findDatesIntersectingWithCbgSliceSegment', () => {
+    const focusedSlice = {
+      data: {
+        msFrom: 0,
+        msTo: 10,
+        ninetiethQuantile: 90,
+        thirdQuartile: 75,
+      },
+    };
+    const focusedSliceKeys = ['thirdQuartile', 'ninetiethQuantile'];
+    const cbgData = [{
+      // ms in range, value = bottom of range
+      localDate: '2016-12-31',
+      msPer24: 5,
+      value: 75,
+    }, {
+      // ms in range, value = top of range
+      localDate: '2016-12-25',
+      msPer24: 5,
+      value: 90,
+    }, {
+      // ms in range, value in range
+      localDate: '2016-12-30',
+      msPer24: 5,
+      value: 80,
+    }, {
+      // ms at bottom (= in range), value in range
+      localDate: '2016-12-26',
+      msPer24: 0,
+      value: 80,
+    }, {
+      // ms at top (out of range), value in range
+      localDate: '2017-01-05',
+      msPer24: 10,
+      value: 80,
+    }, {
+      // ms in range, value below range
+      localDate: '2017-01-01',
+      msPer24: 5,
+      value: 10,
+    }, {
+      // ms in range, value above range
+      localDate: '2017-01-02',
+      msPer24: 5,
+      value: 95,
+    }];
+
+    it('should be a function', () => {
+      assert.isFunction(utils.findDatesIntersectingWithCbgSliceSegment);
+    });
+
+    it('returns an empty array on empty data', () => {
+      expect(utils.findDatesIntersectingWithCbgSliceSegment(
+        [], focusedSlice, focusedSliceKeys
+      )).to.deep.equal([]);
+    });
+
+    it('should find four intersecting 2016 dates', () => {
+      expect(utils.findDatesIntersectingWithCbgSliceSegment(
+        cbgData, focusedSlice, focusedSliceKeys
+      )).to.deep.equal([
+        '2016-12-25',
+        '2016-12-26',
+        '2016-12-30',
+        '2016-12-31',
+      ]);
+    });
+  });
+
   describe('calculateCbgStatsForBin', () => {
     const bin = 900000;
     const binKey = bin.toString();


### PR DESCRIPTION
This adds a bunch of new components (and tests for them) so that when you hover on one of the five segments of a cbg slice in the CGM version of Trends view, all the sensor traces for the dates that intersect with that segment appear on top of the slices display.

I didn't put any tests around the special animation lifecycle methods (added by `TransitionGroupPlus`) where we're doing the GSAP-based animation because it seemed like any testing there would basically be either testing `TransitionGroupPlus` or GSAP itself, not our code... LMK if you feel differently.