### PR TITLE
handle display of out-of-range BGs on Trends

### DIFF
--- a/src/components/trends/common/FocusedRangeLabels.js
+++ b/src/components/trends/common/FocusedRangeLabels.js
@@ -69,7 +69,11 @@ const FocusedRangeLabels = (props) => {
         />
       ) : null}
       <Tooltip
-        content={<span className={styles.number}>{displayBgValue(data[top], bgUnits)}</span>}
+        content={
+          <span className={styles.number}>
+            {displayBgValue(data[top], bgUnits, data.outOfRangeThresholds)}
+          </span>
+        }
         backgroundColor={'transparent'}
         borderColor={'transparent'}
         offset={{ left: 0, top: isCbg ? props.numberOffsets.top : 0 }}
@@ -82,7 +86,7 @@ const FocusedRangeLabels = (props) => {
           title={<span className={styles.explainerText}>{timeFrom} - {timeTo}</span>}
           content={
             <span className={styles.number}>
-              {`Average ${displayBgValue(data[center], bgUnits)}`}
+              {`Average ${displayBgValue(data[center], bgUnits, data.outOfRangeThresholds)}`}
             </span>
           }
           offset={{ top: 0, horizontal: props.numberOffsets.horizontal }}
@@ -91,7 +95,11 @@ const FocusedRangeLabels = (props) => {
         />
       )}
       <Tooltip
-        content={<span className={styles.number}>{displayBgValue(data[bottom], bgUnits)}</span>}
+        content={
+          <span className={styles.number}>
+            {displayBgValue(data[bottom], bgUnits, data.outOfRangeThresholds)}
+          </span>
+        }
         backgroundColor={'transparent'}
         borderColor={'transparent'}
         offset={{ left: 0, top: isCbg ? props.numberOffsets.bottom : 0 }}
@@ -105,9 +113,9 @@ const FocusedRangeLabels = (props) => {
 
 FocusedRangeLabels.defaultProps = {
   numberOffsets: {
-    bottom: -7.5,
+    bottom: -5,
     horizontal: 10,
-    top: 7.5,
+    top: 5,
   },
 };
 
@@ -132,6 +140,10 @@ FocusedRangeLabels.propTypes = {
       msX: PropTypes.number.isRequired,
       msFrom: PropTypes.number.isRequired,
       msTo: PropTypes.number.isRequired,
+      outOfRangeThresholds: PropTypes.shape({
+        low: PropTypes.number,
+        high: PropTypes.number,
+      }),
     }).isRequired,
     position: PropTypes.shape({
       left: PropTypes.number.isRequired,
@@ -154,6 +166,10 @@ FocusedRangeLabels.propTypes = {
       msTo: PropTypes.number.isRequired,
       msX: PropTypes.number.isRequired,
       ninetiethQuantile: PropTypes.number.isRequired,
+      outOfRangeThresholds: PropTypes.shape({
+        low: PropTypes.number,
+        high: PropTypes.number,
+      }),
       tenthQuantile: PropTypes.number.isRequired,
       thirdQuartile: PropTypes.number.isRequired,
     }).isRequired,

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -38,6 +38,14 @@ const FocusedSMBGPointLabel = (props) => {
     return null;
   }
 
+  function getOutOfRangeThreshold(smbg) {
+    const outOfRangeAnnotation = _.find(
+      smbg.annotations || [], (annotation) => (annotation.code === 'bg/out-of-range')
+    );
+    return outOfRangeAnnotation ?
+      { [outOfRangeAnnotation.value]: outOfRangeAnnotation.threshold } : null;
+  }
+
   const {
     bgUnits,
     focusedPoint: { datum, position, allSmbgsOnDate, allPositions },
@@ -57,7 +65,11 @@ const FocusedSMBGPointLabel = (props) => {
   const pointTooltips = _.map(allSmbgsOnDate, (smbg, i) => (
     <Tooltip
       key={i}
-      content={<span className={styles.number}>{displayBgValue(smbg.value, bgUnits)}</span>}
+      content={
+        <span className={styles.number}>
+          {displayBgValue(smbg.value, bgUnits, getOutOfRangeThreshold(smbg))}
+        </span>
+      }
       position={allPositions[i]}
       side={'bottom'}
       tail={false}
@@ -86,7 +98,9 @@ const FocusedSMBGPointLabel = (props) => {
         </span>
         }
         content={<span className={styles.tipWrapper}>
-          <span className={styles.detailNumber}>{displayBgValue(datum.value, bgUnits)}</span>
+          <span className={styles.detailNumber}>
+            {displayBgValue(datum.value, bgUnits, getOutOfRangeThreshold(datum))}
+          </span>
           <span className={styles.subType}>{categorizeSmbgSubtype(datum)}</span>
         </span>
         }

--- a/src/containers/trends/CBGSlicesContainer.js
+++ b/src/containers/trends/CBGSlicesContainer.js
@@ -20,7 +20,9 @@ import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
 import { THIRTY_MINS, TWENTY_FOUR_HRS } from '../../utils/datetime';
-import { findBinForTimeOfDay, calculateCbgStatsForBin } from '../../utils/trends/data';
+import {
+  findBinForTimeOfDay, findOutOfRangeAnnotations, calculateCbgStatsForBin,
+} from '../../utils/trends/data';
 
 import CBGMedianAnimated from '../../components/trends/cbg/CBGMedianAnimated';
 import CBGSliceAnimated from '../../components/trends/cbg/CBGSliceAnimated';
@@ -78,6 +80,7 @@ export default class CBGSlicesContainer extends PureComponent {
 
   mungeData(binSize, data) {
     const binned = _.groupBy(data, (d) => (findBinForTimeOfDay(binSize, d.msPer24)));
+    const outOfRanges = findOutOfRangeAnnotations(data);
     // we need *all* possible keys for TransitionMotion to work on enter/exit
     // and the range starts with binSize/2 because the keys are centered in each bin
     const binKeys = _.map(range(binSize / 2, TWENTY_FOUR_HRS, binSize), (d) => String(d));
@@ -86,7 +89,7 @@ export default class CBGSlicesContainer extends PureComponent {
     const mungedData = [];
     for (let i = 0; i < binKeys.length; ++i) {
       const values = _.map(_.get(binned, binKeys[i], []), valueExtractor);
-      mungedData.push(calculateCbgStatsForBin(binKeys[i], binSize, values));
+      mungedData.push(calculateCbgStatsForBin(binKeys[i], binSize, values, outOfRanges));
     }
     return mungedData;
   }

--- a/src/containers/trends/SMBGRangeAvgContainer.js
+++ b/src/containers/trends/SMBGRangeAvgContainer.js
@@ -20,7 +20,9 @@ import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
 import { THREE_HRS, TWENTY_FOUR_HRS } from '../../utils/datetime';
-import { calculateSmbgStatsForBin, findBinForTimeOfDay } from '../../utils/trends/data';
+import {
+  findBinForTimeOfDay, findOutOfRangeAnnotations, calculateSmbgStatsForBin,
+} from '../../utils/trends/data';
 
 export default class SMBGRangeAvgContainer extends PureComponent {
   static propTypes = {
@@ -62,6 +64,7 @@ export default class SMBGRangeAvgContainer extends PureComponent {
 
   mungeData(binSize, data) {
     const binned = _.groupBy(data, (d) => (findBinForTimeOfDay(binSize, d.msPer24)));
+    const outOfRanges = findOutOfRangeAnnotations(data);
     // we need *all* possible keys for TransitionMotion to work on enter/exit
     // and the range starts with binSize/2 because the keys are centered in each bin
     const binKeys = _.map(range(binSize / 2, TWENTY_FOUR_HRS, binSize), (d) => String(d));
@@ -70,7 +73,7 @@ export default class SMBGRangeAvgContainer extends PureComponent {
     const mungedData = [];
     for (let i = 0; i < binKeys.length; ++i) {
       const values = _.map(binned[binKeys[i]], valueExtractor);
-      mungedData.push(calculateSmbgStatsForBin(binKeys[i], binSize, values));
+      mungedData.push(calculateSmbgStatsForBin(binKeys[i], binSize, values, outOfRanges));
     }
     return mungedData;
   }

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -43,3 +43,13 @@ export function classifyBgValue(bgBounds, bgValue) {
   }
   return 'target';
 }
+
+/**
+ * convertToMmolL
+ * @param {Number} bgVal - blood glucose value in mg/dL
+ *
+ * @return {Number} convertedBgVal - blood glucose value in mmol/L, unrounded
+ */
+export function convertToMmolL(val) {
+  return (val / 18.01559);
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -15,6 +15,9 @@
  * == BSD2 LICENSE ==
  */
 
+export const BG_HIGH = 'High';
+export const BG_LOW = 'Low';
+
 const STIFFNESS = 180;
 const DAMPING = 40;
 const PRECISION = 0.1;

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -15,8 +15,10 @@
  * == BSD2 LICENSE ==
  */
 
+import _ from 'lodash';
 import { format } from 'd3-format';
-import { MMOLL_UNITS } from './constants';
+import { convertToMmolL } from './bloodglucose';
+import { BG_HIGH, BG_LOW, MMOLL_UNITS } from './constants';
 
 /**
  * displayDecimal
@@ -35,10 +37,29 @@ export function displayDecimal(val, places) {
  * displayBgValue
  * @param {Number} val - integer or float blood glucose value in either mg/dL or mmol/L
  * @param {String} units - 'mg/dL' or 'mmol/L'
+ * @param {Object} outOfRangeThresholds - specifies thresholds for `low` and `high` values
  *
  * @return {String} stringBgValue
  */
-export function displayBgValue(val, units) {
+export function displayBgValue(val, units, outOfRangeThresholds) {
+  if (!_.isEmpty(outOfRangeThresholds)) {
+    let lowThreshold = outOfRangeThresholds.low;
+    let highThreshold = outOfRangeThresholds.high;
+    if (units === MMOLL_UNITS) {
+      if (lowThreshold) {
+        lowThreshold = convertToMmolL(lowThreshold);
+      }
+      if (highThreshold) {
+        highThreshold = convertToMmolL(highThreshold);
+      }
+    }
+    if (lowThreshold && val < lowThreshold) {
+      return BG_LOW;
+    }
+    if (highThreshold && val > highThreshold) {
+      return BG_HIGH;
+    }
+  }
   if (units === MMOLL_UNITS) {
     return format('.1f')(val);
   }

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -111,13 +111,14 @@ export function findOutOfRangeAnnotations(data) {
  * @param {String} binKey - String of natural number milliseconds bin
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Array} data - Array of cbg values in mg/dL or mmol/L
+ * @param {Array} outOfRange - Array of out-of-range objects w/threshold and value
  *
  * @return {Object} calculatedCbgStats
  */
-export function calculateCbgStatsForBin(binKey, binSize, data) {
+export function calculateCbgStatsForBin(binKey, binSize, data, outOfRange) {
   const sorted = _.sortBy(data, d => d);
   const centerOfBinMs = parseInt(binKey, 10);
-  return {
+  const stats = {
     id: binKey,
     min: min(sorted),
     tenthQuantile: quantile(sorted, 0.1),
@@ -130,6 +131,11 @@ export function calculateCbgStatsForBin(binKey, binSize, data) {
     msFrom: centerOfBinMs - (binSize / 2),
     msTo: centerOfBinMs + (binSize / 2),
   };
+  if (!_.isEmpty(outOfRange)) {
+    const thresholds = determineRangeBoundaries(outOfRange);
+    stats.outOfRangeThresholds = thresholds;
+  }
+  return stats;
 }
 
 /**
@@ -137,12 +143,13 @@ export function calculateCbgStatsForBin(binKey, binSize, data) {
  * @param {String} binKey - String of natural number milliseconds bin
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Array} data - Array of smbg values in mg/dL or mmol/L
+ * @param {Array} outOfRange - Array of out-of-range objects w/threshold and value
  *
  * @return {Object} calculatedSmbgStats
  */
-export function calculateSmbgStatsForBin(binKey, binSize, data) {
+export function calculateSmbgStatsForBin(binKey, binSize, data, outOfRange) {
   const centerOfBinMs = parseInt(binKey, 10);
-  return {
+  const stats = {
     id: binKey,
     min: min(data),
     mean: mean(data),
@@ -151,6 +158,11 @@ export function calculateSmbgStatsForBin(binKey, binSize, data) {
     msFrom: centerOfBinMs - (binSize / 2),
     msTo: centerOfBinMs + (binSize / 2),
   };
+  if (!_.isEmpty(outOfRange)) {
+    const thresholds = determineRangeBoundaries(outOfRange);
+    stats.outOfRangeThresholds = thresholds;
+  }
+  return stats;
 }
 
 /**

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -86,6 +86,27 @@ export function findDatesIntersectingWithCbgSliceSegment(cbgData, focusedSlice, 
 }
 
 /**
+ * findOutOfRangeAnnotations
+ * @param {Array} data - Array of `cbg` or `smbg` events
+ *
+ * @return {Array} thresholds - Array of objects with unique `threshold`
+ *                              (and `value` of 'low' or 'high')
+ */
+export function findOutOfRangeAnnotations(data) {
+  const isOutOfRangeAnnotation = (annotation) => (annotation.code === 'bg/out-of-range');
+  const eventsAnnotatedAsOutOfRange = _.filter(
+    data,
+    (d) => (_.some(d.annotations || [], isOutOfRangeAnnotation))
+  );
+  const annotations = _.map(eventsAnnotatedAsOutOfRange, (d) => (_.pick(
+    _.find(d.annotations || [], isOutOfRangeAnnotation),
+    ['threshold', 'value'],
+  )));
+  // the numerical `threshold` is our determiner of uniqueness
+  return _.uniq(annotations, (d) => (d.threshold));
+}
+
+/**
  * calculateCbgStatsForBin
  * @param {String} binKey - String of natural number milliseconds bin
  * @param {Number} binSize - natural number duration in milliseconds

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -21,6 +21,29 @@ import { max, mean, median, min, quantile } from 'd3-array';
 import { TWENTY_FOUR_HRS } from '../datetime';
 
 /**
+ * determineRangeBoundaries
+ * @param {Array} outOfRange - Array of out-of-range objects w/threshold and value
+ *
+ * @return {Object} highAndLowThresholds - Object with high and low keys
+ */
+export function determineRangeBoundaries(outOfRange) {
+  const lowThresholds = _.filter(outOfRange, { value: 'low' });
+  const highThresholds = _.filter(outOfRange, { value: 'high' });
+  const boundaries = {};
+  if (!_.isEmpty(lowThresholds)) {
+    // if there is data from multiple devices present with different thresholds
+    // we want to use the more conservative (= higher) threshold for lows
+    boundaries.low = max(lowThresholds, (d) => (d.threshold));
+  }
+  if (!_.isEmpty(highThresholds)) {
+    // if there is data from multiple devices present with different thresholds
+    // we want to use the more conservative (= lower) threshold for highs
+    boundaries.high = min(highThresholds, (d) => (d.threshold));
+  }
+  return boundaries;
+}
+
+/**
  * findBinForTimeOfDay
  * @param {Number} binSize - natural number duration in milliseconds
  * @param {Number} msPer24 - natural number milliseconds into a twenty-four hour day

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -100,4 +100,18 @@ describe('blood glucose utilities', () => {
       expect(bgUtils.classifyBgValue(bgBounds, 181)).to.equal('high');
     });
   });
+
+  describe('convertToMmolL', () => {
+    it('should be a function', () => {
+      assert.isFunction(bgUtils.convertToMmolL);
+    });
+
+    it('should return 2.2202991964182135 when given 40', () => {
+      expect(bgUtils.convertToMmolL(40)).to.equal(2.2202991964182135);
+    });
+
+    it('should return 22.202991964182132 when given 400', () => {
+      expect(bgUtils.convertToMmolL(400)).to.equal(22.202991964182132);
+    });
+  });
 });

--- a/test/utils/constants.test.js
+++ b/test/utils/constants.test.js
@@ -18,11 +18,24 @@
 import * as constants from '../../src/utils/constants';
 
 describe('constants', () => {
+  describe('BG_HIGH', () => {
+    it('should be High', () => {
+      expect(constants.BG_HIGH).to.equal('High');
+    });
+  });
+
+  describe('BG_LOW', () => {
+    it('should be Low', () => {
+      expect(constants.BG_LOW).to.equal('Low');
+    });
+  });
+
   describe('MMOLL_UNITS', () => {
     it('should be mmol/L', () => {
       expect(constants.MMOLL_UNITS).to.equal('mmol/L');
     });
   });
+
   describe('MGDL_UNITS', () => {
     it('should be mg/dL', () => {
       expect(constants.MGDL_UNITS).to.equal('mg/dL');

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -15,7 +15,7 @@
  * == BSD2 LICENSE ==
  */
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
+import { BG_HIGH, BG_LOW, MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
 
 import * as format from '../../src/utils/format';
 
@@ -24,42 +24,90 @@ describe('format', () => {
     it('should give no places when none specified', () => {
       expect(format.displayDecimal(9.3328)).to.equal('9');
     });
+
     it('should give no places when zero specified', () => {
       expect(format.displayDecimal(9.3328, 0)).to.equal('9');
     });
+
     it('should give the number of places when they are specified', () => {
       expect(format.displayDecimal(9.3328, 1)).to.equal('9.3');
     });
   });
+
   describe('displayBgValue', () => {
     it('should be a function', () => {
       assert.isFunction(format.displayBgValue);
     });
 
-    it('should return a String integer by default (no recogizable `units` provided)', () => {
-      expect(format.displayBgValue(120.5)).to.equal('121');
-      expect(format.displayBgValue(120.5, 'foo')).to.equal('121');
+    describe('no recogizable units provided', () => {
+      it('should return a String integer by default (no recogizable `units` provided)', () => {
+        expect(format.displayBgValue(120.5)).to.equal('121');
+        expect(format.displayBgValue(120.5, 'foo')).to.equal('121');
+      });
     });
 
-    it('should return a String integer if `units` are `mg/dL`', () => {
-      expect(format.displayBgValue(120.5, MGDL_UNITS)).to.equal('121');
+    describe('when units are `mg/dL`', () => {
+      it('should return a String integer', () => {
+        expect(format.displayBgValue(120.5, MGDL_UNITS)).to.equal('121');
+      });
+
+      it('should give no decimals', () => {
+        expect(format.displayBgValue(352, MGDL_UNITS)).to.equal('352');
+      });
+
+      it('should round', () => {
+        expect(format.displayBgValue(352.77, MGDL_UNITS)).to.equal('353');
+      });
+
+      describe('when `outOfRangeThresholds` provided', () => {
+        it('should return the String High if value over the high threshold', () => {
+          expect(format.displayBgValue(401, MGDL_UNITS, { high: 400 })).to.equal(BG_HIGH);
+        });
+
+        it('should return normal String integer if value NOT over the high threshold', () => {
+          expect(format.displayBgValue(399, MGDL_UNITS, { high: 400 })).to.equal('399');
+        });
+
+        it('should return the String Low if value under the low threshold', () => {
+          expect(format.displayBgValue(39, MGDL_UNITS, { low: 40 })).to.equal(BG_LOW);
+        });
+
+        it('should return normal String integer if value NOT under the low threshold', () => {
+          expect(format.displayBgValue(41, MGDL_UNITS, { low: 40 })).to.equal('41');
+        });
+      });
     });
 
-    it('should return a String number w/one decimal point precision (`units` are `mmol/L`)', () => {
-      expect(format.displayBgValue(6.6886513292098675, MMOLL_UNITS)).to.equal('6.7');
-    });
-    it('should give no decimals when mg/dl units', () => {
-      expect(format.displayBgValue(352, 'mg/dL')).to.equal('352');
-    });
-    it('should round when mg/dl units', () => {
-      expect(format.displayBgValue(352.77, 'mg/dL')).to.equal('353');
-    });
-    it('should give one decimal place when mmol/L', () => {
-      expect(format.displayBgValue(12.52, 'mmol/L')).to.equal('12.5');
-    });
+    describe('when units are `mmol/L`', () => {
+      it('should return a String number', () => {
+        expect(format.displayBgValue(6.6886513292098675, MMOLL_UNITS)).to.equal('6.7');
+      });
 
-    it('should round when mmol/L', () => {
-      expect(format.displayBgValue(12.77, 'mmol/L')).to.equal('12.8');
+      it('should give one decimal place', () => {
+        expect(format.displayBgValue(12.52, MMOLL_UNITS)).to.equal('12.5');
+      });
+
+      it('should round', () => {
+        expect(format.displayBgValue(12.77, MMOLL_UNITS)).to.equal('12.8');
+      });
+
+      describe('when `outOfRangeThresholds` provided', () => {
+        it('should return the String High if value over the high threshold', () => {
+          expect(format.displayBgValue(23.1, MMOLL_UNITS, { high: 400 })).to.equal(BG_HIGH);
+        });
+
+        it('should return normal String number if value NOT over the high threshold', () => {
+          expect(format.displayBgValue(22.0, MMOLL_UNITS, { high: 400 })).to.equal('22.0');
+        });
+
+        it('should return the String Low if value under the low threshold', () => {
+          expect(format.displayBgValue(2.1, MMOLL_UNITS, { low: 40 })).to.equal(BG_LOW);
+        });
+
+        it('should return normal String number if value NOT under the low threshold', () => {
+          expect(format.displayBgValue(3.36, MMOLL_UNITS, { low: 40 })).to.equal('3.4');
+        });
+      });
     });
   });
 });

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -314,6 +314,30 @@ describe('[trends] data utils', () => {
     it('should add a `msTo` to the resulting object half a bin later', () => {
       expect(res.msTo).to.equal(1800000);
     });
+
+    describe('when an array of out-of-range annotations is provided', () => {
+      const outOfRange = [{
+        value: 'low',
+        threshold: 25,
+      }, {
+        value: 'low',
+        threshold: 40,
+      }, {
+        value: 'high',
+        threshold: 500,
+      }, {
+        value: 'high',
+        threshold: 400,
+      }];
+      const resWithOutOfRange = utils.calculateCbgStatsForBin(binKey, binSize, data, outOfRange);
+
+      it('should add `outOfRangeThresholds` to the resulting object', () => {
+        expect(resWithOutOfRange.outOfRangeThresholds).to.deep.equal({
+          low: 40,
+          high: 400,
+        });
+      });
+    });
   });
 
   describe('calculateSmbgStatsForBin', () => {
@@ -363,6 +387,30 @@ describe('[trends] data utils', () => {
 
     it('should add the bin as `msX` on the resulting object', () => {
       expect(res.msX).to.equal(bin);
+    });
+
+    describe('when an array of out-of-range annotations is provided', () => {
+      const outOfRange = [{
+        value: 'low',
+        threshold: 25,
+      }, {
+        value: 'low',
+        threshold: 40,
+      }, {
+        value: 'high',
+        threshold: 500,
+      }, {
+        value: 'high',
+        threshold: 400,
+      }];
+      const resWithOutOfRange = utils.calculateSmbgStatsForBin(binKey, binSize, data, outOfRange);
+
+      it('should add `outOfRangeThresholds` to the resulting object', () => {
+        expect(resWithOutOfRange.outOfRangeThresholds).to.deep.equal({
+          low: 40,
+          high: 400,
+        });
+      });
     });
   });
 

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -20,6 +20,51 @@ import { range, shuffle } from 'd3-array';
 import * as utils from '../../../src/utils/trends/data';
 
 describe('[trends] data utils', () => {
+  describe('determineRangeBoundaries', () => {
+    it('should be a function', () => {
+      assert.isFunction(utils.determineRangeBoundaries);
+    });
+
+    it('should return the max of all provided `low` thresholds', () => {
+      expect(utils.determineRangeBoundaries([{
+        value: 'low',
+        threshold: 20,
+      }, {
+        value: 'low',
+        threshold: 25,
+      }, {
+        value: 'low',
+        threshold: 15,
+      }])).to.deep.equal({ low: 25 });
+    });
+
+    it('should return the min of all provided `high` thresholds', () => {
+      expect(utils.determineRangeBoundaries([{
+        value: 'high',
+        threshold: 650,
+      }, {
+        value: 'high',
+        threshold: 500,
+      }, {
+        value: 'high',
+        threshold: 600,
+      }])).to.deep.equal({ high: 500 });
+    });
+
+    it('should return both boundaries when a mix of out-of-range objects is provided', () => {
+      expect(utils.determineRangeBoundaries([{
+        value: 'high',
+        threshold: 500,
+      }, {
+        value: 'low',
+        threshold: 20,
+      }, {
+        value: 'low',
+        threshold: 40,
+      }])).to.deep.equal({ low: 40, high: 500 });
+    });
+  });
+
   describe('findBinForTimeOfDay', () => {
     it('should be a function', () => {
       assert.isFunction(utils.findBinForTimeOfDay);

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -197,6 +197,47 @@ describe('[trends] data utils', () => {
     });
   });
 
+  describe('findOutOfRangeAnnotations', () => {
+    it('should be a function', () => {
+      assert.isFunction(utils.findOutOfRangeAnnotations);
+    });
+
+    it('should return an empty array if none of the data is annotated `bg/out-of-range`', () => {
+      expect(utils.findOutOfRangeAnnotations([])).to.deep.equal([]);
+      expect(utils.findOutOfRangeAnnotations([{}, {}, {}])).to.deep.equal([]);
+      expect(utils.findOutOfRangeAnnotations([{}, { annotations: [{ code: 'foo' }] }]))
+        .to.deep.equal([]);
+    });
+
+    it('should return an array of the annotations w/unique thresholds', () => {
+      expect(utils.findOutOfRangeAnnotations([{
+        annotations: [{
+          code: 'bg/out-of-range',
+          value: 'high',
+          threshold: 500,
+        }],
+      }, {
+        annotations: [{
+          code: 'bg/out-of-range',
+          value: 'low',
+          threshold: 25,
+        }],
+      }, {
+        annotations: [{
+          code: 'bg/out-of-range',
+          value: 'high',
+          threshold: 500,
+        }],
+      }])).to.deep.equal([{
+        value: 'high',
+        threshold: 500,
+      }, {
+        value: 'low',
+        threshold: 25,
+      }]);
+    });
+  });
+
   describe('calculateCbgStatsForBin', () => {
     const bin = 900000;
     const binKey = bin.toString();


### PR DESCRIPTION
This change set is more complex than I anticipated. Would be interested in feedback to simplify it, but I'm not sure that's possible.

The root of the problem is that we were showing things like this in Trends, surfacing a fake 39 value (really Low Dexcom data):
<img width="178" alt="screenshot 2017-02-08 19 56 05" src="https://cloud.githubusercontent.com/assets/1588547/22768700/a5dc9592-ee38-11e6-87ca-addd4dd6aa2d.png">

Just as we do in e.g., the Daily view, this should show with 'Low' instead:
<img width="93" alt="screenshot 2017-02-08 19 56 44" src="https://cloud.githubusercontent.com/assets/1588547/22768715/c0968578-ee38-11e6-8682-ad347fe29f8a.png">
(We use the two-letter abbreviations 'Lo' and 'Hi' due to size constraints in the round tooltips on Daily view but will be phasing that out.)

The complication comes in with the fact that on Trends where we are showing *aggregate* data and not surfacing values from individual data points, we may have data from more than one device present (especially on the BGM side) and different devices have different out-of-range value thresholds.

So the general approach here is to:
1. find all the `bg/out-of-range` annotations in the data in view
2. determine the most conservative `low` and `high` thresholds from the annotation data
3. display 'Low' or 'High' as appropriate based on our calculated combined thresholds

@darinkrauss ran a query to confirm that in our current production data, *all* of our `bg/out-of-range` annotations (which have the form e.g., `{ code: 'bg/out-of-range', value: 'low', threshold: 40 }`) are in mg/dL units, so we only need to use the user's display units in the `displayBgValue` function. (That is, we don't need to worry about a step to convert all the thresholds to common units before determining the most conservative set... because they are all already in the same units.)