### PR TITLE
add ability to "stick" date traces on cbg slice segment click

### DIFF
--- a/src/components/trends/cbg/CBGSliceAnimated.js
+++ b/src/components/trends/cbg/CBGSliceAnimated.js
@@ -65,6 +65,7 @@ export class CBGSliceAnimated extends Component {
     medianHeight: PropTypes.number.isRequired,
     medianWidth: PropTypes.number.isRequired,
     sliceWidth: PropTypes.number.isRequired,
+    stickCbgDateTraces: PropTypes.func.isRequired,
     tooltipLeftThreshold: PropTypes.number.isRequired,
     topMargin: PropTypes.number.isRequired,
     unfocusSlice: PropTypes.func.isRequired,
@@ -279,12 +280,13 @@ export class CBGSliceAnimated extends Component {
                   <rect
                     className={segment.className}
                     key={key}
-                    id={key}
+                    id={`cbgSlice-${datum.id}-${key}`}
                     width={style.width}
                     height={style[renderPieces[key].height]}
                     x={style.binLeftX}
                     y={style[renderPieces[key].y]}
                     opacity={style.opacity}
+                    onClick={this.props.stickCbgDateTraces}
                     onMouseOver={() => {
                       focusSlice(datum, {
                         left: xScale(datum.msX),

--- a/src/containers/trends/CBGSlicesContainer.js
+++ b/src/containers/trends/CBGSlicesContainer.js
@@ -47,6 +47,7 @@ export default class CBGSlicesContainer extends React.Component {
     }).isRequired,
     focusedSliceKey: PropTypes.string,
     focusSlice: PropTypes.func.isRequired,
+    stickCbgDateTraces: PropTypes.func.isRequired,
     tooltipLeftThreshold: PropTypes.number.isRequired,
     topMargin: PropTypes.number.isRequired,
     unfocusSlice: PropTypes.func.isRequired,
@@ -98,21 +99,25 @@ export default class CBGSlicesContainer extends React.Component {
 
     return (
       <g id="cbgSlices">
-        {_.map(mungedData, (bin) => (
-          <CBGSliceAnimated
-            bgBounds={this.props.bgBounds}
-            datum={bin}
-            displayFlags={this.props.displayFlags}
-            focusSlice={this.props.focusSlice}
-            isFocused={bin.id === focusedSliceKey}
-            key={bin.id}
-            tooltipLeftThreshold={this.props.tooltipLeftThreshold}
-            topMargin={this.props.topMargin}
-            unfocusSlice={this.props.unfocusSlice}
-            xScale={xScale}
-            yScale={yScale}
-          />
-        ))}
+        {_.map(mungedData, (bin) => {
+          const isFocused = bin.id === focusedSliceKey;
+          return (
+            <CBGSliceAnimated
+              bgBounds={this.props.bgBounds}
+              datum={bin}
+              displayFlags={this.props.displayFlags}
+              focusSlice={this.props.focusSlice}
+              isFocused={isFocused}
+              key={bin.id}
+              stickCbgDateTraces={isFocused ? this.props.stickCbgDateTraces : _.noop}
+              tooltipLeftThreshold={this.props.tooltipLeftThreshold}
+              topMargin={this.props.topMargin}
+              unfocusSlice={this.props.unfocusSlice}
+              xScale={xScale}
+              yScale={yScale}
+            />
+          );
+        })}
       </g>
     );
   }

--- a/src/containers/trends/TrendsContainer.js
+++ b/src/containers/trends/TrendsContainer.js
@@ -85,6 +85,7 @@ export class TrendsContainer extends React.Component {
         cbg50Enabled: PropTypes.bool.isRequired,
         cbgMedianEnabled: PropTypes.bool.isRequired,
       }).isRequired,
+      cbgStuckDateTraces: PropTypes.arrayOf(PropTypes.string),
       focusedCbgSlice: PropTypes.shape({
         data: PropTypes.shape({
           firstQuartile: PropTypes.number.isRequired,
@@ -166,9 +167,11 @@ export class TrendsContainer extends React.Component {
     focusTrendsSmbgRangeAvg: PropTypes.func.isRequired,
     focusTrendsSmbg: PropTypes.func.isRequired,
     markTrendsViewed: PropTypes.func.isRequired,
+    stickCbgDateTraces: PropTypes.func.isRequired,
     unfocusTrendsCbgSlice: PropTypes.func.isRequired,
     unfocusTrendsSmbgRangeAvg: PropTypes.func.isRequired,
     unfocusTrendsSmbg: PropTypes.func.isRequired,
+    unstickCbgDateTraces: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -386,12 +389,17 @@ export class TrendsContainer extends React.Component {
         smbgGrouped={this.props.smbgGrouped}
         smbgLines={this.props.smbgLines}
         smbgRangeOverlay={this.props.smbgRangeOverlay}
+        stickCbgDateTraces={this.props.stickCbgDateTraces}
+        stuckCbgDateTraces={_.get(
+          this.props, ['trendsState', 'cbgStuckDateTraces']
+        )}
         onSelectDay={this.selectDay()}
         xScale={this.state.xScale}
         yScale={this.state.yScale}
         unfocusRange={this.props.unfocusTrendsSmbgRangeAvg}
         unfocusSmbg={this.props.unfocusTrendsSmbg}
         unfocusSlice={this.props.unfocusTrendsCbgSlice}
+        unstickCbgDateTraces={this.props.unstickCbgDateTraces}
       />
     );
   }
@@ -418,6 +426,9 @@ export function mapDispatchToProps(dispatch, ownProps) {
     markTrendsViewed: _.partial(
       actions.markTrendsViewed, ownProps.currentPatientInViewId
     ),
+    stickCbgDateTraces: _.partial(
+      actions.stickCbgDateTraces, ownProps.currentPatientInViewId
+    ),
     unfocusTrendsCbgSlice: _.partial(
       actions.unfocusTrendsCbgSlice, ownProps.currentPatientInViewId
     ),
@@ -426,6 +437,9 @@ export function mapDispatchToProps(dispatch, ownProps) {
     ),
     unfocusTrendsSmbg: _.partial(
       actions.unfocusTrendsSmbg, ownProps.currentPatientInViewId
+    ),
+    unstickCbgDateTraces: _.partial(
+      actions.unstickCbgDateTraces, ownProps.currentPatientInViewId
     ),
   }, dispatch);
 }

--- a/src/redux/actions/trends.js
+++ b/src/redux/actions/trends.js
@@ -47,6 +47,13 @@ export function markTrendsViewed(userId) {
   };
 }
 
+export function stickCbgDateTraces(userId, dates) {
+  return {
+    type: actionTypes.STICK_CBG_DATE_TRACES,
+    payload: { userId, dates },
+  };
+}
+
 export function unfocusTrendsCbgSlice(userId) {
   return {
     type: actionTypes.UNFOCUS_TRENDS_CBG_SLICE,
@@ -64,6 +71,13 @@ export function unfocusTrendsSmbg(userId) {
 export function unfocusTrendsSmbgRangeAvg(userId) {
   return {
     type: actionTypes.UNFOCUS_TRENDS_SMBG_RANGE_AVG,
+    payload: { userId },
+  };
+}
+
+export function unstickCbgDateTraces(userId) {
+  return {
+    type: actionTypes.UNSTICK_CBG_DATE_TRACES,
     payload: { userId },
   };
 }

--- a/src/redux/constants/actionTypes.js
+++ b/src/redux/constants/actionTypes.js
@@ -30,6 +30,9 @@ export const TURN_OFF_CBG_RANGE = 'TURN_OFF_CBG_RANGE';
 
 export const TOGGLE_SETTINGS_SECTION = 'TOGGLE_SETTINGS_SECTION';
 
+export const STICK_CBG_DATE_TRACES = 'STICK_CBG_DATE_TRACES';
+export const UNSTICK_CBG_DATE_TRACES = 'UNSTICK_CBG_DATE_TRACES';
+
 // from blip's redux implementation
 // TODO: how could we DRY this out??
 

--- a/src/redux/reducers/trendsStateByUser.js
+++ b/src/redux/reducers/trendsStateByUser.js
@@ -20,6 +20,7 @@ import update from 'react-addons-update';
 
 import * as actionTypes from '../constants/actionTypes';
 
+const CBG_DATE_TRACES = 'cbgStuckDateTraces';
 const CBG_FLAGS = 'cbgFlags';
 const CBG_100_ENABLED = 'cbg100Enabled';
 const CBG_80_ENABLED = 'cbg80Enabled';
@@ -46,6 +47,7 @@ const initialState = {
     [CBG_50_ENABLED]: true,
     [CBG_MEDIAN_ENABLED]: true,
   },
+  [CBG_DATE_TRACES]: null,
   [FOCUSED_CBG_SLICE]: null,
   [FOCUSED_CBG_KEYS]: null,
   [FOCUSED_SMBG]: null,
@@ -110,6 +112,15 @@ const trendsStateByUser = (state = {}, action) => {
         { [userId]: { [TOUCHED]: { $set: true } } }
       );
     }
+    case actionTypes.STICK_CBG_DATE_TRACES: {
+      const { userId, dates: newDates } = action.payload;
+      const currentDates = _.get(state, [userId, CBG_DATE_TRACES], []);
+      const updatedDates = _.union(currentDates, newDates);
+      return update(
+        state,
+        { [userId]: { [CBG_DATE_TRACES]: { $set: updatedDates } } }
+      );
+    }
     case actionTypes.UNFOCUS_TRENDS_CBG_SLICE: {
       const { userId } = action.payload;
       return update(
@@ -136,6 +147,13 @@ const trendsStateByUser = (state = {}, action) => {
         { [userId]: {
           [FOCUSED_SMBG_RANGE_AVG]: { $set: null },
         } }
+      );
+    }
+    case actionTypes.UNSTICK_CBG_DATE_TRACES: {
+      const { userId } = action.payload;
+      return update(
+        state,
+        { [userId]: { [CBG_DATE_TRACES]: { $set: null } } }
       );
     }
     case actionTypes.TURN_ON_CBG_RANGE: {

--- a/test/components/trends/cbg/CBGSliceAnimated.test.js
+++ b/test/components/trends/cbg/CBGSliceAnimated.test.js
@@ -37,6 +37,7 @@ import { CBGSliceAnimated } from '../../../../src/components/trends/cbg/CBGSlice
 describe('CBGSliceAnimated', () => {
   let wrapper;
   const focusSlice = sinon.spy();
+  const stickCbgDateTraces = sinon.spy();
   const unfocusSlice = sinon.spy();
   const datum = {
     id: '2700000',
@@ -63,6 +64,7 @@ describe('CBGSliceAnimated', () => {
     },
     focusSlice,
     isFocused: false,
+    stickCbgDateTraces,
     tooltipLeftThreshold: 6 * THREE_HRS,
     unfocusSlice,
     xScale,
@@ -84,7 +86,7 @@ describe('CBGSliceAnimated', () => {
     });
 
     it('should render the #median rect on top (i.e., last)', () => {
-      expect(wrapper.find('rect').last().prop('id')).to.equal('median');
+      expect(wrapper.find('rect').last().prop('id')).to.equal(`cbgSlice-${datum.id}-median`);
     });
 
     it('should vertically center the median rect on the value', () => {
@@ -110,6 +112,35 @@ describe('CBGSliceAnimated', () => {
         expect(CBGSliceAnimated.prototype.willLeave).to.exist;
       });
     });
+
+    describe('interactions', () => {
+      describe('onMouseOver', () => {
+        it('should fire the `focusSlice` function', () => {
+          const top10 = wrapper.find(`#cbgSlice-${datum.id}-top10`);
+          expect(props.focusSlice.callCount).to.equal(0);
+          top10.simulate('mouseover');
+          expect(props.focusSlice.callCount).to.equal(1);
+        });
+      });
+
+      describe('onMouseOut', () => {
+        it('should fire the `unfocusSlice` function', () => {
+          const top10 = wrapper.find(`#cbgSlice-${datum.id}-top10`);
+          expect(props.unfocusSlice.callCount).to.equal(0);
+          top10.simulate('mouseout');
+          expect(props.unfocusSlice.callCount).to.equal(1);
+        });
+      });
+
+      describe('onClick', () => {
+        it('should fire the `stickCbgDateTraces` function', () => {
+          const top10 = wrapper.find(`#cbgSlice-${datum.id}-top10`);
+          expect(props.stickCbgDateTraces.callCount).to.equal(0);
+          top10.simulate('click');
+          expect(props.stickCbgDateTraces.callCount).to.equal(1);
+        });
+      });
+    });
   });
 
   describe('when only `cbg100Enabled`', () => {
@@ -131,8 +162,8 @@ describe('CBGSliceAnimated', () => {
 
     it('should render #top10 and a #bottom10 <rect>s only', () => {
       expect(wrapper.find('rect').length).to.equal(2);
-      expect(wrapper.find('#top10').length).to.equal(1);
-      expect(wrapper.find('#bottom10').length).to.equal(1);
+      expect(wrapper.find(`#cbgSlice-${datum.id}-top10`).length).to.equal(1);
+      expect(wrapper.find(`#cbgSlice-${datum.id}-bottom10`).length).to.equal(1);
     });
   });
 
@@ -155,8 +186,8 @@ describe('CBGSliceAnimated', () => {
 
     it('should render #upper15 and a #lower15 <rect>s only', () => {
       expect(wrapper.find('rect').length).to.equal(2);
-      expect(wrapper.find('#upper15').length).to.equal(1);
-      expect(wrapper.find('#lower15').length).to.equal(1);
+      expect(wrapper.find(`#cbgSlice-${datum.id}-upper15`).length).to.equal(1);
+      expect(wrapper.find(`#cbgSlice-${datum.id}-lower15`).length).to.equal(1);
     });
   });
 
@@ -179,7 +210,7 @@ describe('CBGSliceAnimated', () => {
 
     it('should render a #innerQuartiles <rect> only', () => {
       expect(wrapper.find('rect').length).to.equal(1);
-      expect(wrapper.find('#innerQuartiles').length).to.equal(1);
+      expect(wrapper.find(`#cbgSlice-${datum.id}-innerQuartiles`).length).to.equal(1);
     });
   });
 
@@ -202,7 +233,7 @@ describe('CBGSliceAnimated', () => {
 
     it('should render a #median <rect> only', () => {
       expect(wrapper.find('rect').length).to.equal(1);
-      expect(wrapper.find('#median').length).to.equal(1);
+      expect(wrapper.find(`#cbgSlice-${datum.id}-median`).length).to.equal(1);
     });
   });
 

--- a/test/redux/actions/trends.test.js
+++ b/test/redux/actions/trends.test.js
@@ -100,6 +100,22 @@ describe('trends action creators', () => {
     });
   });
 
+  describe('stickCbgDateTraces', () => {
+    const dates = ['2017-01-01', '2017-01-05'];
+    const action = actions.stickCbgDateTraces(userId, dates);
+
+    it('should be a TSA', () => {
+      expect(isTSA(action)).to.be.true;
+    });
+
+    it('should create an action to stick cbg date traces for a slice segment', () => {
+      expect(action).to.deep.equal({
+        type: actionTypes.STICK_CBG_DATE_TRACES,
+        payload: { userId, dates },
+      });
+    });
+  });
+
   describe('turnOnCbgRange', () => {
     const range = '100';
     const action = actions.turnOnCbgRange(userId, range);
@@ -172,6 +188,21 @@ describe('trends action creators', () => {
     it('should create an action to unfocus (all) trends smbg range averages', () => {
       expect(action).to.deep.equal({
         type: actionTypes.UNFOCUS_TRENDS_SMBG_RANGE_AVG,
+        payload: { userId },
+      });
+    });
+  });
+
+  describe('unstickCbgDateTraces', () => {
+    const action = actions.unstickCbgDateTraces(userId);
+
+    it('should be a TSA', () => {
+      expect(isTSA(action)).to.be.true;
+    });
+
+    it('should create an action to unstick cbg date traces for a slice segment', () => {
+      expect(action).to.deep.equal({
+        type: actionTypes.UNSTICK_CBG_DATE_TRACES,
         payload: { userId },
       });
     });

--- a/test/redux/reducers/trendsStateByUser.test.js
+++ b/test/redux/reducers/trendsStateByUser.test.js
@@ -48,6 +48,7 @@ describe('trendsStateByUser', () => {
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: null,
@@ -62,17 +63,18 @@ describe('trendsStateByUser', () => {
     it('should not change anything if the user is in tree already', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -92,6 +94,7 @@ describe('trendsStateByUser', () => {
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: null,
@@ -112,6 +115,7 @@ describe('trendsStateByUser', () => {
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: null,
@@ -126,6 +130,7 @@ describe('trendsStateByUser', () => {
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: null,
@@ -144,17 +149,18 @@ describe('trendsStateByUser', () => {
     it('should store focused slice, slice\'s position, and the focused slice keys', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: ['median'],
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: ['median'],
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -162,17 +168,18 @@ describe('trendsStateByUser', () => {
         type: actionTypes.FOCUS_TRENDS_CBG_SLICE,
         payload: { focusedKeys, sliceData: datum, slicePosition: position, userId: USER_1 },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: { data: datum, position },
-        focusedCbgSliceKeys: focusedKeys,
-        focusedSmbg: null,
-        focusedSmbgRangeAvg: null,
-        touched: true,
         cbgFlags: {
           cbg100Enabled: false,
           cbg80Enabled: true,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: { data: datum, position },
+        focusedCbgSliceKeys: focusedKeys,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -182,17 +189,18 @@ describe('trendsStateByUser', () => {
     it('should store focused datum and the datum\'s position', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -209,17 +217,18 @@ describe('trendsStateByUser', () => {
           userId: USER_1,
         },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: null,
-        focusedCbgSliceKeys: null,
-        focusedSmbg: { date, datum, position, allSmbgsOnDate, allPositions },
-        focusedSmbgRangeAvg: null,
-        touched: true,
         cbgFlags: {
           cbg100Enabled: false,
           cbg80Enabled: true,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: { date, datum, position, allSmbgsOnDate, allPositions },
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -229,17 +238,18 @@ describe('trendsStateByUser', () => {
     it('should store focused datum and the datum\'s position', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -247,17 +257,18 @@ describe('trendsStateByUser', () => {
         type: actionTypes.FOCUS_TRENDS_SMBG_RANGE_AVG,
         payload: { rangeAvgData: datum, rangeAvgPosition: position, userId: USER_1 },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: null,
-        focusedCbgSliceKeys: null,
-        focusedSmbg: null,
-        focusedSmbgRangeAvg: { data: datum, position },
-        touched: true,
         cbgFlags: {
           cbg100Enabled: false,
           cbg80Enabled: true,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: { data: datum, position },
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -267,17 +278,18 @@ describe('trendsStateByUser', () => {
     it('should reset to the initial state of {}', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: { datum, position },
-          focusedCbgSliceKeys: ['median'],
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: { datum, position },
+          focusedCbgSliceKeys: ['median'],
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -292,30 +304,32 @@ describe('trendsStateByUser', () => {
     it('should flip `touched` to true for the given user', () => {
       const initialState = {
         [USER_1]: {
+          cbgFlags: {
+            cbg100Enabled: false,
+            cbg80Enabled: true,
+            cbg50Enabled: true,
+            cbgMedianEnabled: true,
+          },
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: null,
           focusedSmbgRangeAvg: null,
           touched: true,
+        },
+        [USER_2]: {
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
-        },
-        [USER_2]: {
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: null,
           focusedSmbgRangeAvg: null,
           touched: false,
-          cbgFlags: {
-            cbg100Enabled: false,
-            cbg80Enabled: true,
-            cbg50Enabled: true,
-            cbgMedianEnabled: true,
-          },
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -324,31 +338,118 @@ describe('trendsStateByUser', () => {
         payload: { userId: USER_2 },
       })).to.deep.equal({
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
         [USER_2]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
+      });
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+  });
+
+  describe('STICK_CBG_DATE_TRACES', () => {
+    const dates = ['2017-01-01', '2017-01-05'];
+    it('should set dates as stuck', () => {
+      const initialState = {
+        [USER_1]: {
+          cbgFlags: {
+            cbg100Enabled: true,
+            cbg80Enabled: true,
+            cbg50Enabled: true,
+            cbgMedianEnabled: true,
+          },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
+        },
+      };
+      const tracked = mutationTracker.trackObj(initialState);
+      expect(trendsStateByUser(initialState, {
+        type: actionTypes.STICK_CBG_DATE_TRACES,
+        payload: { userId: USER_1, dates },
+      })[USER_1]).to.deep.equal({
+        cbgFlags: {
+          cbg100Enabled: true,
+          cbg80Enabled: true,
+          cbg50Enabled: true,
+          cbgMedianEnabled: true,
+        },
+        cbgStuckDateTraces: dates,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
+      });
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+
+    it('should merge new stuck dates with current', () => {
+      const newDates = ['2017-01-05', '2017-01-07', '2017-01-08'];
+      const initialState = {
+        [USER_1]: {
+          cbgFlags: {
+            cbg100Enabled: true,
+            cbg80Enabled: true,
+            cbg50Enabled: true,
+            cbgMedianEnabled: true,
+          },
+          cbgStuckDateTraces: dates,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
+        },
+      };
+      const tracked = mutationTracker.trackObj(initialState);
+      expect(trendsStateByUser(initialState, {
+        type: actionTypes.STICK_CBG_DATE_TRACES,
+        payload: { userId: USER_1, dates: newDates },
+      })[USER_1]).to.deep.equal({
+        cbgFlags: {
+          cbg100Enabled: true,
+          cbg80Enabled: true,
+          cbg50Enabled: true,
+          cbgMedianEnabled: true,
+        },
+        cbgStuckDateTraces: [
+          '2017-01-01',
+          '2017-01-05',
+          '2017-01-07',
+          '2017-01-08',
+        ],
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -358,17 +459,18 @@ describe('trendsStateByUser', () => {
     it('should reset the focusedCbgSlice and focusedCbgSliceKeys state to `null`', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: { datum, position },
-          focusedCbgSliceKeys: ['median'],
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: { datum, position },
+          focusedCbgSliceKeys: ['median'],
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -376,17 +478,18 @@ describe('trendsStateByUser', () => {
         type: actionTypes.UNFOCUS_TRENDS_CBG_SLICE,
         payload: { userId: USER_1 },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: null,
-        focusedCbgSliceKeys: null,
-        focusedSmbg: null,
-        focusedSmbgRangeAvg: null,
-        touched: true,
         cbgFlags: {
           cbg100Enabled: false,
           cbg80Enabled: true,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -395,6 +498,13 @@ describe('trendsStateByUser', () => {
     it('should reset the focusedSmbg state to `null`', () => {
       const initialState = {
         [USER_1]: {
+          cbgFlags: {
+            cbg100Enabled: false,
+            cbg80Enabled: true,
+            cbg50Enabled: true,
+            cbgMedianEnabled: true,
+          },
+          cbgStuckDateTraces: null,
           focusedCbgSlice: null,
           focusedCbgSliceKeys: null,
           focusedSmbg: { datum, position },
@@ -407,6 +517,13 @@ describe('trendsStateByUser', () => {
         type: actionTypes.UNFOCUS_TRENDS_SMBG,
         payload: { userId: USER_1 },
       })[USER_1]).to.deep.equal({
+        cbgFlags: {
+          cbg100Enabled: false,
+          cbg80Enabled: true,
+          cbg50Enabled: true,
+          cbgMedianEnabled: true,
+        },
+        cbgStuckDateTraces: null,
         focusedCbgSlice: null,
         focusedCbgSliceKeys: null,
         focusedSmbg: null,
@@ -420,17 +537,18 @@ describe('trendsStateByUser', () => {
     it('should reset the focusedSmbgRangeAvg state to `null`', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          focusedSmbg: null,
-          focusedSmbgRangeAvg: { datum, position },
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: { datum, position },
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -438,17 +556,58 @@ describe('trendsStateByUser', () => {
         type: actionTypes.UNFOCUS_TRENDS_SMBG_RANGE_AVG,
         payload: { userId: USER_1 },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: null,
-        focusedCbgSliceKeys: null,
-        focusedSmbg: null,
-        focusedSmbgRangeAvg: null,
-        touched: true,
         cbgFlags: {
           cbg100Enabled: false,
           cbg80Enabled: true,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
+      });
+      expect(mutationTracker.hasMutated(tracked)).to.be.false;
+    });
+  });
+
+  describe('UNSTICK_CBG_DATE_TRACES', () => {
+    it('should reset the `cbgStuckDateTraces` to `null`', () => {
+      const initialState = {
+        [USER_1]: {
+          cbgFlags: {
+            cbg100Enabled: true,
+            cbg80Enabled: true,
+            cbg50Enabled: true,
+            cbgMedianEnabled: true,
+          },
+          cbgStuckDateTraces: ['2017-01-01', '2017-01-05'],
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
+        },
+      };
+      const tracked = mutationTracker.trackObj(initialState);
+      expect(trendsStateByUser(initialState, {
+        type: actionTypes.UNSTICK_CBG_DATE_TRACES,
+        payload: { userId: USER_1 },
+      })[USER_1]).to.deep.equal({
+        cbgFlags: {
+          cbg100Enabled: true,
+          cbg80Enabled: true,
+          cbg50Enabled: true,
+          cbgMedianEnabled: true,
+        },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -458,15 +617,18 @@ describe('trendsStateByUser', () => {
     it('should set the specified cbgFlag to true', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -474,15 +636,18 @@ describe('trendsStateByUser', () => {
         type: actionTypes.TURN_ON_CBG_RANGE,
         payload: { userId: USER_1, range: '100' },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: null,
-        focusedCbgSliceKeys: null,
-        touched: true,
         cbgFlags: {
           cbg100Enabled: true,
           cbg80Enabled: true,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });
@@ -492,15 +657,18 @@ describe('trendsStateByUser', () => {
     it('should set the specified cbgFlag to false', () => {
       const initialState = {
         [USER_1]: {
-          focusedCbgSlice: null,
-          focusedCbgSliceKeys: null,
-          touched: true,
           cbgFlags: {
             cbg100Enabled: false,
             cbg80Enabled: true,
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
+          cbgStuckDateTraces: null,
+          focusedCbgSlice: null,
+          focusedCbgSliceKeys: null,
+          focusedSmbg: null,
+          focusedSmbgRangeAvg: null,
+          touched: true,
         },
       };
       const tracked = mutationTracker.trackObj(initialState);
@@ -508,15 +676,18 @@ describe('trendsStateByUser', () => {
         type: actionTypes.TURN_OFF_CBG_RANGE,
         payload: { userId: USER_1, range: '80' },
       })[USER_1]).to.deep.equal({
-        focusedCbgSlice: null,
-        focusedCbgSliceKeys: null,
-        touched: true,
         cbgFlags: {
           cbg100Enabled: false,
           cbg80Enabled: false,
           cbg50Enabled: true,
           cbgMedianEnabled: true,
         },
+        cbgStuckDateTraces: null,
+        focusedCbgSlice: null,
+        focusedCbgSliceKeys: null,
+        focusedSmbg: null,
+        focusedSmbgRangeAvg: null,
+        touched: true,
       });
       expect(mutationTracker.hasMutated(tracked)).to.be.false;
     });


### PR DESCRIPTION
This is the next feature add in the Trends work - allowing the user to "stick" the CGM sensor traces for the dates that intersect with a given slice segment so that they stay even when the user stops hovering on that segment. This way the user can build up a set of traces for comparison.

Clicking anywhere on the chart background "unsticks" all traces.

There will be another tiny PR on this with some alphabetization - I find it really useful to alphabetize the redux action creators and reducers, mainly so that going back and forth between the source and test files I can easily tell which things do & don't have tests.

Testing the click interaction on the SVG for unsticking was tough because we really need to use `mount` to test each code path fully but we can't because of the issues with `TransitionMotion` and full mount... Ideas welcome!