### PR TITLE
day to date renaming

### DIFF
--- a/src/components/trends/smbg/SMBGDateLineAnimated.js
+++ b/src/components/trends/smbg/SMBGDateLineAnimated.js
@@ -56,7 +56,7 @@ class SMBGDateLineAnimated extends Component {
     focusedDay: PropTypes.string.isRequired,
     focusLine: PropTypes.func.isRequired,
     grouped: PropTypes.bool.isRequired,
-    onSelectDay: PropTypes.func.isRequired,
+    onSelectDate: PropTypes.func.isRequired,
     nonInteractive: PropTypes.bool,
     tooltipLeftThreshold: PropTypes.number.isRequired,
     unfocusLine: PropTypes.func.isRequired,
@@ -135,7 +135,7 @@ class SMBGDateLineAnimated extends Component {
       date,
       focusedDay,
       focusLine,
-      onSelectDay,
+      onSelectDate,
       nonInteractive,
       tooltipLeftThreshold,
       unfocusLine,
@@ -177,7 +177,7 @@ class SMBGDateLineAnimated extends Component {
                 onMouseOver={() => { focusLine(data[0], positions[0], data, positions, date); }}
                 onMouseOut={() => { unfocusLine(); }}
                 onClick={() => {
-                  onSelectDay(date);
+                  onSelectDate(date);
                 }}
                 pointerEvents={nonInteractive ? 'none' : 'stroke'}
                 strokeOpacity={_.get(interpolated[0], ['style', 'opacity'])}

--- a/src/components/trends/smbg/SMBGDatePointsAnimated.js
+++ b/src/components/trends/smbg/SMBGDatePointsAnimated.js
@@ -45,7 +45,7 @@ class SMBGDatePointsAnimated extends Component {
     grouped: PropTypes.bool.isRequired,
     isFocused: PropTypes.bool.isRequired,
     nonInteractive: PropTypes.bool,
-    onSelectDay: PropTypes.func.isRequired,
+    onSelectDate: PropTypes.func.isRequired,
     smbgOpts: PropTypes.shape({
       maxR: PropTypes.number.isRequired,
       r: PropTypes.number.isRequired,
@@ -92,7 +92,7 @@ class SMBGDatePointsAnimated extends Component {
       grouped,
       isFocused,
       nonInteractive,
-      onSelectDay,
+      onSelectDate,
       smbgOpts,
       someSmbgDataIsFocused,
       tooltipLeftThreshold,
@@ -166,7 +166,7 @@ class SMBGDatePointsAnimated extends Component {
                       () => focusSmbg(smbg.data.smbg, smbg.data.position, data, positions, date)
                     }
                     onMouseOut={unfocusSmbg}
-                    onClick={() => onSelectDay(date)}
+                    onClick={() => onSelectDate(date)}
                     cx={style.cx}
                     cy={style.cy}
                     r={style.r}

--- a/src/containers/trends/SMBGsByDateContainer.js
+++ b/src/containers/trends/SMBGsByDateContainer.js
@@ -36,7 +36,7 @@ const SMBGsByDateContainer = (props) => {
     grouped,
     lines,
     nonInteractive,
-    onSelectDay,
+    onSelectDate,
     smbgOpts,
     someSmbgDataIsFocused,
     tooltipLeftThreshold,
@@ -67,7 +67,7 @@ const SMBGsByDateContainer = (props) => {
           focusLine={focusSmbg}
           grouped={grouped}
           key={date}
-          onSelectDay={onSelectDay}
+          onSelectDate={onSelectDate}
           nonInteractive={nonInteractive}
           tooltipLeftThreshold={tooltipLeftThreshold}
           unfocusLine={unfocusSmbg}
@@ -86,7 +86,7 @@ const SMBGsByDateContainer = (props) => {
           focusedDay={focusedDay}
           focusLine={focusSmbg}
           grouped={grouped}
-          onSelectDay={onSelectDay}
+          onSelectDate={onSelectDate}
           nonInteractive={nonInteractive}
           tooltipLeftThreshold={tooltipLeftThreshold}
           unfocusLine={unfocusSmbg}
@@ -110,7 +110,7 @@ const SMBGsByDateContainer = (props) => {
         isFocused={focusedDay === date}
         key={date}
         nonInteractive={nonInteractive}
-        onSelectDay={onSelectDay}
+        onSelectDate={onSelectDate}
         smbgOpts={smbgOpts}
         someSmbgDataIsFocused={someSmbgDataIsFocused}
         tooltipLeftThreshold={tooltipLeftThreshold}
@@ -166,7 +166,7 @@ SMBGsByDateContainer.propTypes = {
   grouped: PropTypes.bool.isRequired,
   lines: PropTypes.bool.isRequired,
   nonInteractive: PropTypes.bool,
-  onSelectDay: PropTypes.func.isRequired,
+  onSelectDate: PropTypes.func.isRequired,
   smbgOpts: PropTypes.shape({
     maxR: PropTypes.number.isRequired,
     r: PropTypes.number.isRequired,

--- a/src/containers/trends/TrendsContainer.js
+++ b/src/containers/trends/TrendsContainer.js
@@ -75,7 +75,7 @@ export class TrendsContainer extends React.Component {
     smbgByDayOfWeek: PropTypes.object.isRequired,
     // handlers
     onDatetimeLocationChange: PropTypes.func.isRequired,
-    onSelectDay: PropTypes.func.isRequired,
+    onSelectDate: PropTypes.func.isRequired,
     onSwitchBgDataSource: PropTypes.func.isRequired,
     // viz state
     trendsState: PropTypes.shape({
@@ -277,7 +277,7 @@ export class TrendsContainer extends React.Component {
   }
 
   selectDay() {
-    return (date) => this.props.onSelectDay(datetime.midDayForDate(date, this.props.timePrefs));
+    return (date) => this.props.onSelectDate(datetime.midDayForDate(date, this.props.timePrefs));
   }
 
   goBack() {
@@ -386,7 +386,7 @@ export class TrendsContainer extends React.Component {
         smbgGrouped={this.props.smbgGrouped}
         smbgLines={this.props.smbgLines}
         smbgRangeOverlay={this.props.smbgRangeOverlay}
-        onSelectDay={this.selectDay()}
+        onSelectDate={this.selectDay()}
         xScale={this.state.xScale}
         yScale={this.state.yScale}
         unfocusRange={this.props.unfocusTrendsSmbgRangeAvg}

--- a/src/containers/trends/TrendsSVGContainer.js
+++ b/src/containers/trends/TrendsSVGContainer.js
@@ -205,7 +205,7 @@ export class TrendsSVGContainer extends React.Component {
           grouped={this.props.smbgGrouped}
           key="smbgDaysContainer"
           lines={this.props.smbgLines}
-          onSelectDay={this.props.onSelectDay}
+          onSelectDate={this.props.onSelectDate}
           smbgOpts={this.props.smbgOpts}
           someSmbgDataIsFocused={this.props.focusedSmbg !== null}
           tooltipLeftThreshold={this.props.tooltipLeftThreshold}
@@ -229,7 +229,7 @@ export class TrendsSVGContainer extends React.Component {
           key="focusedSmbgDayContainer"
           lines={this.props.smbgLines}
           nonInteractive
-          onSelectDay={this.props.onSelectDay}
+          onSelectDate={this.props.onSelectDate}
           smbgOpts={this.props.smbgOpts}
           someSmbgDataIsFocused={false}
           tooltipLeftThreshold={this.props.tooltipLeftThreshold}
@@ -397,7 +397,7 @@ TrendsSVGContainer.propTypes = {
     bottom: PropTypes.number.isRequired,
     left: PropTypes.number.isRequired,
   }).isRequired,
-  onSelectDay: PropTypes.func.isRequired,
+  onSelectDate: PropTypes.func.isRequired,
   showingCbg: PropTypes.bool.isRequired,
   showingSmbg: PropTypes.bool.isRequired,
   smbgGrouped: PropTypes.bool.isRequired,

--- a/test/components/trends/smbg/SMBGDateLineAnimated.test.js
+++ b/test/components/trends/smbg/SMBGDateLineAnimated.test.js
@@ -37,7 +37,7 @@ describe('SMBGDateLineAnimated', () => {
   let wrapper;
   const focusLine = sinon.spy();
   const unfocusLine = sinon.spy();
-  const onSelectDay = sinon.spy();
+  const onSelectDate = sinon.spy();
   const grouped = true;
   const focusedDay = [];
   const date = '2016-08-14';
@@ -54,7 +54,7 @@ describe('SMBGDateLineAnimated', () => {
     focusedDay,
     focusLine,
     grouped,
-    onSelectDay,
+    onSelectDate,
     unfocusLine,
     xScale,
     yScale,
@@ -115,12 +115,12 @@ describe('SMBGDateLineAnimated', () => {
       expect(unfocusLine.callCount).to.equal(1);
     });
 
-    it('should call onSelectDay on click of smbg line', () => {
+    it('should call onSelectDate on click of smbg line', () => {
       const smbgDateLine = wrapper
         .find(`#smbgDateLine-${date} path`);
-      expect(onSelectDay.callCount).to.equal(0);
+      expect(onSelectDate.callCount).to.equal(0);
       smbgDateLine.simulate('click');
-      expect(onSelectDay.callCount).to.equal(1);
+      expect(onSelectDate.callCount).to.equal(1);
     });
   });
 });

--- a/test/components/trends/smbg/SMBGDatePointsAnimated.test.js
+++ b/test/components/trends/smbg/SMBGDatePointsAnimated.test.js
@@ -39,7 +39,7 @@ describe('SMBGDatePointsAnimated', () => {
   let wrapper;
   const focusSmbg = sinon.spy();
   const unfocusSmbg = sinon.spy();
-  const onSelectDay = sinon.spy();
+  const onSelectDate = sinon.spy();
   const grouped = true;
   const focusedDay = [];
   const date = '2016-08-14';
@@ -61,7 +61,7 @@ describe('SMBGDatePointsAnimated', () => {
     yScale,
     focusSmbg,
     unfocusSmbg,
-    onSelectDay,
+    onSelectDate,
     grouped,
     focusedDay,
     smbgOpts,
@@ -124,12 +124,12 @@ describe('SMBGDatePointsAnimated', () => {
       expect(unfocusSmbg.callCount).to.equal(1);
     });
 
-    it('should call onSelectDay on click of smbg circle', () => {
+    it('should call onSelectDate on click of smbg circle', () => {
       const smbgCircle = wrapper
         .find(`#smbg-${data[0].id}`);
-      expect(onSelectDay.callCount).to.equal(0);
+      expect(onSelectDate.callCount).to.equal(0);
       smbgCircle.simulate('click');
-      expect(onSelectDay.callCount).to.equal(1);
+      expect(onSelectDate.callCount).to.equal(1);
     });
   });
 });

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -126,7 +126,7 @@ describe('TrendsContainer', () => {
         [MMOLL_UNITS]: 25,
       },
       onDatetimeLocationChange,
-      onSelectDay: sinon.stub(),
+      onSelectDate: sinon.stub(),
       onSwitchBgDataSource,
       trendsState: {
         touched: false,

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -72,7 +72,7 @@ describe('TrendsSVGContainer', () => {
     focusRange: () => {},
     focusSlice: () => {},
     focusSmbg: () => {},
-    onSelectDay: () => {},
+    onSelectDate: () => {},
     showingCbg: true,
     showingSmbg: false,
     smbgGrouped: true,


### PR DESCRIPTION
Since I have to reorg a bunch of my work I was able to separate out this cleanup as a tiny PR. Just more consistency fixes to ensure we always use "date" to talk about a YYYY-MM-DD date of data, not "day" (which we use for Mon, Tues, etc.).

Another quickie for @hntrdglss or @krystophv 