### PR TITLE
port bolus logic

### DIFF
--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -1,0 +1,167 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+/* the logic here (and the tests) are a port of tideline's
+   js/plot/util/commonbolus.js */
+
+import _ from 'lodash';
+
+import { displayDecimal } from './format';
+
+/**
+ * fixFloatingPoint
+ * @param {Number} numeric value
+ *
+ * @return {Number} numeric value rounded to 3 decimal places
+ */
+function fixFloatingPoint(n) {
+  return parseFloat(displayDecimal(n, 3));
+}
+
+/**
+ * getBolusFromInsulinEvent
+ * @param {Object} insulinEvent - a Tidepool wizard or bolus object
+ *
+ * @return {Object} a Tidepool bolus object
+ */
+export function getBolusFromInsulinEvent(insulinEvent) {
+  let bolus = insulinEvent;
+  if (insulinEvent.bolus) {
+    bolus = insulinEvent.bolus;
+  }
+  return bolus;
+}
+
+/**
+ * getDelivered
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} units of insulin delivered in this insulinEvent
+ */
+export function getDelivered(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+    if (!bolus) {
+      return NaN;
+    }
+  }
+  if (bolus.extended != null) {
+    if (bolus.normal != null) {
+      return fixFloatingPoint(bolus.extended + bolus.normal);
+    }
+    return bolus.extended;
+  }
+  return bolus.normal;
+}
+
+/**
+ * getProgrammed
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} value of insulin programmed for delivery in the given insulinEvent
+ */
+export function getProgrammed(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+    if (!bolus) {
+      return NaN;
+    }
+  }
+  if (bolus.extended != null && bolus.expectedExtended != null) {
+    if (bolus.normal != null) {
+      if (bolus.expectedNormal != null) {
+        return fixFloatingPoint(bolus.expectedNormal + bolus.expectedExtended);
+      }
+      return fixFloatingPoint(bolus.normal + bolus.expectedExtended);
+    }
+    return bolus.expectedExtended;
+  } else if (bolus.extended != null) {
+    if (bolus.normal != null) {
+      if (bolus.expectedNormal != null) {
+        return fixFloatingPoint(bolus.expectedNormal + bolus.extended);
+      }
+      return fixFloatingPoint(bolus.normal + bolus.extended);
+    }
+    return bolus.extended;
+  }
+  return bolus.expectedNormal || bolus.normal;
+}
+
+/**
+ * getRecommended
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} total recommended insulin dose
+ */
+export function getRecommended(insulinEvent) {
+  // a simple manual/"quick" bolus won't have a `recommended` field
+  if (!insulinEvent.recommended) {
+    return NaN;
+  }
+  const netRecommendation = _.get(insulinEvent, ['recommended', 'net'], null);
+  if (netRecommendation !== null) {
+    return netRecommendation;
+  }
+  let rec = 0;
+  rec += _.get(insulinEvent, ['recommended', 'carb'], 0);
+  rec += _.get(insulinEvent, ['recommended', 'correction'], 0);
+
+  return fixFloatingPoint(rec);
+}
+
+/**
+ * getMaxDuration
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} duration value in milliseconds
+ */
+export function getMaxDuration(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+    if (!bolus) {
+      return NaN;
+    }
+  }
+  // don't want truthiness here because want to return expectedDuration
+  // from a bolus interrupted immediately (duration = 0)
+  if (bolus.duration == null) {
+    return NaN;
+  }
+  return bolus.expectedDuration || bolus.duration;
+}
+
+/**
+ * getMaxValue
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} max programmed or recommended value wrt the insulinEvent
+ */
+export function getMaxValue(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+    if (!bolus) {
+      return NaN;
+    }
+  }
+  const programmed = getProgrammed(bolus);
+  const recommended = getRecommended(insulinEvent) || 0;
+  return (recommended > programmed) ? recommended : programmed;
+}

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -56,7 +56,7 @@ export function getDelivered(insulinEvent) {
   let bolus = insulinEvent;
   if (_.get(insulinEvent, 'type') === 'wizard') {
     bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus) {
+    if (!bolus.normal && !bolus.extended) {
       return NaN;
     }
   }
@@ -79,7 +79,7 @@ export function getProgrammed(insulinEvent) {
   let bolus = insulinEvent;
   if (_.get(insulinEvent, 'type') === 'wizard') {
     bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus) {
+    if (!bolus.normal && !bolus.extended) {
       return NaN;
     }
   }
@@ -94,7 +94,10 @@ export function getProgrammed(insulinEvent) {
   } else if (bolus.extended != null) {
     if (bolus.normal != null) {
       if (bolus.expectedNormal != null) {
-        return fixFloatingPoint(bolus.expectedNormal + bolus.extended);
+        // this situation should not exist!
+        throw new Error(
+          'Combo bolus found with a cancelled `normal` portion and non-cancelled `extended`!'
+        );
       }
       return fixFloatingPoint(bolus.normal + bolus.extended);
     }
@@ -135,9 +138,6 @@ export function getMaxDuration(insulinEvent) {
   let bolus = insulinEvent;
   if (_.get(insulinEvent, 'type') === 'wizard') {
     bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus) {
-      return NaN;
-    }
   }
   // don't want truthiness here because want to return expectedDuration
   // from a bolus interrupted immediately (duration = 0)
@@ -157,7 +157,7 @@ export function getMaxValue(insulinEvent) {
   let bolus = insulinEvent;
   if (_.get(insulinEvent, 'type') === 'wizard') {
     bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus) {
+    if (!bolus.normal && !bolus.extended) {
       return NaN;
     }
   }

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -1,0 +1,434 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import * as bolusUtils from '../../src/utils/bolus';
+
+/* eslint-disable no-unused-vars */
+
+const normal = {
+  normal: 5,
+};
+
+const cancelled = {
+  normal: 2,
+  expectedNormal: 5,
+};
+
+const override = {
+  type: 'wizard',
+  bolus: {
+    normal: 2,
+  },
+  recommended: {
+    carb: 0,
+    correction: 0,
+  },
+};
+
+const underride = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+  },
+  recommended: {
+    carb: 1,
+    correction: 0.5,
+  },
+};
+
+const combo = {
+  normal: 1,
+  extended: 2,
+  duration: 36e5,
+};
+
+const cancelledInNormalCombo = {
+  normal: 0.2,
+  expectedNormal: 1,
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: 36e5,
+};
+
+const cancelledInExtendedCombo = {
+  normal: 1,
+  extended: 0.5,
+  expectedExtended: 2,
+  duration: 9e5,
+  expectedDuration: 36e5,
+};
+
+const comboOverride = {
+  type: 'wizard',
+  bolus: {
+    normal: 1.5,
+    extended: 2.5,
+  },
+  recommended: {
+    carb: 3,
+  },
+};
+
+const comboUnderrideCancelled = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+    extended: 1,
+    expectedExtended: 3,
+    duration: 1200000,
+    expectedDuration: 3600000,
+  },
+  recommended: {
+    carb: 5,
+  },
+};
+
+const extended = {
+  extended: 2,
+  duration: 36e5,
+};
+
+const cancelledExtended = {
+  extended: 0.2,
+  expectedExtended: 2,
+  duration: 36e4,
+  expectedDuration: 36e5,
+};
+
+const immediatelyCancelledExtended = {
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: 36e5,
+};
+
+const extendedUnderride = {
+  type: 'wizard',
+  bolus: {
+    extended: 3,
+  },
+  recommended: {
+    correction: 3.5,
+  },
+};
+
+const withNetRec = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+  },
+  recommended: {
+    net: 2,
+  },
+};
+
+describe('bolus utilities', () => {
+  describe('getBolusFromInsulinEvent', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getBolusFromInsulinEvent);
+    });
+
+    it('should return any object that doesn\'t have an embedded bolus', () => {
+      const obj = {};
+      expect(bolusUtils.getBolusFromInsulinEvent(obj)).to.equal(obj);
+    });
+
+    it('errors on `null` or `undefined` ¯\\_(ツ)_/¯', () => {
+      const fn1 = () => { bolusUtils.getBolusFromInsulinEvent(null); };
+      const fn2 = () => { bolusUtils.getBolusFromInsulinEvent(undefined); };
+      const fn3 = () => { bolusUtils.getBolusFromInsulinEvent(); };
+      expect(fn1).to.throw();
+      expect(fn2).to.throw();
+      expect(fn3).to.throw();
+    });
+
+    it('should return the embedded `bolus` if it exists', () => {
+      const obj = { bolus: 2 };
+      expect(bolusUtils.getBolusFromInsulinEvent(obj)).to.equal(obj.bolus);
+      const obj2 = { bolus: { type: 'bolus', normal: 5 } };
+      expect(bolusUtils.getBolusFromInsulinEvent(obj2)).to.equal(obj2.bolus);
+    });
+  });
+
+  describe('getDelivered', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getDelivered);
+    });
+
+    it('should return NaN if type `wizard` and no bolus attached', () => {
+      expect(bolusUtils.getDelivered({ type: 'wizard' })).to.be.NaN;
+    });
+
+    it('should return the value of a no-frills `normal` bolus', () => {
+      expect(bolusUtils.getDelivered(normal)).to.equal(normal.normal);
+    });
+
+    it('should return the value of a no-frills `extended` bolus', () => {
+      expect(bolusUtils.getDelivered(extended)).to.equal(extended.extended);
+    });
+
+    it('should return the combined `normal` and `extended` of a no-frills `combo` bolus', () => {
+      expect(bolusUtils.getDelivered(combo)).to.equal(combo.normal + combo.extended);
+    });
+
+    it('should return the delivered of a cancelled `normal` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelled)).to.equal(cancelled.normal);
+    });
+
+    it('should return the delivered of a cancelled `extended` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelledExtended)).to.equal(cancelledExtended.extended);
+    });
+
+    it('should return the `normal` of a `normal`-cancelled `combo` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelledInNormalCombo))
+        .to.equal(cancelledInNormalCombo.normal);
+    });
+
+    it('should return the `normal` & `extended` of an `extended`-cancelled `combo` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelledInExtendedCombo)).to.equal(
+        cancelledInExtendedCombo.normal + cancelledInExtendedCombo.extended
+      );
+    });
+
+    it('should return the programmed & delivered of an underride', () => {
+      expect(bolusUtils.getDelivered(underride)).to.equal(underride.bolus.normal);
+    });
+
+    it('should return the programmed & delivered of an override', () => {
+      expect(bolusUtils.getDelivered(override)).to.equal(override.bolus.normal);
+    });
+
+    it('should return the programmed & delivered of an `extended` underride', () => {
+      expect(bolusUtils.getDelivered(extendedUnderride)).to.equal(extendedUnderride.bolus.extended);
+    });
+
+    it('should return the the `normal` & `extended` of a `combo` override', () => {
+      expect(bolusUtils.getDelivered(comboOverride)).to.equal(
+        comboOverride.bolus.normal + comboOverride.bolus.extended
+      );
+    });
+
+    it('should return the `normal` & `extended` of a cancelled `combo` underride', () => {
+      expect(bolusUtils.getDelivered(comboUnderrideCancelled)).to.equal(
+        comboUnderrideCancelled.bolus.normal + comboUnderrideCancelled.bolus.extended
+      );
+    });
+  });
+
+  describe('getProgrammed', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getProgrammed);
+    });
+
+    it('should return NaN if type `wizard` and no bolus attached', () => {
+      expect(bolusUtils.getProgrammed({ type: 'wizard' })).to.be.NaN;
+    });
+
+    it('should return the value of a no-frills `normal` bolus', () => {
+      expect(bolusUtils.getProgrammed(normal)).to.equal(normal.normal);
+    });
+
+    it('should return the value of a no-frills `extended` bolus', () => {
+      expect(bolusUtils.getProgrammed(extended)).to.equal(extended.extended);
+    });
+
+    it('should return the combined `normal` and `extended` of a no-frills `combo` bolus', () => {
+      expect(bolusUtils.getProgrammed(combo)).to.equal(combo.normal + combo.extended);
+    });
+
+    it('should return the `expectedNormal` of a cancelled `normal` bolus', () => {
+      expect(bolusUtils.getProgrammed(cancelled)).to.equal(cancelled.expectedNormal);
+    });
+
+    it('should return the `expectedExtended` of a cancelled `extended` bolus', () => {
+      expect(bolusUtils.getProgrammed(cancelledExtended));
+    });
+
+    it(`should return the \`expectedNormal\` & \`expectedExtended\`
+        of a \`normal\`-cancelled \`combo\` bolus`, () => {
+      expect(bolusUtils.getProgrammed(cancelledInNormalCombo)).to.equal(
+        cancelledInNormalCombo.expectedNormal + cancelledInNormalCombo.expectedExtended
+      );
+    });
+
+    it(`should return the \`normal\` & \`expectedExtended\`
+        of an \`extended\`-cancelled \`combo\` bolus`, () => {
+      expect(bolusUtils.getProgrammed(cancelledInExtendedCombo)).to.equal(
+        cancelledInExtendedCombo.normal + cancelledInExtendedCombo.expectedExtended
+      );
+    });
+
+    it('should return the `normal` of an underride', () => {
+      expect(bolusUtils.getProgrammed(underride)).to.equal(underride.bolus.normal);
+    });
+
+    it('should return the `normal` of a `normal` override', () => {
+      expect(bolusUtils.getProgrammed(override)).to.equal(override.bolus.normal);
+    });
+
+    it('should return the `extended` of an `extended` underride', () => {
+      expect(bolusUtils.getProgrammed(extendedUnderride))
+        .to.equal(extendedUnderride.bolus.extended);
+    });
+
+    it('should return the combined `normal` & `extended` of a `combo` override', () => {
+      expect(bolusUtils.getProgrammed(comboOverride)).to.equal(
+        comboOverride.bolus.normal + comboOverride.bolus.extended
+      );
+    });
+
+    it(`should return the \`normal\` and \`expectedExtended\`
+        of an \`extended\`-cancelled combo underride`, () => {
+      expect(bolusUtils.getProgrammed(comboUnderrideCancelled)).to.equal(
+        comboUnderrideCancelled.bolus.normal + comboUnderrideCancelled.bolus.expectedExtended
+      );
+    });
+  });
+
+  describe('getRecommended', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getRecommended);
+    });
+
+    it('should return NaN when no recommended exists (i.e., "quick" or manual bolus)', () => {
+      expect(bolusUtils.getRecommended(normal)).to.be.NaN;
+    });
+
+    it('should return total when both `carb` and `correction` recs exist', () => {
+      const { recommended: { carb, correction } } = underride;
+      expect(bolusUtils.getRecommended(underride)).to.equal(carb + correction);
+    });
+
+    it('should return `carb` rec when only `carb` rec exists', () => {
+      const { recommended: { carb } } = comboOverride;
+      expect(bolusUtils.getRecommended(comboOverride)).to.equal(carb);
+    });
+
+    it('should return `correction` rec when only `correction` rec exists', () => {
+      const { recommended: { correction } } = extendedUnderride;
+      expect(bolusUtils.getRecommended(extendedUnderride)).to.equal(correction);
+    });
+
+    it('should return `net` rec when `net` rec exists', () => {
+      const { recommended: { net } } = withNetRec;
+      expect(bolusUtils.getRecommended(withNetRec)).to.equal(net);
+    });
+
+    it('should return 0 when no bolus recommended, even if overridden', () => {
+      expect(bolusUtils.getRecommended(override)).to.equal(0);
+    });
+  });
+
+  describe('getMaxDuration', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getMaxDuration);
+    });
+
+    it('should return NaN if type `wizard` and no bolus attached', () => {
+      expect(bolusUtils.getMaxDuration({ type: 'wizard' })).to.be.NaN;
+    });
+
+    it('should return NaN on an non-`extended` bolus', () => {
+      expect(bolusUtils.getMaxDuration(normal)).to.be.NaN;
+    });
+
+    it('should return `duration` of an `extended` bolus', () => {
+      expect(bolusUtils.getMaxDuration(extended)).to.equal(extended.duration);
+    });
+
+    it('should return `expectedDuration` of a cancelled `extended` bolus', () => {
+      expect(bolusUtils.getMaxDuration(cancelledExtended))
+        .to.equal(cancelledExtended.expectedDuration);
+    });
+
+    it('should return `expectedDuration` of a cancelled `combo` underride', () => {
+      expect(bolusUtils.getMaxDuration(comboUnderrideCancelled))
+        .to.equal(comboUnderrideCancelled.bolus.expectedDuration);
+    });
+
+    it('should return `expectedDuration` of an immediately-cancelled `extended` bolus', () => {
+      expect(bolusUtils.getMaxDuration(immediatelyCancelledExtended))
+        .to.equal(immediatelyCancelledExtended.expectedDuration);
+    });
+  });
+
+  describe('getMaxValue', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getMaxValue);
+    });
+
+    it('should return NaN if type `wizard` and no bolus attached', () => {
+      expect(bolusUtils.getMaxValue({ type: 'wizard' })).to.be.NaN;
+    });
+
+    it('should return the value of a no-frills `normal` bolus', () => {
+      expect(bolusUtils.getMaxValue(normal)).to.equal(normal.normal);
+    });
+
+    it('should return the value of a no-frills `extended` bolus', () => {
+      expect(bolusUtils.getMaxValue(extended)).to.equal(extended.extended);
+    });
+
+    it('should return the combined `normal` and `extended` of a no-frills `combo` bolus', () => {
+      expect(bolusUtils.getMaxValue(combo)).to.equal(combo.normal + combo.extended);
+    });
+
+    it('should return the programmed value of a cancelled `normal` bolus', () => {
+      expect(bolusUtils.getMaxValue(cancelled)).to.equal(cancelled.expectedNormal);
+    });
+
+    it('should return the programmed value of a cancelled `extended` bolus', () => {
+      expect(bolusUtils.getMaxValue(cancelledExtended))
+        .to.equal(cancelledExtended.expectedExtended);
+    });
+
+    it('should return the combined programmed values of a `normal`-cancelled `combo` bolus', () => {
+      const { expectedNormal, expectedExtended } = cancelledInNormalCombo;
+      expect(bolusUtils.getMaxValue(cancelledInNormalCombo))
+        .to.equal(expectedNormal + expectedExtended);
+    });
+
+    it(`should return the combined programmed values
+        of an \`extended\`-cancelled \`combo\` bolus`, () => {
+      expect(bolusUtils.getMaxValue(cancelledInExtendedCombo))
+        .to.equal(cancelledInExtendedCombo.normal + cancelledInExtendedCombo.expectedExtended);
+    });
+
+    it('should return the net recommendation in the case of an underride', () => {
+      expect(bolusUtils.getMaxValue(underride)).to.equal(1.5);
+    });
+
+    it('should return the delivered in the case of an override', () => {
+      expect(bolusUtils.getMaxValue(override)).to.equal(override.bolus.normal);
+    });
+
+    it('should return the net recommendation in the case of an `extended` underride', () => {
+      expect(bolusUtils.getMaxValue(extendedUnderride)).to.equal(3.5);
+    });
+
+    it('should return the delivered in the case of a `combo` override', () => {
+      expect(bolusUtils.getMaxValue(comboOverride)).to.equal(
+        comboOverride.bolus.normal + comboOverride.bolus.extended
+      );
+    });
+
+    it('should return the net recommendation in the case of a cancelled `combo` underride', () => {
+      expect(bolusUtils.getMaxValue(comboUnderrideCancelled)).to.equal(5);
+    });
+  });
+});

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -73,6 +73,13 @@ const cancelledInExtendedCombo = {
   expectedDuration: 36e5,
 };
 
+const doesNotExist = {
+  normal: 0.2,
+  expectedNormal: 1,
+  extended: 2,
+  duration: 36e5,
+};
+
 const comboOverride = {
   type: 'wizard',
   bolus: {
@@ -171,7 +178,7 @@ describe('bolus utilities', () => {
     });
 
     it('should return NaN if type `wizard` and no bolus attached', () => {
-      expect(bolusUtils.getDelivered({ type: 'wizard' })).to.be.NaN;
+      expect(Number.isNaN(bolusUtils.getDelivered({ type: 'wizard' }))).to.be.true;
     });
 
     it('should return the value of a no-frills `normal` bolus', () => {
@@ -236,7 +243,7 @@ describe('bolus utilities', () => {
     });
 
     it('should return NaN if type `wizard` and no bolus attached', () => {
-      expect(bolusUtils.getProgrammed({ type: 'wizard' })).to.be.NaN;
+      expect(Number.isNaN(bolusUtils.getProgrammed({ type: 'wizard' }))).to.be.true;
     });
 
     it('should return the value of a no-frills `normal` bolus', () => {
@@ -273,6 +280,14 @@ describe('bolus utilities', () => {
       );
     });
 
+    it(`should throw an error on a \`normal\`-cancelled \`combo\` bolus
+        with no \`expectedExtended\``, () => {
+      const fn = () => { bolusUtils.getProgrammed(doesNotExist); };
+      expect(fn).to.throw(
+        'Combo bolus found with a cancelled `normal` portion and non-cancelled `extended`!'
+      );
+    });
+
     it('should return the `normal` of an underride', () => {
       expect(bolusUtils.getProgrammed(underride)).to.equal(underride.bolus.normal);
     });
@@ -306,7 +321,7 @@ describe('bolus utilities', () => {
     });
 
     it('should return NaN when no recommended exists (i.e., "quick" or manual bolus)', () => {
-      expect(bolusUtils.getRecommended(normal)).to.be.NaN;
+      expect(Number.isNaN(bolusUtils.getRecommended(normal))).to.be.true;
     });
 
     it('should return total when both `carb` and `correction` recs exist', () => {
@@ -340,11 +355,11 @@ describe('bolus utilities', () => {
     });
 
     it('should return NaN if type `wizard` and no bolus attached', () => {
-      expect(bolusUtils.getMaxDuration({ type: 'wizard' })).to.be.NaN;
+      expect(Number.isNaN(bolusUtils.getMaxDuration({ type: 'wizard' }))).to.be.true;
     });
 
-    it('should return NaN on an non-`extended` bolus', () => {
-      expect(bolusUtils.getMaxDuration(normal)).to.be.NaN;
+    it('should return NaN on a non-`extended` bolus', () => {
+      expect(Number.isNaN(bolusUtils.getMaxDuration(normal))).to.be.true;
     });
 
     it('should return `duration` of an `extended` bolus', () => {
@@ -373,7 +388,7 @@ describe('bolus utilities', () => {
     });
 
     it('should return NaN if type `wizard` and no bolus attached', () => {
-      expect(bolusUtils.getMaxValue({ type: 'wizard' })).to.be.NaN;
+      expect(Number.isNaN(bolusUtils.getMaxValue({ type: 'wizard' }))).to.be.true;
     });
 
     it('should return the value of a no-frills `normal` bolus', () => {


### PR DESCRIPTION
This is a port of tideline's js/plot/util/commonbolus.js which basically maps the bolus data model onto the concepts used for rendering boluses - things like getting the total programmed dose, the total recommended dose, etc.