### PR TITLE
refactor util to reshape tideline-style bgClasses to viz-style bgBounds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,8 @@ import TrendsContainer from './containers/trends/TrendsContainer';
 
 import vizReducer from './redux/reducers/';
 
+import { reshapeBgClassesToBgBounds } from './utils/bloodglucose';
+
 const components = {
   CBGDateTraceLabel,
   FocusedRangeLabels,
@@ -42,4 +44,8 @@ const containers = {
   TrendsContainer,
 };
 
-export { components, containers, vizReducer };
+const utils = {
+  reshapeBgClassesToBgBounds,
+};
+
+export { components, containers, vizReducer, utils };

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -53,3 +53,21 @@ export function classifyBgValue(bgBounds, bgValue) {
 export function convertToMmolL(val) {
   return (val / 18.01559);
 }
+
+/**
+ * reshapeBgClassesToBgBounds
+ * @param {Object} bgPrefs - bgPrefs object from blip containing tideline-style bgClasses
+ *
+ * @return {Object} bgBounds - @tidepool/viz-style bgBounds
+ */
+export function reshapeBgClassesToBgBounds(bgPrefs) {
+  const { bgClasses } = bgPrefs;
+  const bgBounds = {
+    veryHighThreshold: bgClasses.high.boundary,
+    targetUpperBound: bgClasses.target.boundary,
+    targetLowerBound: bgClasses.low.boundary,
+    veryLowThreshold: bgClasses['very-low'].boundary,
+  };
+
+  return bgBounds;
+}

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -114,4 +114,30 @@ describe('blood glucose utilities', () => {
       expect(bgUtils.convertToMmolL(400)).to.equal(22.202991964182132);
     });
   });
+
+  describe('reshapeBgClassesToBgBounds', () => {
+    const bgPrefs = {
+      bgClasses: {
+        'very-high': { boundary: 600 },
+        high: { boundary: 300 },
+        target: { boundary: 180 },
+        low: { boundary: 70 },
+        'very-low': { boundary: 54 },
+      },
+      bgUnits: 'mg/dL',
+    };
+
+    it('should be a function', () => {
+      assert.isFunction(bgUtils.reshapeBgClassesToBgBounds);
+    });
+
+    it('should extract and reshape `bgClasses` to `bgBounds`', () => {
+      expect(bgUtils.reshapeBgClassesToBgBounds(bgPrefs)).to.deep.equal({
+        veryHighThreshold: 300,
+        targetUpperBound: 180,
+        targetLowerBound: 70,
+        veryLowThreshold: 54,
+      });
+    });
+  });
 });


### PR DESCRIPTION
This was being done in trends.js in Blip, and I'll need it now for the print view, so factored it out and made a separate branch since it's just a util that can come into master at any time.