### PR TITLE
Trends BGM changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.4.3-alpha",
+  "version": "0.4.6-alpha",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-react": "5.2.2",
     "gitbook-cli": "2.3.0",
     "json-loader": "0.5.4",
+    "jsx-ast-utils": "1.3.5",
     "karma": "1.2.0",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "2.0.0",

--- a/src/components/trends/cbg/CBGSliceAnimated.css
+++ b/src/components/trends/cbg/CBGSliceAnimated.css
@@ -52,7 +52,7 @@
   fill: transparent;
 }
 
-.rangeSegment:hover {
+.rangeSegment:hover, .rangeSegmentFaded:hover {
   opacity: 0;
 }
 
@@ -86,7 +86,7 @@
   animation: fadeOuterOut 0.25s forwards ease-in-out;
 }
 
-.outerSegment:hover {
+.outerSegment:hover, .outerSegmentFaded:hover {
   opacity: 0;
 }
 
@@ -120,6 +120,6 @@
   animation: fadeInnerOut 0.25s forwards ease-in-out;
 }
 
-.innerQuartilesSegment:hover {
+.innerQuartilesSegment:hover, .innerQuartilesSegmentFaded:hover {
   opacity: 0;
 }

--- a/src/components/trends/common/FocusedRangeLabels.js
+++ b/src/components/trends/common/FocusedRangeLabels.js
@@ -69,7 +69,11 @@ const FocusedRangeLabels = (props) => {
         />
       ) : null}
       <Tooltip
-        content={<span className={styles.number}>{displayBgValue(data[top], bgUnits)}</span>}
+        content={
+          <span className={styles.number}>
+            {displayBgValue(data[top], bgUnits, data.outOfRangeThresholds)}
+          </span>
+        }
         backgroundColor={'transparent'}
         borderColor={'transparent'}
         offset={{ left: 0, top: isCbg ? props.numberOffsets.top : 0 }}
@@ -82,7 +86,7 @@ const FocusedRangeLabels = (props) => {
           title={<span className={styles.explainerText}>{timeFrom} - {timeTo}</span>}
           content={
             <span className={styles.number}>
-              {`Average ${displayBgValue(data[center], bgUnits)}`}
+              {`Average ${displayBgValue(data[center], bgUnits, data.outOfRangeThresholds)}`}
             </span>
           }
           offset={{ top: 0, horizontal: props.numberOffsets.horizontal }}
@@ -91,7 +95,11 @@ const FocusedRangeLabels = (props) => {
         />
       )}
       <Tooltip
-        content={<span className={styles.number}>{displayBgValue(data[bottom], bgUnits)}</span>}
+        content={
+          <span className={styles.number}>
+            {displayBgValue(data[bottom], bgUnits, data.outOfRangeThresholds)}
+          </span>
+        }
         backgroundColor={'transparent'}
         borderColor={'transparent'}
         offset={{ left: 0, top: isCbg ? props.numberOffsets.bottom : 0 }}
@@ -105,9 +113,9 @@ const FocusedRangeLabels = (props) => {
 
 FocusedRangeLabels.defaultProps = {
   numberOffsets: {
-    bottom: -7.5,
+    bottom: -5,
     horizontal: 10,
-    top: 7.5,
+    top: 5,
   },
 };
 
@@ -132,6 +140,10 @@ FocusedRangeLabels.propTypes = {
       msX: PropTypes.number.isRequired,
       msFrom: PropTypes.number.isRequired,
       msTo: PropTypes.number.isRequired,
+      outOfRangeThresholds: PropTypes.shape({
+        low: PropTypes.number,
+        high: PropTypes.number,
+      }),
     }).isRequired,
     position: PropTypes.shape({
       left: PropTypes.number.isRequired,
@@ -154,6 +166,10 @@ FocusedRangeLabels.propTypes = {
       msTo: PropTypes.number.isRequired,
       msX: PropTypes.number.isRequired,
       ninetiethQuantile: PropTypes.number.isRequired,
+      outOfRangeThresholds: PropTypes.shape({
+        low: PropTypes.number,
+        high: PropTypes.number,
+      }),
       tenthQuantile: PropTypes.number.isRequired,
       thirdQuartile: PropTypes.number.isRequired,
     }).isRequired,

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -38,6 +38,14 @@ const FocusedSMBGPointLabel = (props) => {
     return null;
   }
 
+  function getOutOfRangeThreshold(smbg) {
+    const outOfRangeAnnotation = _.find(
+      smbg.annotations || [], (annotation) => (annotation.code === 'bg/out-of-range')
+    );
+    return outOfRangeAnnotation ?
+      { [outOfRangeAnnotation.value]: outOfRangeAnnotation.threshold } : null;
+  }
+
   const {
     bgUnits,
     focusedPoint: { datum, position, allSmbgsOnDate, allPositions },
@@ -57,7 +65,11 @@ const FocusedSMBGPointLabel = (props) => {
   const pointTooltips = _.map(allSmbgsOnDate, (smbg, i) => (
     <Tooltip
       key={i}
-      content={<span className={styles.number}>{displayBgValue(smbg.value, bgUnits)}</span>}
+      content={
+        <span className={styles.number}>
+          {displayBgValue(smbg.value, bgUnits, getOutOfRangeThreshold(smbg))}
+        </span>
+      }
       position={allPositions[i]}
       side={'bottom'}
       tail={false}
@@ -86,7 +98,9 @@ const FocusedSMBGPointLabel = (props) => {
         </span>
         }
         content={<span className={styles.tipWrapper}>
-          <span className={styles.detailNumber}>{displayBgValue(datum.value, bgUnits)}</span>
+          <span className={styles.detailNumber}>
+            {displayBgValue(datum.value, bgUnits, getOutOfRangeThreshold(datum))}
+          </span>
           <span className={styles.subType}>{categorizeSmbgSubtype(datum)}</span>
         </span>
         }

--- a/src/components/trends/smbg/SMBGMean.js
+++ b/src/components/trends/smbg/SMBGMean.js
@@ -21,11 +21,7 @@ import { bindActionCreators } from 'redux';
 
 import { focusTrendsSmbgRangeAvg, unfocusTrendsSmbgRangeAvg } from '../../../redux/actions/trends';
 
-export class SMBGRange extends PureComponent {
-  static defaultProps = {
-    rectWidth: 108,
-  };
-
+export class SMBGMean extends PureComponent {
   static propTypes = {
     classes: PropTypes.string.isRequired,
     datum: PropTypes.shape({
@@ -55,9 +51,10 @@ export class SMBGRange extends PureComponent {
         min: PropTypes.number.isRequired,
       }).isRequired,
     }),
-    rectWidth: PropTypes.number.isRequired,
     unfocusRange: PropTypes.func.isRequired,
     userId: PropTypes.string.isRequired,
+    width: PropTypes.number.isRequired,
+    x: PropTypes.number.isRequired,
   };
 
   constructor(props) {
@@ -78,16 +75,17 @@ export class SMBGRange extends PureComponent {
   }
 
   render() {
-    const { classes, interpolated: { key, style }, positionData, rectWidth } = this.props;
+    const { classes, interpolated: { key, style }, width, x } = this.props;
+
     return (
       <rect
         className={classes}
         id={`smbgRange-${key}`}
         onMouseOver={this.handleMouseOver}
         onMouseOut={this.handleMouseOut}
-        x={positionData.left - rectWidth / 2}
+        x={x}
         y={style.y}
-        width={rectWidth}
+        width={width}
         height={style.height}
         opacity={style.opacity}
       />
@@ -109,4 +107,4 @@ export function mapDispatchToProps(dispatch) {
   }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SMBGRange);
+export default connect(mapStateToProps, mapDispatchToProps)(SMBGMean);

--- a/src/components/trends/smbg/SMBGMeanAnimated.css
+++ b/src/components/trends/smbg/SMBGMeanAnimated.css
@@ -1,0 +1,90 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+:export {
+  stroke: 2;
+}
+
+.thickStroke {
+  stroke-width: 2;
+}
+
+.smbgMean {
+  stroke: white;
+  composes: thickStroke;
+  pointer-events: all;
+}
+
+.transparent {
+  fill: transparent;
+}
+
+@keyframes fadein {
+  from {
+    fill-opacity: 0.0;
+  }
+  to {
+    fill-opacity: 1.0;
+  }
+}
+
+@keyframes fadeout {
+  from {
+    fill-opacity: 1.0;
+  }
+  to {
+    fill-opacity: 0.0;
+  }
+}
+
+.fadeinAnimation {
+  animation: fadein 0.25s forwards ease-in-out;
+}
+
+.fadeoutAnimation {
+  animation: fadeout 0.25s forwards ease-in-out;
+}
+
+.lowFadeIn {
+  composes: bgLow from '../../../styles/diabetes.css';
+  composes: fadeinAnimation;
+}
+
+.lowFadeOut {
+  composes: bgLow from '../../../styles/diabetes.css';
+  composes: fadeoutAnimation;
+}
+
+.targetFadeIn {
+  composes: bgTarget from '../../../styles/diabetes.css';
+  composes: fadeinAnimation;
+}
+
+.targetFadeOut {
+  composes: bgTarget from '../../../styles/diabetes.css';
+  composes: fadeoutAnimation;
+}
+
+.highFadeIn {
+  composes: bgHigh from '../../../styles/diabetes.css';
+  composes: fadeinAnimation;
+}
+
+.highFadeOut {
+  composes: bgHigh from '../../../styles/diabetes.css';
+  composes: fadeoutAnimation;
+}

--- a/src/components/trends/smbg/SMBGRangeAnimated.css
+++ b/src/components/trends/smbg/SMBGRangeAnimated.css
@@ -15,8 +15,33 @@
  * == BSD2 LICENSE ==
  */
 
+@keyframes fadein {
+  from {
+    fill-opacity: 0.3;
+  }
+  to {
+    fill-opacity: 0.4;
+  }
+}
+
+@keyframes fadeout {
+  from {
+    fill-opacity: 0.4;
+  }
+  to {
+    fill-opacity: 0.3;
+  }
+}
+
 .smbgRange {
-  fill: transparent;
-  stroke: var(--trends--light);
-  stroke-width: 2px;
+  fill: var(--trends--light);
+  stroke: none;
+}
+
+.fadeIn {
+  animation: fadein 0.25s forwards ease-in-out;
+}
+
+.fadeOut {
+  animation: fadeout 0.25s forwards ease-in-out;
 }

--- a/src/containers/trends/CBGSlicesContainer.js
+++ b/src/containers/trends/CBGSlicesContainer.js
@@ -20,7 +20,9 @@ import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
 import { THIRTY_MINS, TWENTY_FOUR_HRS } from '../../utils/datetime';
-import { findBinForTimeOfDay, calculateCbgStatsForBin } from '../../utils/trends/data';
+import {
+  findBinForTimeOfDay, findOutOfRangeAnnotations, calculateCbgStatsForBin,
+} from '../../utils/trends/data';
 
 import CBGMedianAnimated from '../../components/trends/cbg/CBGMedianAnimated';
 import CBGSliceAnimated from '../../components/trends/cbg/CBGSliceAnimated';
@@ -78,6 +80,7 @@ export default class CBGSlicesContainer extends PureComponent {
 
   mungeData(binSize, data) {
     const binned = _.groupBy(data, (d) => (findBinForTimeOfDay(binSize, d.msPer24)));
+    const outOfRanges = findOutOfRangeAnnotations(data);
     // we need *all* possible keys for TransitionMotion to work on enter/exit
     // and the range starts with binSize/2 because the keys are centered in each bin
     const binKeys = _.map(range(binSize / 2, TWENTY_FOUR_HRS, binSize), (d) => String(d));
@@ -86,7 +89,7 @@ export default class CBGSlicesContainer extends PureComponent {
     const mungedData = [];
     for (let i = 0; i < binKeys.length; ++i) {
       const values = _.map(_.get(binned, binKeys[i], []), valueExtractor);
-      mungedData.push(calculateCbgStatsForBin(binKeys[i], binSize, values));
+      mungedData.push(calculateCbgStatsForBin(binKeys[i], binSize, values, outOfRanges));
     }
     return mungedData;
   }

--- a/src/containers/trends/SMBGRangeAvgContainer.js
+++ b/src/containers/trends/SMBGRangeAvgContainer.js
@@ -20,7 +20,9 @@ import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
 import { THREE_HRS, TWENTY_FOUR_HRS } from '../../utils/datetime';
-import { calculateSmbgStatsForBin, findBinForTimeOfDay } from '../../utils/trends/data';
+import {
+  findBinForTimeOfDay, findOutOfRangeAnnotations, calculateSmbgStatsForBin,
+} from '../../utils/trends/data';
 
 export default class SMBGRangeAvgContainer extends PureComponent {
   static propTypes = {
@@ -62,6 +64,7 @@ export default class SMBGRangeAvgContainer extends PureComponent {
 
   mungeData(binSize, data) {
     const binned = _.groupBy(data, (d) => (findBinForTimeOfDay(binSize, d.msPer24)));
+    const outOfRanges = findOutOfRangeAnnotations(data);
     // we need *all* possible keys for TransitionMotion to work on enter/exit
     // and the range starts with binSize/2 because the keys are centered in each bin
     const binKeys = _.map(range(binSize / 2, TWENTY_FOUR_HRS, binSize), (d) => String(d));
@@ -70,7 +73,7 @@ export default class SMBGRangeAvgContainer extends PureComponent {
     const mungedData = [];
     for (let i = 0; i < binKeys.length; ++i) {
       const values = _.map(binned[binKeys[i]], valueExtractor);
-      mungedData.push(calculateSmbgStatsForBin(binKeys[i], binSize, values));
+      mungedData.push(calculateSmbgStatsForBin(binKeys[i], binSize, values, outOfRanges));
     }
     return mungedData;
   }

--- a/src/containers/trends/TrendsContainer.js
+++ b/src/containers/trends/TrendsContainer.js
@@ -162,6 +162,9 @@ export class TrendsContainer extends PureComponent {
       }),
       touched: PropTypes.bool.isRequired,
     }).isRequired,
+    unfocusCbgSlice: PropTypes.func.isRequired,
+    unfocusSmbg: PropTypes.func.isRequired,
+    unfocusSmbgRangeAvg: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -241,6 +244,25 @@ export class TrendsContainer extends PureComponent {
         currentCbgData: cbgByDate.top(Infinity).reverse(),
         currentSmbgData: smbgByDate.top(Infinity).reverse(),
       });
+    }
+  }
+
+  componentWillUnmount() {
+    const {
+      currentPatientInViewId,
+      trendsState,
+      unfocusCbgSlice,
+      unfocusSmbg,
+      unfocusSmbgRangeAvg,
+    } = this.props;
+    if (_.get(trendsState, 'focusedCbgSlice') !== null) {
+      unfocusCbgSlice(currentPatientInViewId);
+    }
+    if (_.get(trendsState, 'focusedSmbg') !== null) {
+      unfocusSmbg(currentPatientInViewId);
+    }
+    if (_.get(trendsState, 'focusedSmbgRangeAvg') !== null) {
+      unfocusSmbgRangeAvg(currentPatientInViewId);
     }
   }
 
@@ -397,6 +419,9 @@ export function mapStateToProps(state, ownProps) {
 export function mapDispatchToProps(dispatch) {
   return bindActionCreators({
     markTrendsViewed: actions.markTrendsViewed,
+    unfocusCbgSlice: actions.unfocusTrendsCbgSlice,
+    unfocusSmbg: actions.unfocusTrendsSmbg,
+    unfocusSmbgRangeAvg: actions.unfocusTrendsSmbgRangeAvg,
   }, dispatch);
 }
 

--- a/src/containers/trends/TrendsSVGContainer.js
+++ b/src/containers/trends/TrendsSVGContainer.js
@@ -53,6 +53,7 @@ import FocusedCBGSliceSegment from '../../components/trends/cbg/FocusedCBGSliceS
 import SMBGsByDateContainer from './SMBGsByDateContainer';
 import SMBGRangeAvgContainer from './SMBGRangeAvgContainer';
 import SMBGRangeAnimated from '../../components/trends/smbg/SMBGRangeAnimated';
+import SMBGMeanAnimated from '../../components/trends/smbg/SMBGMeanAnimated';
 
 import NoData from '../../components/trends/common/NoData';
 import TargetRangeLines from '../../components/trends/common/TargetRangeLines';
@@ -248,6 +249,7 @@ export class TrendsSVGContainer extends PureComponent {
         <g id="smbgTrends">
         {this.renderOverlay(SMBGRangeAnimated, 'SMBGRangeContainer')}
         {allSmbgsByDate}
+        {this.renderOverlay(SMBGMeanAnimated, 'SMBGMeanContainer')}
         {focusedSmbgDate}
         </g>
       );

--- a/src/redux/reducers/trendsStateByUser.js
+++ b/src/redux/reducers/trendsStateByUser.js
@@ -168,6 +168,7 @@ const trendsStateByUser = (state = {}, action) => {
       return update(
         state,
         { [userId]: {
+          [FOCUSED_CBG_DATE_TRACE]: { $set: null },
           [FOCUSED_CBG_SLICE]: { $set: null },
           [FOCUSED_CBG_KEYS]: { $set: null },
           [SHOW_CBG_DATE_TRACES]: { $set: false },

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -23,9 +23,9 @@
   --table-stripe--dark: #ECECEC;
 
   --trends--light: #D0D0D0;
-  --trends--light--faded: #DBDBDB;
+  --trends--light--faded: #F0F0F0;
   --trends--dark: #BCBCBC;
-  --trends--dark--faded: #C7C7C7;
+  --trends--dark--faded: #E3E3E3;
 
   --axis-tick: #E7E7E7;
 

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -43,3 +43,13 @@ export function classifyBgValue(bgBounds, bgValue) {
   }
   return 'target';
 }
+
+/**
+ * convertToMmolL
+ * @param {Number} bgVal - blood glucose value in mg/dL
+ *
+ * @return {Number} convertedBgVal - blood glucose value in mmol/L, unrounded
+ */
+export function convertToMmolL(val) {
+  return (val / 18.01559);
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -15,6 +15,9 @@
  * == BSD2 LICENSE ==
  */
 
+export const BG_HIGH = 'High';
+export const BG_LOW = 'Low';
+
 const STIFFNESS = 180;
 const DAMPING = 40;
 const PRECISION = 0.1;

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -15,8 +15,10 @@
  * == BSD2 LICENSE ==
  */
 
+import _ from 'lodash';
 import { format } from 'd3-format';
-import { MMOLL_UNITS } from './constants';
+import { convertToMmolL } from './bloodglucose';
+import { BG_HIGH, BG_LOW, MMOLL_UNITS } from './constants';
 
 /**
  * displayDecimal
@@ -35,10 +37,29 @@ export function displayDecimal(val, places) {
  * displayBgValue
  * @param {Number} val - integer or float blood glucose value in either mg/dL or mmol/L
  * @param {String} units - 'mg/dL' or 'mmol/L'
+ * @param {Object} outOfRangeThresholds - specifies thresholds for `low` and `high` values
  *
  * @return {String} stringBgValue
  */
-export function displayBgValue(val, units) {
+export function displayBgValue(val, units, outOfRangeThresholds) {
+  if (!_.isEmpty(outOfRangeThresholds)) {
+    let lowThreshold = outOfRangeThresholds.low;
+    let highThreshold = outOfRangeThresholds.high;
+    if (units === MMOLL_UNITS) {
+      if (lowThreshold) {
+        lowThreshold = convertToMmolL(lowThreshold);
+      }
+      if (highThreshold) {
+        highThreshold = convertToMmolL(highThreshold);
+      }
+    }
+    if (lowThreshold && val < lowThreshold) {
+      return BG_LOW;
+    }
+    if (highThreshold && val > highThreshold) {
+      return BG_HIGH;
+    }
+  }
   if (units === MMOLL_UNITS) {
     return format('.1f')(val);
   }

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -21,6 +21,29 @@ import { max, mean, median, min, quantile } from 'd3-array';
 import { TWENTY_FOUR_HRS } from '../datetime';
 
 /**
+ * determineRangeBoundaries
+ * @param {Array} outOfRange - Array of out-of-range objects w/threshold and value
+ *
+ * @return {Object} highAndLowThresholds - Object with high and low keys
+ */
+export function determineRangeBoundaries(outOfRange) {
+  const lowThresholds = _.filter(outOfRange, { value: 'low' });
+  const highThresholds = _.filter(outOfRange, { value: 'high' });
+  const boundaries = {};
+  if (!_.isEmpty(lowThresholds)) {
+    // if there is data from multiple devices present with different thresholds
+    // we want to use the more conservative (= higher) threshold for lows
+    boundaries.low = max(lowThresholds, (d) => (d.threshold));
+  }
+  if (!_.isEmpty(highThresholds)) {
+    // if there is data from multiple devices present with different thresholds
+    // we want to use the more conservative (= lower) threshold for highs
+    boundaries.high = min(highThresholds, (d) => (d.threshold));
+  }
+  return boundaries;
+}
+
+/**
  * findBinForTimeOfDay
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Number} msPer24 - natural number milliseconds into a twenty-four hour day
@@ -63,17 +86,39 @@ export function findDatesIntersectingWithCbgSliceSegment(cbgData, focusedSlice, 
 }
 
 /**
+ * findOutOfRangeAnnotations
+ * @param {Array} data - Array of `cbg` or `smbg` events
+ *
+ * @return {Array} thresholds - Array of objects with unique `threshold`
+ *                              (and `value` of 'low' or 'high')
+ */
+export function findOutOfRangeAnnotations(data) {
+  const isOutOfRangeAnnotation = (annotation) => (annotation.code === 'bg/out-of-range');
+  const eventsAnnotatedAsOutOfRange = _.filter(
+    data,
+    (d) => (_.some(d.annotations || [], isOutOfRangeAnnotation))
+  );
+  const annotations = _.map(eventsAnnotatedAsOutOfRange, (d) => (_.pick(
+    _.find(d.annotations || [], isOutOfRangeAnnotation),
+    ['threshold', 'value'],
+  )));
+  // the numerical `threshold` is our determiner of uniqueness
+  return _.uniq(annotations, (d) => (d.threshold));
+}
+
+/**
  * calculateCbgStatsForBin
  * @param {String} binKey - String of natural number milliseconds bin
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Array} data - Array of cbg values in mg/dL or mmol/L
+ * @param {Array} outOfRange - Array of out-of-range objects w/threshold and value
  *
  * @return {Object} calculatedCbgStats
  */
-export function calculateCbgStatsForBin(binKey, binSize, data) {
+export function calculateCbgStatsForBin(binKey, binSize, data, outOfRange) {
   const sorted = _.sortBy(data, d => d);
   const centerOfBinMs = parseInt(binKey, 10);
-  return {
+  const stats = {
     id: binKey,
     min: min(sorted),
     tenthQuantile: quantile(sorted, 0.1),
@@ -86,6 +131,11 @@ export function calculateCbgStatsForBin(binKey, binSize, data) {
     msFrom: centerOfBinMs - (binSize / 2),
     msTo: centerOfBinMs + (binSize / 2),
   };
+  if (!_.isEmpty(outOfRange)) {
+    const thresholds = determineRangeBoundaries(outOfRange);
+    stats.outOfRangeThresholds = thresholds;
+  }
+  return stats;
 }
 
 /**
@@ -93,12 +143,13 @@ export function calculateCbgStatsForBin(binKey, binSize, data) {
  * @param {String} binKey - String of natural number milliseconds bin
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Array} data - Array of smbg values in mg/dL or mmol/L
+ * @param {Array} outOfRange - Array of out-of-range objects w/threshold and value
  *
  * @return {Object} calculatedSmbgStats
  */
-export function calculateSmbgStatsForBin(binKey, binSize, data) {
+export function calculateSmbgStatsForBin(binKey, binSize, data, outOfRange) {
   const centerOfBinMs = parseInt(binKey, 10);
-  return {
+  const stats = {
     id: binKey,
     min: min(data),
     mean: mean(data),
@@ -107,6 +158,11 @@ export function calculateSmbgStatsForBin(binKey, binSize, data) {
     msFrom: centerOfBinMs - (binSize / 2),
     msTo: centerOfBinMs + (binSize / 2),
   };
+  if (!_.isEmpty(outOfRange)) {
+    const thresholds = determineRangeBoundaries(outOfRange);
+    stats.outOfRangeThresholds = thresholds;
+  }
+  return stats;
 }
 
 /**

--- a/test/components/trends/smbg/SMBGMean.test.js
+++ b/test/components/trends/smbg/SMBGMean.test.js
@@ -1,0 +1,116 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import {
+  SMBGMean, mapDispatchToProps, mapStateToProps,
+} from '../../../../src/components/trends/smbg/SMBGMean';
+
+describe('SMBGMean', () => {
+  let wrapper;
+  const props = {
+    classes: 'foo bar baz',
+    datum: {
+      id: '5400000',
+      max: 521,
+      mean: 140,
+      min: 22,
+      msX: 5400000,
+    },
+    focusRange: sinon.spy(),
+    interpolated: {
+      key: '5400000',
+      style: {
+        height: 120,
+        opacity: 0.5,
+        width: 15,
+        x: 10,
+        y: 25,
+      },
+    },
+    positionData: {
+      left: 8,
+      tooltipLeft: false,
+      yPositions: {
+        max: 150,
+        mean: 80,
+        min: 25,
+      },
+    },
+    unfocusRange: sinon.spy(),
+    userId: 'a1b2c3',
+  };
+
+  before(() => {
+    wrapper = shallow(<SMBGMean {...props} />);
+  });
+
+  it('should render a single <rect>', () => {
+    expect(wrapper.find('rect').length).to.equal(1);
+  });
+
+  describe('interactions', () => {
+    afterEach(() => {
+      props.focusRange.reset();
+      props.unfocusRange.reset();
+    });
+
+    describe('onMouseOver', () => {
+      it('should fire the `focusRange` function', () => {
+        const rect = wrapper.find('rect');
+        expect(props.focusRange.callCount).to.equal(0);
+        rect.simulate('mouseover');
+        expect(props.focusRange.callCount).to.equal(1);
+        expect(props.focusRange.args[0][0]).to.equal(props.userId);
+        expect(props.focusRange.args[0][1]).to.deep.equal(props.datum);
+        expect(props.focusRange.args[0][2]).to.deep.equal(props.positionData);
+      });
+    });
+
+    describe('onMouseOut', () => {
+      it('should fire the `unfocusRange` function', () => {
+        const rect = wrapper.find('rect');
+        expect(props.unfocusRange.callCount).to.equal(0);
+        rect.simulate('mouseout');
+        expect(props.unfocusRange.callCount).to.equal(1);
+        expect(props.unfocusRange.args[0][0]).to.equal(props.userId);
+      });
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const state = {
+      blip: { currentPatientInViewId: 'a1b2c3' },
+    };
+
+    it('should map blip.currentPatientInViewId to `userId`', () => {
+      expect(mapStateToProps(state).userId).to.equal(state.blip.currentPatientInViewId);
+    });
+  });
+
+  describe('mapDispatchToProps', () => {
+    it('should return an object with a `focusRange` key', () => {
+      expect(mapDispatchToProps(sinon.stub())).to.have.property('focusRange');
+    });
+
+    it('should return an object with a `unfocusRange` key', () => {
+      expect(mapDispatchToProps(sinon.stub())).to.have.property('unfocusRange');
+    });
+  });
+});

--- a/test/components/trends/smbg/SMBGMeanAnimated.test.js
+++ b/test/components/trends/smbg/SMBGMeanAnimated.test.js
@@ -1,0 +1,96 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import _ from 'lodash';
+import React from 'react';
+import { TransitionMotion } from 'react-motion';
+
+import { shallow } from 'enzyme';
+
+import * as scales from '../../../helpers/scales';
+const {
+  trendsXScale: xScale,
+  trendsYScale: yScale,
+} = scales.trends;
+import bgBounds from '../../../helpers/bgBounds';
+
+import { THREE_HRS } from '../../../../src/utils/datetime';
+import { SMBGMeanAnimated } from '../../../../src/components/trends/smbg/SMBGMeanAnimated';
+
+describe('SMBGMeanAnimated', () => {
+  let wrapper;
+  const focus = sinon.spy();
+  const unfocus = sinon.spy();
+  const datum = {
+    id: '5400000',
+    max: 521,
+    mean: 140,
+    min: 22,
+    msX: 5400000,
+  };
+  const props = {
+    bgBounds,
+    datum,
+    defaultY: 100,
+    focus,
+    tooltipLeftThreshold: THREE_HRS * 6,
+    unfocus,
+    xScale,
+    yScale,
+  };
+
+  before(() => {
+    wrapper = shallow(<SMBGMeanAnimated {...props} />);
+  });
+
+  describe('when a datum (overlay data) is provided', () => {
+    it('should create an array of 1 `styles` to render on the TransitionMotion', () => {
+      const styles = wrapper.find(TransitionMotion).prop('styles');
+      expect(styles.length).to.equal(1);
+    });
+
+    it('should create `styles` for a <rect> vertically centered on the mean', () => {
+      const { datum: { mean }, meanHeight } = wrapper.instance().props;
+      const { style } = wrapper.find(TransitionMotion).prop('styles')[0];
+      expect(style.y.val)
+        .to.equal(yScale(mean) - meanHeight / 2);
+    });
+  });
+
+  describe('when datum with `undefined` statistics (i.e., gap in data)', () => {
+    let noDatumWrapper;
+    before(() => {
+      const noDatumProps = _.assign({}, props, {
+        datum: {
+          id: '5400000',
+          max: undefined,
+          mean: undefined,
+          min: undefined,
+          msX: 5400000,
+        },
+      });
+
+      noDatumWrapper = shallow(<SMBGMeanAnimated {...noDatumProps} />);
+    });
+
+    it('should create an array of 0 `styles` to render on the TransitionMotion', () => {
+      expect(noDatumWrapper.find(TransitionMotion).length).to.equal(1);
+      const styles = noDatumWrapper.find(TransitionMotion).prop('styles');
+      expect(styles.length).to.equal(0);
+    });
+  });
+});

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -98,6 +98,9 @@ describe('TrendsContainer', () => {
     const onDatetimeLocationChange = sinon.spy();
     const onSwitchBgDataSource = sinon.spy();
     const markTrendsViewed = sinon.spy();
+    const unfocusCbgSlice = sinon.spy();
+    const unfocusSmbg = sinon.spy();
+    const unfocusSmbgRangeAvg = sinon.spy();
 
     const props = {
       activeDays: {
@@ -138,6 +141,9 @@ describe('TrendsContainer', () => {
         },
       },
       markTrendsViewed,
+      unfocusCbgSlice,
+      unfocusSmbg,
+      unfocusSmbgRangeAvg,
     };
 
     const mgdl = {
@@ -301,6 +307,58 @@ describe('TrendsContainer', () => {
         expect(stateSpy.callCount).to.equal(0);
         instance.refilterByDayOfWeek.restore();
         instance.setState.restore();
+      });
+    });
+
+    describe('componentWillUnmount', () => {
+      let toBeUnmounted;
+
+      beforeEach(() => {
+        toBeUnmounted = mount(
+          <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum)} />
+        );
+      });
+
+      afterEach(() => {
+        unfocusCbgSlice.reset();
+        unfocusSmbg.reset();
+        unfocusSmbgRangeAvg.reset();
+      });
+
+      describe('when a cbg slice segment is focused', () => {
+        it('should fire unfocusCbgSlice', () => {
+          expect(unfocusCbgSlice.callCount).to.equal(0);
+          toBeUnmounted.setProps({ trendsState: _.assign(
+            {}, props.trendsState, { focusedCbgSlice: {} }
+          ) });
+          toBeUnmounted.unmount();
+          expect(unfocusCbgSlice.callCount).to.equal(1);
+          expect(unfocusCbgSlice.args[0][0]).to.equal(props.currentPatientInViewId);
+        });
+      });
+
+      describe('when an smbg is focused', () => {
+        it('should fire unfocusSmbg', () => {
+          expect(unfocusSmbg.callCount).to.equal(0);
+          toBeUnmounted.setProps({ trendsState: _.assign(
+            {}, props.trendsState, { focusedSmbg: {} }
+          ) });
+          toBeUnmounted.unmount();
+          expect(unfocusSmbg.callCount).to.equal(1);
+          expect(unfocusSmbg.args[0][0]).to.equal(props.currentPatientInViewId);
+        });
+      });
+
+      describe('when an smbg range+avg is focused', () => {
+        it('should fire unfocusSmbgRangeAvg', () => {
+          expect(unfocusSmbgRangeAvg.callCount).to.equal(0);
+          toBeUnmounted.setProps({ trendsState: _.assign(
+            {}, props.trendsState, { focusedSmbgRangeAvg: {} }
+          ) });
+          toBeUnmounted.unmount();
+          expect(unfocusSmbgRangeAvg.callCount).to.equal(1);
+          expect(unfocusSmbgRangeAvg.args[0][0]).to.equal(props.currentPatientInViewId);
+        });
       });
     });
 

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -318,23 +318,23 @@ describe('TrendsSVGContainer', () => {
       });
 
       describe('when smbgRangeOverlay is true', () => {
-        it('should render an SMBGRangeAvgContainer for range', () => {
+        it('should render an SMBGRangeAvgContainer each for range and mean', () => {
           const smbgRangeProps = _.assign(
             {}, props, { showingSmbg: true, smbgRangeOverlay: true }
           );
           const smbgRangeWrapper = shallow(<TrendsSVGContainer {...smbgRangeProps} />);
-          expect(smbgRangeWrapper.find(SMBGRangeAvgContainer)).to.have.length(1);
+          expect(smbgRangeWrapper.find(SMBGRangeAvgContainer)).to.have.length(2);
         });
       });
 
       describe('when smbgRangeOverlay is false', () => {
-        it('should render an SMBGRangeAvgContainer with empty data (to get exit animation)', () => {
+        it('should render SMBGRangeAvgContainers with empty data (to get exit animation)', () => {
           const smbgRangeProps = _.assign(
             {}, props, { showingSmbg: true, smbgRangeOverlay: false }
           );
           const smbgRangeWrapper = shallow(<TrendsSVGContainer {...smbgRangeProps} />);
           const rangeAvgContainer = smbgRangeWrapper.find(SMBGRangeAvgContainer);
-          expect(rangeAvgContainer).to.have.length(1);
+          expect(rangeAvgContainer).to.have.length(2);
           // eslint-disable-next-line lodash/prefer-lodash-method
           rangeAvgContainer.forEach((container) => {
             expect(container.prop('data')).to.deep.equal([]);
@@ -347,7 +347,7 @@ describe('TrendsSVGContainer', () => {
           const noCbgProps = _.assign({}, props, { showingCbg: false, showingSmbg: true });
           const noCbgWrapper = shallow(<TrendsSVGContainer {...noCbgProps} />);
           expect(noCbgWrapper.find(CBGSlicesContainer)).to.have.length(0);
-          expect(noCbgWrapper.find(SMBGRangeAvgContainer)).to.have.length(1);
+          expect(noCbgWrapper.find(SMBGRangeAvgContainer)).to.have.length(2);
         });
       });
 

--- a/test/redux/reducers/trendsStateByUser.test.js
+++ b/test/redux/reducers/trendsStateByUser.test.js
@@ -605,7 +605,7 @@ describe('trendsStateByUser', () => {
   });
 
   describe('UNFOCUS_TRENDS_CBG_SLICE', () => {
-    it('should reset focusedCbgSlice, focusedCbgSliceKeys, and showingCbgDateTraces', () => {
+    it('should reset all focusedCbg* props and showingCbgDateTraces', () => {
       const initialState = {
         [USER_1]: {
           cbgFlags: {
@@ -614,7 +614,7 @@ describe('trendsStateByUser', () => {
             cbg50Enabled: true,
             cbgMedianEnabled: true,
           },
-          focusedCbgDateTrace: null,
+          focusedCbgDateTrace: {},
           focusedCbgSlice: { datum, position },
           focusedCbgSliceKeys: ['median'],
           focusedSmbg: null,

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -100,4 +100,18 @@ describe('blood glucose utilities', () => {
       expect(bgUtils.classifyBgValue(bgBounds, 181)).to.equal('high');
     });
   });
+
+  describe('convertToMmolL', () => {
+    it('should be a function', () => {
+      assert.isFunction(bgUtils.convertToMmolL);
+    });
+
+    it('should return 2.2202991964182135 when given 40', () => {
+      expect(bgUtils.convertToMmolL(40)).to.equal(2.2202991964182135);
+    });
+
+    it('should return 22.202991964182132 when given 400', () => {
+      expect(bgUtils.convertToMmolL(400)).to.equal(22.202991964182132);
+    });
+  });
 });

--- a/test/utils/constants.test.js
+++ b/test/utils/constants.test.js
@@ -18,11 +18,24 @@
 import * as constants from '../../src/utils/constants';
 
 describe('constants', () => {
+  describe('BG_HIGH', () => {
+    it('should be High', () => {
+      expect(constants.BG_HIGH).to.equal('High');
+    });
+  });
+
+  describe('BG_LOW', () => {
+    it('should be Low', () => {
+      expect(constants.BG_LOW).to.equal('Low');
+    });
+  });
+
   describe('MMOLL_UNITS', () => {
     it('should be mmol/L', () => {
       expect(constants.MMOLL_UNITS).to.equal('mmol/L');
     });
   });
+
   describe('MGDL_UNITS', () => {
     it('should be mg/dL', () => {
       expect(constants.MGDL_UNITS).to.equal('mg/dL');

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -15,7 +15,7 @@
  * == BSD2 LICENSE ==
  */
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
+import { BG_HIGH, BG_LOW, MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
 
 import * as format from '../../src/utils/format';
 
@@ -24,42 +24,90 @@ describe('format', () => {
     it('should give no places when none specified', () => {
       expect(format.displayDecimal(9.3328)).to.equal('9');
     });
+
     it('should give no places when zero specified', () => {
       expect(format.displayDecimal(9.3328, 0)).to.equal('9');
     });
+
     it('should give the number of places when they are specified', () => {
       expect(format.displayDecimal(9.3328, 1)).to.equal('9.3');
     });
   });
+
   describe('displayBgValue', () => {
     it('should be a function', () => {
       assert.isFunction(format.displayBgValue);
     });
 
-    it('should return a String integer by default (no recogizable `units` provided)', () => {
-      expect(format.displayBgValue(120.5)).to.equal('121');
-      expect(format.displayBgValue(120.5, 'foo')).to.equal('121');
+    describe('no recogizable units provided', () => {
+      it('should return a String integer by default (no recogizable `units` provided)', () => {
+        expect(format.displayBgValue(120.5)).to.equal('121');
+        expect(format.displayBgValue(120.5, 'foo')).to.equal('121');
+      });
     });
 
-    it('should return a String integer if `units` are `mg/dL`', () => {
-      expect(format.displayBgValue(120.5, MGDL_UNITS)).to.equal('121');
+    describe('when units are `mg/dL`', () => {
+      it('should return a String integer', () => {
+        expect(format.displayBgValue(120.5, MGDL_UNITS)).to.equal('121');
+      });
+
+      it('should give no decimals', () => {
+        expect(format.displayBgValue(352, MGDL_UNITS)).to.equal('352');
+      });
+
+      it('should round', () => {
+        expect(format.displayBgValue(352.77, MGDL_UNITS)).to.equal('353');
+      });
+
+      describe('when `outOfRangeThresholds` provided', () => {
+        it('should return the String High if value over the high threshold', () => {
+          expect(format.displayBgValue(401, MGDL_UNITS, { high: 400 })).to.equal(BG_HIGH);
+        });
+
+        it('should return normal String integer if value NOT over the high threshold', () => {
+          expect(format.displayBgValue(399, MGDL_UNITS, { high: 400 })).to.equal('399');
+        });
+
+        it('should return the String Low if value under the low threshold', () => {
+          expect(format.displayBgValue(39, MGDL_UNITS, { low: 40 })).to.equal(BG_LOW);
+        });
+
+        it('should return normal String integer if value NOT under the low threshold', () => {
+          expect(format.displayBgValue(41, MGDL_UNITS, { low: 40 })).to.equal('41');
+        });
+      });
     });
 
-    it('should return a String number w/one decimal point precision (`units` are `mmol/L`)', () => {
-      expect(format.displayBgValue(6.6886513292098675, MMOLL_UNITS)).to.equal('6.7');
-    });
-    it('should give no decimals when mg/dl units', () => {
-      expect(format.displayBgValue(352, 'mg/dL')).to.equal('352');
-    });
-    it('should round when mg/dl units', () => {
-      expect(format.displayBgValue(352.77, 'mg/dL')).to.equal('353');
-    });
-    it('should give one decimal place when mmol/L', () => {
-      expect(format.displayBgValue(12.52, 'mmol/L')).to.equal('12.5');
-    });
+    describe('when units are `mmol/L`', () => {
+      it('should return a String number', () => {
+        expect(format.displayBgValue(6.6886513292098675, MMOLL_UNITS)).to.equal('6.7');
+      });
 
-    it('should round when mmol/L', () => {
-      expect(format.displayBgValue(12.77, 'mmol/L')).to.equal('12.8');
+      it('should give one decimal place', () => {
+        expect(format.displayBgValue(12.52, MMOLL_UNITS)).to.equal('12.5');
+      });
+
+      it('should round', () => {
+        expect(format.displayBgValue(12.77, MMOLL_UNITS)).to.equal('12.8');
+      });
+
+      describe('when `outOfRangeThresholds` provided', () => {
+        it('should return the String High if value over the high threshold', () => {
+          expect(format.displayBgValue(23.1, MMOLL_UNITS, { high: 400 })).to.equal(BG_HIGH);
+        });
+
+        it('should return normal String number if value NOT over the high threshold', () => {
+          expect(format.displayBgValue(22.0, MMOLL_UNITS, { high: 400 })).to.equal('22.0');
+        });
+
+        it('should return the String Low if value under the low threshold', () => {
+          expect(format.displayBgValue(2.1, MMOLL_UNITS, { low: 40 })).to.equal(BG_LOW);
+        });
+
+        it('should return normal String number if value NOT under the low threshold', () => {
+          expect(format.displayBgValue(3.36, MMOLL_UNITS, { low: 40 })).to.equal('3.4');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Replaces #52 with a clean change (specifying a working version for `jsx-ast-utils` in our package.json) for the build problem.

The companion to [blip #383](https://github.com/tidepool-org/blip/pull/383).

Various changes:
- bring back mean rectangle + tests
- same fades in & out on range rect and mean fill as on CGM side when indiv smbg(s) focused
- wider range box with new styling

I've stacked this on #51 for easy diffing.