### PR TITLE
format utils cleanup

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -20,5 +20,7 @@
 + [utilities](src/utils/README.md)
     + [API docs for utilities](src/utils/apidocs/README.md)
         + [datetime](src/utils/apidocs/datetime.md)
+        + [format](src/utils/apidocs/format.md)
+        + [misc](src/utils/apidocs/misc.md)
 + [misc](docs/misc/README.md)
     + [Time-rendering modes](docs/misc/TimeRenderingModes.md)

--- a/docs/DirectoryStructure.md
+++ b/docs/DirectoryStructure.md
@@ -16,7 +16,7 @@
 
 * * * * *
 
-As of November, 2016, the directory structure is as follows (although this may change as we continue to develop new code in this repository):
+As of May, 2017, the directory structure is as follows (although this may change as we continue to develop new code in this repository):
 
 <!-- to generate the directory structure below use `tree -d --matchdirs -I '_book|coverage|dist|node_modules|web'` -->
 ```
@@ -27,48 +27,52 @@ As of November, 2016, the directory structure is as follows (although this may c
 │       ├── omnipod
 │       └── tandem
 ├── docs
+│   ├── deps
+│   ├── misc
+│   └── views
+│       └── images
+├── local
 ├── src
 │   ├── components
 │   │   ├── common
-│   │   │   └── controls
+│   │   │   ├── controls
+│   │   │   └── tooltips
 │   │   ├── settings
 │   │   │   └── common
 │   │   └── trends
 │   │       ├── cbg
-│   │       └── common
-│   ├── containers
-│   │   ├── settings
-│   │   └── trends
+│   │       ├── common
+│   │       └── smbg
 │   ├── redux
 │   │   ├── actions
 │   │   ├── constants
 │   │   └── reducers
 │   ├── styles
 │   └── utils
+│       ├── apidocs
 │       ├── settings
 │       └── trends
 ├── stories
 │   ├── components
 │   │   ├── common
-│   │   │   └── controls
+│   │   │   ├── controls
+│   │   │   └── tooltips
 │   │   ├── settings
 │   │   └── trends
 │   │       └── common
-│   └── containers
-│       └── trends
+│   └── helpers
 ├── storybook
 └── test
     ├── components
     │   ├── common
-    │   │   └── controls
+    │   │   ├── controls
+    │   │   └── tooltip
     │   ├── settings
     │   │   └── common
     │   └── trends
     │       ├── cbg
-    │       └── common
-    ├── containers
-    │   ├── settings
-    │   └── trends
+    │       ├── common
+    │       └── smbg
     ├── helpers
     ├── redux
     │   ├── actions
@@ -85,7 +89,6 @@ All active, non-tooling code in the repository is contained in `src/`, and `src/
 ```
 └── src
     ├── components
-    ├── containers
     ├── redux
     ├── styles
     └── utils
@@ -96,6 +99,7 @@ All active, non-tooling code in the repository is contained in `src/`, and `src/
 ```
 └── redux
     ├── actions
+    ├── constants
     └── reducers
 ```
 
@@ -103,27 +107,30 @@ Within `src/redux/`, the `actions/` and `reducers/` contain the actions and redu
 
 In both `actions/` and `reducers/`, files should be grouped into sub-directories by ["view"](#views) or located in a directory called `common/` if the action(s) or reducer(s) is relevant to more than one view.
 
+The `src/redux/constants/` directory at present contains just the `actionTypes.js` file, which exports (as individual named exports) the action type constants for every action defined in `actions/` as well as those of blip's actions that are relevant to the viz reducers.
+
 ### React component directories
 
-Within `src/`, the `components/`, `containers/`, and (eventually) `views/` directories all contain the source for React components of various types and purposes.
+Within `src/`, the `components/` directory contains the source for React components of various types and purposes.
 
 Note that our convention for naming React component files is [PascalCase](https://en.wikipedia.org/wiki/PascalCase): `BGSlice`, `DailyContainer`, &c.
 
-#### components
+By convention, React components that meet most or all of the following criteria are considered "container" components and named as such—e.g., `TrendsContainer` and `CBGDateTracesAnimationContainer`.
 
-`components/` contains the lowest level of component. For the most part, these components should be stateless and (albeit with some rare exceptions) coded as [stateless functional components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components) rather than ES6 classes extending `React.Component`.
+- implemented as a `class` extension of `React.Component` or `React.PureComponent` (rather than a pure functional component)
+- needs only minimal or zero styles
+- primarily performs data munging or other "business logic" (or animation logic) in response to data (i.e., props) changes, potentially storing internal derived state as a result
+- renders other React components, *not* HTML or SVG elements
+
+The distinction between a "container" and a "pure" component is admittedly a bit fuzzy[^a], but generally the purpose of a container is to perform logic to *prepare* for rendering and then pass the resulting state to one or more stateless functional components for pure rendering. For example, for the trends view, the `TrendsContainer` determines the blood glucose and time domains on mount and on every update, preserving the current time domain in view and arrays of `cbg` and `smbg` currently in view (given the time domain) in its state. At the next level down, the `TrendsSVGContainer` sets up the rendering "canvas" (actually an SVG element) and scales for rendering (given the dimensions of the "canvas"). Another hallmark of "container" components is that they often do *not* have any associated styles since their purpose is computation and set up, not rendering.
+
+For the most part, *non*-"container" components should be stateless and (albeit with some rare exceptions) coded as [stateless functional components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components) rather than ES6 classes extending `React.Component` or `React.PureComponent`.
 
 Files should be grouped into sub-directories by ["view"](#views) and where necessary (because of a large number of components) into further sub-directories by datatype.
 
 Components used in more than one view should be located in `common/`. Examples of common components are controls like the BGM <-> CGM toggle used in both the basics and trends views and, potentially, animation containers like the header + child component (proposed for new device settings and potentially useful as well for sections in the basics view) that will slide the child component in and out on click of the header.
 
 CSS particular to a component should be written using [CSS modules](https://github.com/css-modules/css-modules) and contained in a file in the same directory and with the same name as the component, substituting the `.css` suffix for `.js`.
-
-#### containers
-
-`containers/` contains the mid-tier type of component. The distinction between a "container" and a "component" is a bit fuzzy, but generally the purpose of a container is to perform logic to *prepare* for rendering and then pass the resulting state to one or more stateless functional components for pure rendering. For example, for the trends view, the `TrendsContainer` determines the blood glucose and time domains on mount and on every update, preserving the current time domain in view and arrays of `cbg` and `smbg` currently in view (given the time domain) in its state. At the next level down, the `CBGTrendsContainer` sets up the rendering "canvas" (actually an SVG element) and scales for rendering (given the dimensions of the "canvas"). Another hallmark of "container" components is that they often do *not* have any associated styles since their purpose is computation and set up, not rendering.
-
-Files should be grouped into sub-directories by ["view"](#views) or located in a directory called `common/` if applicable to more than one view.
 
 #### views
 
@@ -150,3 +157,5 @@ In general, utilities should export individual constants, functions, &c, **not**
 ### The test directory
 
 The `test/` directory mirrors the structure of `src/`. Our convention for naming test files is to use the same names but insert `.test` before the `.js` suffix. For example, the tests for a component `BGSlice.js` should be in a file named `BGSlice.test.js`. The tests for a `datetime.js` utility file should be in a file named `datetime.test.js`.
+
+[^a]: Hence our decision to give up on organizing containers in a `src/containers/` directory distinct from `src/components/`.

--- a/docs/FeatureOverview.md
+++ b/docs/FeatureOverview.md
@@ -82,7 +82,7 @@ The device settings view is the simplest, showing just a relatively simple tabul
 
 Because Tandem pumps require a quite different visual representation (as well as a different structure to the data model) to capture the way the settings are programmed, the release of support for Tandem pumps was our forcing function for writing new code to display the Tandem settings, and so we also reimplemented the device settings display for all other Tidepool-supported pumps.
 
-A new feature added as part of the reimplementation is the preservation of open or collapsed basal schedules (or Tandem "timed profiles") even when the user navigates away from Device Settings to elsewhere in the app before coming back. Leveraging blip's Redux store to manage the state of each collapsible section made this feature-add quite easy. (See [@tidepool/viz's usage of Redux](./Redux.md) for more information on managing visualization state through blip's redux store.)
+A new feature added as part of the reimplementation is the preservation of open or collapsed basal schedules (or Tandem "timed profiles") even when the user navigates away from Device Settings to elsewhere in the app before coming back. Leveraging blip's Redux store to manage the state of each collapsible section made this feature-add quite easy. (See [@tidepool/viz's usage of Redux](./deps/Redux.md) for more information on managing visualization state through blip's redux store.)
 
 [💣 tech debt 💣] Only the most recent insulin pump settings are displayed, and a blip user cannot navigate along the datetime dimension at all to view older insulin pump settings.
 

--- a/docs/StartHere.md
+++ b/docs/StartHere.md
@@ -9,7 +9,7 @@ As you're getting ready to develop code in this repository, we recommend startin
 - [planned architecture](./Architecture.md)
 - [app & directory structure](./DirectoryStructure.md)
 - [code style](./CodeStyle.md)
-- [dependencies](./Dependencies.md)
+- [dependencies](./deps/README.md)
 
 The root-level [README]('../README.md') contains the nuts & bolts of installing, configuring, and commands to accomplish various tasks.
 

--- a/docs/deps/React.md
+++ b/docs/deps/React.md
@@ -2,5 +2,5 @@
 
 Aside from [our general views on React best practices at Tidepool](http://developer.tidepool.io/docs/front-end/react/index.html 'Tidepool developer portal: React @ Tidepool'), to develop code in this repository you should:
 
-- understand our division between [components, containers, and views](../DirectoryStructure.md#react-component-directories)
+- understand our division between [components, "container" components, and views](../DirectoryStructure.md#react-component-directories)
 - understand [how we use D3 and React together]('./D3.md')

--- a/docs/deps/React.md
+++ b/docs/deps/React.md
@@ -2,5 +2,5 @@
 
 Aside from [our general views on React best practices at Tidepool](http://developer.tidepool.io/docs/front-end/react/index.html 'Tidepool developer portal: React @ Tidepool'), to develop code in this repository you should:
 
-- understand our division between [components, containers, and views](./DirectoryStructure.md#react-component-directories)
+- understand our division between [components, containers, and views](../DirectoryStructure.md#react-component-directories)
 - understand [how we use D3 and React together]('./D3.md')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/settings/common/PumpSettingsContainer.js
+++ b/src/components/settings/common/PumpSettingsContainer.js
@@ -20,12 +20,12 @@ import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import * as actions from '../../redux/actions/';
-import { MGDL_UNITS, MMOLL_UNITS } from '../../utils/constants';
+import * as actions from '../../../redux/actions/';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
 
-import NonTandem from '../../components/settings/NonTandem';
-import Tandem from '../../components/settings/Tandem';
-import { DISPLAY_VIEW, PRINT_VIEW } from '../../components/settings/constants';
+import NonTandem from '../NonTandem';
+import Tandem from '../Tandem';
+import { DISPLAY_VIEW, PRINT_VIEW } from '../../../components/settings/constants';
 
 export class PumpSettingsContainer extends PureComponent {
   static propTypes = {

--- a/src/components/trends/cbg/CBGDateTracesAnimationContainer.js
+++ b/src/components/trends/cbg/CBGDateTracesAnimationContainer.js
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import React, { PropTypes } from 'react';
 import TransitionGroupPlus from 'react-transition-group-plus';
 
-import CBGDateTraceAnimated from '../../components/trends/cbg/CBGDateTraceAnimated';
+import CBGDateTraceAnimated from './CBGDateTraceAnimated';
 
 const CBGDateTracesAnimationContainer = (props) => {
   const { bgBounds, data, dates, topMargin, xScale, yScale } = props;

--- a/src/components/trends/cbg/CBGSlicesContainer.js
+++ b/src/components/trends/cbg/CBGSlicesContainer.js
@@ -19,13 +19,13 @@ import _ from 'lodash';
 import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
-import { THIRTY_MINS, TWENTY_FOUR_HRS } from '../../utils/datetime';
+import { THIRTY_MINS, TWENTY_FOUR_HRS } from '../../../utils/datetime';
 import {
   findBinForTimeOfDay, findOutOfRangeAnnotations, calculateCbgStatsForBin,
-} from '../../utils/trends/data';
+} from '../../../utils/trends/data';
 
-import CBGMedianAnimated from '../../components/trends/cbg/CBGMedianAnimated';
-import CBGSliceAnimated from '../../components/trends/cbg/CBGSliceAnimated';
+import CBGMedianAnimated from './CBGMedianAnimated';
+import CBGSliceAnimated from './CBGSliceAnimated';
 
 export default class CBGSlicesContainer extends PureComponent {
   static propTypes = {

--- a/src/components/trends/common/FocusedRangeLabels.js
+++ b/src/components/trends/common/FocusedRangeLabels.js
@@ -20,7 +20,7 @@ import React, { PropTypes } from 'react';
 import Tooltip from '../../common/tooltips/Tooltip';
 
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
-import { displayBgValue } from '../../../utils/format';
+import { formatBgValue } from '../../../utils/format';
 import { formatClocktimeFromMsPer24 } from '../../../utils/datetime';
 
 import styles from './FocusedRangeLabels.css';
@@ -35,7 +35,7 @@ const FocusedRangeLabels = (props) => {
     return null;
   }
 
-  const { bgUnits, dataType } = props;
+  const { bgPrefs, dataType } = props;
   const isCbg = dataType === 'cbg';
   const dataBucket = isCbg ? 'focusedSlice' : 'focusedRange';
   const { [dataBucket]: { data, position } } = props;
@@ -71,7 +71,7 @@ const FocusedRangeLabels = (props) => {
       <Tooltip
         content={
           <span className={styles.number}>
-            {displayBgValue(data[top], bgUnits, data.outOfRangeThresholds)}
+            {formatBgValue(data[top], bgPrefs, data.outOfRangeThresholds)}
           </span>
         }
         backgroundColor={'transparent'}
@@ -86,7 +86,7 @@ const FocusedRangeLabels = (props) => {
           title={<span className={styles.explainerText}>{timeFrom} - {timeTo}</span>}
           content={
             <span className={styles.number}>
-              {`Average ${displayBgValue(data[center], bgUnits, data.outOfRangeThresholds)}`}
+              {`Average ${formatBgValue(data[center], bgPrefs, data.outOfRangeThresholds)}`}
             </span>
           }
           offset={{ top: 0, horizontal: props.numberOffsets.horizontal }}
@@ -97,7 +97,7 @@ const FocusedRangeLabels = (props) => {
       <Tooltip
         content={
           <span className={styles.number}>
-            {displayBgValue(data[bottom], bgUnits, data.outOfRangeThresholds)}
+            {formatBgValue(data[bottom], bgPrefs, data.outOfRangeThresholds)}
           </span>
         }
         backgroundColor={'transparent'}
@@ -120,7 +120,11 @@ FocusedRangeLabels.defaultProps = {
 };
 
 FocusedRangeLabels.propTypes = {
-  bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
+  bgPrefs: PropTypes.shape({
+    bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
+    // only the bgUnits required in this component
+    // so leaving off specification of bgBounds shape
+  }).isRequired,
   dataType: PropTypes.oneOf(['cbg', 'smbg']).isRequired,
   focusedKeys: PropTypes.arrayOf(PropTypes.oneOf([
     'firstQuartile',

--- a/src/components/trends/common/TrendsContainer.js
+++ b/src/components/trends/common/TrendsContainer.js
@@ -27,13 +27,13 @@ import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import * as actions from '../../redux/actions/';
+import * as actions from '../../../redux/actions/';
 import TrendsSVGContainer from './TrendsSVGContainer';
 import {
   MGDL_CLAMP_TOP, MMOLL_CLAMP_TOP, MGDL_UNITS, MMOLL_UNITS, trends,
-} from '../../utils/constants';
+} from '../../../utils/constants';
 const { extentSizes: { ONE_WEEK, TWO_WEEKS, FOUR_WEEKS } } = trends;
-import * as datetime from '../../utils/datetime';
+import * as datetime from '../../../utils/datetime';
 
 /**
  * getAllDatesInRange

--- a/src/components/trends/common/TrendsSVGContainer.js
+++ b/src/components/trends/common/TrendsSVGContainer.js
@@ -43,23 +43,23 @@ import React, { PropTypes, PureComponent } from 'react';
 import dimensions from 'react-dimensions';
 import _ from 'lodash';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../utils/constants';
-import { THREE_HRS } from '../../utils/datetime';
-import { findDatesIntersectingWithCbgSliceSegment } from '../../utils/trends/data';
-import Background from '../../components/trends/common/Background';
-import CBGDateTracesAnimationContainer from './CBGDateTracesAnimationContainer';
-import CBGSlicesContainer from './CBGSlicesContainer';
-import FocusedCBGSliceSegment from '../../components/trends/cbg/FocusedCBGSliceSegment';
-import SMBGsByDateContainer from './SMBGsByDateContainer';
-import SMBGRangeAvgContainer from './SMBGRangeAvgContainer';
-import SMBGRangeAnimated from '../../components/trends/smbg/SMBGRangeAnimated';
-import SMBGMeanAnimated from '../../components/trends/smbg/SMBGMeanAnimated';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
+import { THREE_HRS } from '../../../utils/datetime';
+import { findDatesIntersectingWithCbgSliceSegment } from '../../../utils/trends/data';
+import Background from './Background';
+import CBGDateTracesAnimationContainer from '../cbg/CBGDateTracesAnimationContainer';
+import CBGSlicesContainer from '../cbg/CBGSlicesContainer';
+import FocusedCBGSliceSegment from '../cbg/FocusedCBGSliceSegment';
+import SMBGsByDateContainer from '../smbg/SMBGsByDateContainer';
+import SMBGRangeAvgContainer from '../smbg/SMBGRangeAvgContainer';
+import SMBGRangeAnimated from '../smbg/SMBGRangeAnimated';
+import SMBGMeanAnimated from '../smbg/SMBGMeanAnimated';
 
-import NoData from '../../components/trends/common/NoData';
-import TargetRangeLines from '../../components/trends/common/TargetRangeLines';
-import XAxisLabels from '../../components/trends/common/XAxisLabels';
-import XAxisTicks from '../../components/trends/common/XAxisTicks';
-import YAxisLabelsAndTicks from '../../components/trends/common/YAxisLabelsAndTicks';
+import NoData from './NoData';
+import TargetRangeLines from './TargetRangeLines';
+import XAxisLabels from './XAxisLabels';
+import XAxisTicks from './XAxisTicks';
+import YAxisLabelsAndTicks from './YAxisLabelsAndTicks';
 
 export class TrendsSVGContainer extends PureComponent {
   constructor(props) {

--- a/src/components/trends/common/YAxisLabelsAndTicks.js
+++ b/src/components/trends/common/YAxisLabelsAndTicks.js
@@ -19,12 +19,13 @@ import _ from 'lodash';
 import React, { PropTypes } from 'react';
 
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
-import { displayBgValue } from '../../../utils/format';
+import { formatBgValue } from '../../../utils/format';
 
 import styles from './YAxisLabelsAndTicks.css';
 
 const YAxisLabels = (props) => {
-  const { bgBounds, bgUnits, margins, textToTickGap, tickWidth, yScale } = props;
+  const { bgPrefs, margins, textToTickGap, tickWidth, yScale } = props;
+  const { bgBounds } = bgPrefs;
 
   return (
     <g id="yAxisLabels">
@@ -36,7 +37,7 @@ const YAxisLabels = (props) => {
               x={margins.left - tickWidth - textToTickGap}
               y={yScale(bgBounds[boundKey])}
             >
-              {displayBgValue(bgBounds[boundKey], bgUnits)}
+              {formatBgValue(bgBounds[boundKey], bgPrefs)}
             </text>
             <line
               className={styles.tick}
@@ -58,13 +59,15 @@ YAxisLabels.defaultProps = {
 };
 
 YAxisLabels.propTypes = {
-  bgBounds: PropTypes.shape({
-    veryHighThreshold: PropTypes.number.isRequired,
-    targetUpperBound: PropTypes.number.isRequired,
-    targetLowerBound: PropTypes.number.isRequired,
-    veryLowThreshold: PropTypes.number.isRequired,
+  bgPrefs: PropTypes.shape({
+    bgBounds: PropTypes.shape({
+      veryHighThreshold: PropTypes.number.isRequired,
+      targetUpperBound: PropTypes.number.isRequired,
+      targetLowerBound: PropTypes.number.isRequired,
+      veryLowThreshold: PropTypes.number.isRequired,
+    }),
+    bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
   }),
-  bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
   margins: PropTypes.shape({
     top: PropTypes.number.isRequired,
     right: PropTypes.number.isRequired,

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -20,7 +20,7 @@ import _ from 'lodash';
 import Tooltip from '../../common/tooltips/Tooltip';
 
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
-import { displayBgValue } from '../../../utils/format';
+import { formatBgValue } from '../../../utils/format';
 import {
   formatClocktimeFromMsPer24,
   formatLocalizedFromUTC,
@@ -51,7 +51,7 @@ const FocusedSMBGPointLabel = (props) => {
   }
 
   const {
-    bgUnits,
+    bgPrefs,
     focusedPoint: { datum, position, allSmbgsOnDate, allPositions },
     timePrefs,
     lines,
@@ -71,7 +71,7 @@ const FocusedSMBGPointLabel = (props) => {
       key={i}
       content={
         <span className={styles.number}>
-          {displayBgValue(smbg.value, bgUnits, getOutOfRangeThreshold(smbg))}
+          {formatBgValue(smbg.value, bgPrefs, getOutOfRangeThreshold(smbg))}
         </span>
       }
       position={allPositions[i]}
@@ -103,7 +103,7 @@ const FocusedSMBGPointLabel = (props) => {
         }
         content={<span className={styles.tipWrapper}>
           <span className={styles.detailNumber}>
-            {displayBgValue(datum.value, bgUnits, getOutOfRangeThreshold(datum))}
+            {formatBgValue(datum.value, bgPrefs, getOutOfRangeThreshold(datum))}
           </span>
           <span className={styles.subType}>{categorizeSmbgSubtype(datum)}</span>
         </span>
@@ -126,7 +126,11 @@ const FocusedSMBGPointLabel = (props) => {
 };
 
 FocusedSMBGPointLabel.propTypes = {
-  bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
+  bgPrefs: PropTypes.shape({
+    bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
+    // only the bgUnits required in this component
+    // so leaving off specification of bgBounds shape
+  }).isRequired,
   focusedPoint: PropTypes.shape({
     allPositions: PropTypes.arrayOf(PropTypes.shape({
       tooltipLeft: PropTypes.bool.isRequired,

--- a/src/components/trends/smbg/SMBGRangeAvgContainer.js
+++ b/src/components/trends/smbg/SMBGRangeAvgContainer.js
@@ -19,10 +19,10 @@ import _ from 'lodash';
 import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
-import { THREE_HRS, TWENTY_FOUR_HRS } from '../../utils/datetime';
+import { THREE_HRS, TWENTY_FOUR_HRS } from '../../../utils/datetime';
 import {
   findBinForTimeOfDay, findOutOfRangeAnnotations, calculateSmbgStatsForBin,
-} from '../../utils/trends/data';
+} from '../../../utils/trends/data';
 
 export default class SMBGRangeAvgContainer extends PureComponent {
   static propTypes = {

--- a/src/components/trends/smbg/SMBGsByDateContainer.js
+++ b/src/components/trends/smbg/SMBGsByDateContainer.js
@@ -18,8 +18,8 @@
 import React, { PropTypes } from 'react';
 import _ from 'lodash';
 
-import SMBGDatePointsAnimated from '../../components/trends/smbg/SMBGDatePointsAnimated';
-import SMBGDateLineAnimated from '../../components/trends/smbg/SMBGDateLineAnimated';
+import SMBGDatePointsAnimated from './SMBGDatePointsAnimated';
+import SMBGDateLineAnimated from './SMBGDateLineAnimated';
 
 const SMBGsByDateContainer = (props) => {
   const { data } = props;

--- a/src/containers/trends/TrendsContainer.js
+++ b/src/containers/trends/TrendsContainer.js
@@ -361,7 +361,7 @@ export class TrendsContainer extends PureComponent {
         .startOf('day')
         .add(12, 'hours')
         .toISOString();
-      return noonOnDate;
+      this.props.onSelectDate(noonOnDate);
     };
   }
 

--- a/src/containers/trends/TrendsContainer.js
+++ b/src/containers/trends/TrendsContainer.js
@@ -108,13 +108,15 @@ export class TrendsContainer extends PureComponent {
       saturday: PropTypes.bool.isRequired,
       sunday: PropTypes.bool.isRequired,
     }).isRequired,
-    bgBounds: PropTypes.shape({
-      veryHighThreshold: PropTypes.number.isRequired,
-      targetUpperBound: PropTypes.number.isRequired,
-      targetLowerBound: PropTypes.number.isRequired,
-      veryLowThreshold: PropTypes.number.isRequired,
+    bgPrefs: PropTypes.shape({
+      bgBounds: PropTypes.shape({
+        veryHighThreshold: PropTypes.number.isRequired,
+        targetUpperBound: PropTypes.number.isRequired,
+        targetLowerBound: PropTypes.number.isRequired,
+        veryLowThreshold: PropTypes.number.isRequired,
+      }).isRequired,
+      bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
     }).isRequired,
-    bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
     currentPatientInViewId: PropTypes.string.isRequired,
     extentSize: PropTypes.oneOf([ONE_WEEK, TWO_WEEKS, FOUR_WEEKS]).isRequired,
     initialDatetimeLocation: PropTypes.string,
@@ -259,7 +261,7 @@ export class TrendsContainer extends PureComponent {
     const allBg = cbgByDate.filterAll().top(Infinity).concat(smbgByDate.filterAll().top(Infinity));
     const bgDomain = extent(allBg, d => d.value);
 
-    const { bgBounds, bgUnits, yScaleClampTop } = this.props;
+    const { bgPrefs: { bgBounds, bgUnits }, yScaleClampTop } = this.props;
     const upperBound = yScaleClampTop[bgUnits];
     const yScaleDomain = [bgDomain[0], upperBound];
     if (bgDomain[0] > bgBounds.targetLowerBound) {
@@ -446,8 +448,7 @@ export class TrendsContainer extends PureComponent {
     return (
       <TrendsSVGContainer
         activeDays={this.props.activeDays}
-        bgBounds={this.props.bgBounds}
-        bgUnits={this.props.bgUnits}
+        bgPrefs={this.props.bgPrefs}
         smbgData={this.state.currentSmbgData}
         cbgData={this.state.currentCbgData}
         dates={getAllDatesInRange(start, end, this.props.timePrefs)}

--- a/src/containers/trends/TrendsSVGContainer.js
+++ b/src/containers/trends/TrendsSVGContainer.js
@@ -141,7 +141,7 @@ export class TrendsSVGContainer extends PureComponent {
     const data = this.props.smbgRangeOverlay ? this.props.smbgData : [];
     return (
       <SMBGRangeAvgContainer
-        bgBounds={this.props.bgBounds}
+        bgBounds={this.props.bgPrefs.bgBounds}
         data={data}
         key={componentKey}
         smbgComponent={smbgComponent}
@@ -157,7 +157,7 @@ export class TrendsSVGContainer extends PureComponent {
     if (this.props.showingCbg) {
       const slices = (
         <CBGSlicesContainer
-          bgBounds={this.props.bgBounds}
+          bgBounds={this.props.bgPrefs.bgBounds}
           data={this.props.cbgData}
           displayFlags={this.props.displayFlags}
           showingCbgDateTraces={this.props.showingCbgDateTraces}
@@ -171,7 +171,7 @@ export class TrendsSVGContainer extends PureComponent {
       const { focusedSegmentDataGroupedByDate } = this.state;
       const dateTraces = (
         <CBGDateTracesAnimationContainer
-          bgBounds={this.props.bgBounds}
+          bgBounds={this.props.bgPrefs.bgBounds}
           data={focusedSegmentDataGroupedByDate}
           dates={_.keys(focusedSegmentDataGroupedByDate) || []}
           onSelectDate={this.props.onSelectDate}
@@ -208,7 +208,7 @@ export class TrendsSVGContainer extends PureComponent {
       const allSmbgsByDate = (
         <SMBGsByDateContainer
           anSmbgRangeAvgIsFocused={this.props.focusedSmbgRangeAvgKey !== null}
-          bgBounds={this.props.bgBounds}
+          bgBounds={this.props.bgPrefs.bgBounds}
           data={this.props.smbgData}
           dates={this.props.dates}
           grouped={this.props.smbgGrouped}
@@ -228,7 +228,7 @@ export class TrendsSVGContainer extends PureComponent {
       const focusedSmbgDate = this.props.focusedSmbg ? (
         <SMBGsByDateContainer
           anSmbgRangeAvgIsFocused={false}
-          bgBounds={this.props.bgBounds}
+          bgBounds={this.props.bgPrefs.bgBounds}
           data={this.props.focusedSmbg.allSmbgsOnDate}
           dates={[this.props.focusedSmbg.date]}
           focusedSmbg={this.props.focusedSmbg}
@@ -278,7 +278,7 @@ export class TrendsSVGContainer extends PureComponent {
           xScale={this.props.xScale}
         />
         <YAxisLabelsAndTicks
-          bgBounds={this.props.bgBounds}
+          bgPrefs={this.props.bgPrefs}
           bgUnits={this.props.bgUnits}
           margins={this.props.margins}
           yScale={this.props.yScale}
@@ -286,7 +286,7 @@ export class TrendsSVGContainer extends PureComponent {
         {this.renderCbg()}
         {this.renderSmbg()}
         <TargetRangeLines
-          bgBounds={this.props.bgBounds}
+          bgBounds={this.props.bgPrefs.bgBounds}
           smbgOpts={this.props.smbgOpts}
           xScale={this.props.xScale}
           yScale={this.props.yScale}
@@ -314,13 +314,15 @@ TrendsSVGContainer.propTypes = {
     saturday: PropTypes.bool.isRequired,
     sunday: PropTypes.bool.isRequired,
   }).isRequired,
-  bgBounds: PropTypes.shape({
-    veryHighThreshold: PropTypes.number.isRequired,
-    targetUpperBound: PropTypes.number.isRequired,
-    targetLowerBound: PropTypes.number.isRequired,
-    veryLowThreshold: PropTypes.number.isRequired,
+  bgPrefs: PropTypes.shape({
+    bgBounds: PropTypes.shape({
+      veryHighThreshold: PropTypes.number.isRequired,
+      targetUpperBound: PropTypes.number.isRequired,
+      targetLowerBound: PropTypes.number.isRequired,
+      veryLowThreshold: PropTypes.number.isRequired,
+    }).isRequired,
+    bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
   }).isRequired,
-  bgUnits: PropTypes.oneOf([MGDL_UNITS, MMOLL_UNITS]).isRequired,
   containerHeight: PropTypes.number.isRequired,
   containerWidth: PropTypes.number.isRequired,
   smbgData: PropTypes.arrayOf(PropTypes.shape({

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,8 @@ import RangeSelect from './components/trends/cbg/RangeSelect';
 
 import TwoOptionToggle from './components/common/controls/TwoOptionToggle';
 
-import PumpSettingsContainer from './containers/settings/PumpSettingsContainer';
-import TrendsContainer from './containers/trends/TrendsContainer';
+import PumpSettingsContainer from './components/settings/common/PumpSettingsContainer';
+import TrendsContainer from './components/trends/common/TrendsContainer';
 
 import vizReducer from './redux/reducers/';
 

--- a/src/utils/apidocs/datetime.md
+++ b/src/utils/apidocs/datetime.md
@@ -1,5 +1,5 @@
 
-> @tidepool/viz@0.7.14 apidocs /Users/janabeck/Tidepool/viz
+> @tidepool/viz@0.7.16 apidocs /Volumes/Tidepool/viz
 > jsdoc2md "src/utils/datetime.js"
 
 ## Functions
@@ -8,17 +8,23 @@
 <dt><a href="#getTimezoneFromTimePrefs">getTimezoneFromTimePrefs(timePrefs)</a> ⇒ <code>String</code></dt>
 <dd><p>getTimezoneFromTimePrefs</p>
 </dd>
+<dt><a href="#formatBirthdate">formatBirthdate(patient)</a> ⇒ <code>String</code></dt>
+<dd><p>formatBirthdate</p>
+</dd>
+<dt><a href="#formatClocktimeFromMsPer24">formatClocktimeFromMsPer24(duration, [format])</a> ⇒ <code>String</code></dt>
+<dd><p>formatClocktimeFromMsPer24</p>
+</dd>
+<dt><a href="#formatDiagnosisDate">formatDiagnosisDate(patient)</a> ⇒ <code>String</code></dt>
+<dd><p>formatDiagnosisDate</p>
+</dd>
+<dt><a href="#formatLocalizedFromUTC">formatLocalizedFromUTC(utc, timePrefs, [format])</a> ⇒ <code>String</code></dt>
+<dd><p>formatLocalizedFromUTC</p>
+</dd>
 <dt><a href="#getHammertimeFromDatumWithTimePrefs">getHammertimeFromDatumWithTimePrefs(datum, timePrefs)</a> ⇒ <code>Number</code></dt>
 <dd><p>getHammertimeFromDatumWithTimePrefs</p>
 </dd>
 <dt><a href="#getLocalizedCeiling">getLocalizedCeiling(utc, timePrefs)</a> ⇒ <code>Object</code></dt>
 <dd><p>getLocalizedCeiling</p>
-</dd>
-<dt><a href="#formatClocktimeFromMsPer24">formatClocktimeFromMsPer24(duration, [format])</a> ⇒ <code>String</code></dt>
-<dd><p>formatClocktimeFromMsPer24</p>
-</dd>
-<dt><a href="#formatLocalizedFromUTC">formatLocalizedFromUTC(utc, timePrefs, [format])</a> ⇒ <code>String</code></dt>
-<dd><p>formatLocalizedFromUTC</p>
 </dd>
 </dl>
 
@@ -33,6 +39,57 @@ getTimezoneFromTimePrefs
 | Param | Type | Description |
 | --- | --- | --- |
 | timePrefs | <code>Object</code> | object containing timezoneAware Boolean and timezoneName String |
+
+<a name="formatBirthdate"></a>
+
+## formatBirthdate(patient) ⇒ <code>String</code>
+formatBirthdate
+
+**Kind**: global function  
+**Returns**: <code>String</code> - formatted birthdate, e.g., 'Jul 4, 1975'; empty String if none found  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| patient | <code>Object</code> | Tidepool patient object containing profile |
+
+<a name="formatClocktimeFromMsPer24"></a>
+
+## formatClocktimeFromMsPer24(duration, [format]) ⇒ <code>String</code>
+formatClocktimeFromMsPer24
+
+**Kind**: global function  
+**Returns**: <code>String</code> - formatted clocktime, e.g., '12:05 pm'  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| duration | <code>Number</code> | positive integer representing a time of day                            in milliseconds within a 24-hr day |
+| [format] | <code>String</code> | optional moment display format string; default is 'h:mm a' |
+
+<a name="formatDiagnosisDate"></a>
+
+## formatDiagnosisDate(patient) ⇒ <code>String</code>
+formatDiagnosisDate
+
+**Kind**: global function  
+**Returns**: <code>String</code> - formatted diagnosis date, e.g., 'Jul 4, 1975'; empty String if none found  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| patient | <code>Object</code> | Tidepool patient object containing profile |
+
+<a name="formatLocalizedFromUTC"></a>
+
+## formatLocalizedFromUTC(utc, timePrefs, [format]) ⇒ <code>String</code>
+formatLocalizedFromUTC
+
+**Kind**: global function  
+**Returns**: <code>String</code> - formatted datetime, e.g., 'Sunday, January 1'  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| utc | <code>String</code> | Zulu timestamp (Integer hammertime also OK) |
+| timePrefs | <code>Object</code> | object containing timezoneAware Boolean and timezoneName String |
+| [format] | <code>String</code> | optional moment display format string; default is 'dddd, MMMM D' |
 
 <a name="getHammertimeFromDatumWithTimePrefs"></a>
 
@@ -60,31 +117,4 @@ getLocalizedCeiling
 | --- | --- | --- |
 | utc | <code>String</code> | Zulu timestamp (Integer hammertime also OK) |
 | timePrefs | <code>Object</code> | object containing timezoneAware Boolean and timezoneName String |
-
-<a name="formatClocktimeFromMsPer24"></a>
-
-## formatClocktimeFromMsPer24(duration, [format]) ⇒ <code>String</code>
-formatClocktimeFromMsPer24
-
-**Kind**: global function  
-**Returns**: <code>String</code> - formatted clocktime, e.g., '12:05 pm'  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| duration | <code>Number</code> | positive integer representing a time of day                            in milliseconds within a 24-hr day |
-| [format] | <code>String</code> | optional moment display format string; default is 'h:mm a' |
-
-<a name="formatLocalizedFromUTC"></a>
-
-## formatLocalizedFromUTC(utc, timePrefs, [format]) ⇒ <code>String</code>
-formatLocalizedFromUTC
-
-**Kind**: global function  
-**Returns**: <code>String</code> - formatted datetime, e.g., 'Sunday, January 1'  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| utc | <code>String</code> | Zulu timestamp (Integer hammertime also OK) |
-| timePrefs | <code>Object</code> | object containing timezoneAware Boolean and timezoneName String |
-| [format] | <code>String</code> | optional moment display format string; default is 'dddd, MMMM D' |
 

--- a/src/utils/apidocs/format.md
+++ b/src/utils/apidocs/format.md
@@ -1,0 +1,42 @@
+
+> @tidepool/viz@0.7.16 apidocs /Volumes/Tidepool/viz
+> jsdoc2md "src/utils/format.js"
+
+## Functions
+
+<dl>
+<dt><a href="#formatBgValue">formatBgValue(val, bgPrefs, [outOfRangeThresholds])</a> ⇒ <code>String</code></dt>
+<dd><p>formatBgValue</p>
+</dd>
+<dt><a href="#formatDecimalNumber">formatDecimalNumber(val, [places])</a> ⇒ <code>String</code></dt>
+<dd><p>formatDecimalNumber</p>
+</dd>
+</dl>
+
+<a name="formatBgValue"></a>
+
+## formatBgValue(val, bgPrefs, [outOfRangeThresholds]) ⇒ <code>String</code>
+formatBgValue
+
+**Kind**: global function  
+**Returns**: <code>String</code> - formatted blood glucose value  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| val | <code>Number</code> | integer or float blood glucose value in either mg/dL or mmol/L |
+| bgPrefs | <code>Object</code> | object containing bgUnits String and bgBounds Object |
+| [outOfRangeThresholds] | <code>Object</code> | optional thresholds for `low` and `high` values;                                          derived from annotations in PwD's data, so may not exist |
+
+<a name="formatDecimalNumber"></a>
+
+## formatDecimalNumber(val, [places]) ⇒ <code>String</code>
+formatDecimalNumber
+
+**Kind**: global function  
+**Returns**: <code>String</code> - numeric value rounded to the desired number of decimal places  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| val | <code>Number</code> | numeric value to format |
+| [places] | <code>Number</code> | optional number of decimal places to display;                            if not provided, will display as integer (0 decimal places) |
+

--- a/src/utils/apidocs/misc.md
+++ b/src/utils/apidocs/misc.md
@@ -1,0 +1,16 @@
+
+> @tidepool/viz@0.7.16 apidocs /Volumes/Tidepool/viz
+> jsdoc2md "src/utils/misc.js"
+
+<a name="getPatientFullName"></a>
+
+## getPatientFullName(patient) ⇒ <code>String</code>
+getPatientFullName
+
+**Kind**: global function  
+**Returns**: <code>String</code> - PwD's full name (first & last)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| patient | <code>Object</code> | Tidepool patient object containing profile |
+

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -20,7 +20,7 @@
 
 import _ from 'lodash';
 
-import { displayDecimal } from './format';
+import { formatDecimalNumber } from './format';
 
 /**
  * fixFloatingPoint
@@ -29,7 +29,7 @@ import { displayDecimal } from './format';
  * @return {Number} numeric value rounded to 3 decimal places
  */
 function fixFloatingPoint(n) {
-  return parseFloat(displayDecimal(n, 3));
+  return parseFloat(formatDecimalNumber(n, 3));
 }
 
 /**

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -66,8 +66,9 @@ export function getTimezoneFromTimePrefs(timePrefs) {
 
 /**
  * formatBirthdate
- * @param  {Object} patient   the patient object that contains the profile
- * @return {String}           MMM D, YYYY formated birthday or empty if none
+ * @param {Object} patient - Tidepool patient object containing profile
+ *
+ * @return {String} formatted birthdate, e.g., 'Jul 4, 1975'; empty String if none found
  */
 export function formatBirthdate(patient) {
   const bday = _.get(patient, ['profile', 'patient', 'birthday'], '');
@@ -95,8 +96,9 @@ export function formatClocktimeFromMsPer24(milliseconds, format = 'h:mm a') {
 
 /**
  * formatDiagnosisDate
- * @param  {Object} patient   the patient object that contains the profile
- * @return {String}           MMM D, YYYY formated diagnosisDate or empty if none
+ * @param {Object} patient - Tidepool patient object containing profile
+ *
+ * @return {String} formatted diagnosis date, e.g., 'Jul 4, 1975'; empty String if none found
  */
 export function formatDiagnosisDate(patient) {
   const diagnosis = _.get(patient, ['profile', 'patient', 'diagnosisDate'], '');

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -93,21 +93,6 @@ export function formatBgValue(val, bgPrefs, outOfRangeThresholds) {
 }
 
 /**
- * patientFullName
- * @param  {Object} patient   the patient object that contains the profile
- * @return {String}           fullName of patient or empty if there is none
- */
-export function patientFullName(patient) {
-  const profile = _.get(patient, ['profile'], {});
-  const patientInfo = profile.patient || {};
-
-  if (patientInfo.isOtherPerson) {
-    return patientInfo.fullName;
-  }
-  return profile.fullName;
-}
-
-/**
  * birthday
  * @param  {Object} patient   the patient object that contains the profile
  * @return {String}           MMM D, YYYY formated birthday or empty if none

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -43,12 +43,14 @@ import { convertToMmolL } from './bloodglucose';
 import { BG_HIGH, BG_LOW, MMOLL_UNITS } from './constants';
 
 /**
- * displayDecimal
- * @param  {Number} val    numeric value to format
- * @param  {Number} places number of decimal places to displayDecimal
- * @return {String}        val formatted to places decimal places
+ * formatDecimalNumber
+ * @param {Number} val - numeric value to format
+ * @param {Number} [places] - optional number of decimal places to display;
+ *                            if not provided, will display as integer (0 decimal places)
+ *
+ * @return {String} numeric value rounded to the desired number of decimal places
  */
-export function displayDecimal(val, places) {
+export function formatDecimalNumber(val, places) {
   if (places === null || places === undefined) {
     return format('d')(val);
   }

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -58,14 +58,16 @@ export function formatDecimalNumber(val, places) {
 }
 
 /**
- * displayBgValue
+ * formatBgValue
  * @param {Number} val - integer or float blood glucose value in either mg/dL or mmol/L
- * @param {String} units - 'mg/dL' or 'mmol/L'
- * @param {Object} outOfRangeThresholds - specifies thresholds for `low` and `high` values
+ * @param {Object} bgPrefs - object containing bgUnits String and bgBounds Object
+ * @param {Object} [outOfRangeThresholds] - optional thresholds for `low` and `high` values;
+ *                                          derived from annotations in PwD's data, so may not exist
  *
- * @return {String} stringBgValue
+ * @return {String} formatted blood glucose value
  */
-export function displayBgValue(val, units, outOfRangeThresholds) {
+export function formatBgValue(val, bgPrefs, outOfRangeThresholds) {
+  const units = _.get(bgPrefs, 'bgUnits', '');
   if (!_.isEmpty(outOfRangeThresholds)) {
     let lowThreshold = outOfRangeThresholds.low;
     let highThreshold = outOfRangeThresholds.high;

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -28,7 +28,9 @@
  *
  * 2. Function naming scheme: the main verb here is `format`. Start all function names with that.
  *
- * 3. Try to be consistent in how params are used:
+ * 3. Function organizational scheme in this file and tests file: alphabetical plz
+ *
+ * 4. Try to be consistent in how params are used:
  * (e.g., always pass in `bgPrefs`) rather than some (subset) of bgUnits and/or bgBounds
  * and try to copy & paste JSDoc @param descriptions for common params.
  *
@@ -36,26 +38,8 @@
 
 import _ from 'lodash';
 import { format } from 'd3-format';
-// using d3-time-format because time is time of data access in
-// user’s browser time, not PwD’s configured timezone
-import { utcFormat } from 'd3-time-format';
 import { convertToMmolL } from './bloodglucose';
 import { BG_HIGH, BG_LOW, MMOLL_UNITS } from './constants';
-
-/**
- * formatDecimalNumber
- * @param {Number} val - numeric value to format
- * @param {Number} [places] - optional number of decimal places to display;
- *                            if not provided, will display as integer (0 decimal places)
- *
- * @return {String} numeric value rounded to the desired number of decimal places
- */
-export function formatDecimalNumber(val, places) {
-  if (places === null || places === undefined) {
-    return format('d')(val);
-  }
-  return format(`.${places}f`)(val);
-}
 
 /**
  * formatBgValue
@@ -93,27 +77,16 @@ export function formatBgValue(val, bgPrefs, outOfRangeThresholds) {
 }
 
 /**
- * birthday
- * @param  {Object} patient   the patient object that contains the profile
- * @return {String}           MMM D, YYYY formated birthday or empty if none
+ * formatDecimalNumber
+ * @param {Number} val - numeric value to format
+ * @param {Number} [places] - optional number of decimal places to display;
+ *                            if not provided, will display as integer (0 decimal places)
+ *
+ * @return {String} numeric value rounded to the desired number of decimal places
  */
-export function birthday(patient) {
-  const bday = _.get(patient, ['profile', 'patient', 'birthday'], '');
-  if (bday) {
-    return utcFormat('%b %-d, %Y')(Date.parse(bday));
+export function formatDecimalNumber(val, places) {
+  if (places === null || places === undefined) {
+    return format('d')(val);
   }
-  return '';
-}
-
-/**
- * diagnosisDate
- * @param  {Object} patient   the patient object that contains the profile
- * @return {String}           MMM D, YYYY formated diagnosisDate or empty if none
- */
-export function diagnosisDate(patient) {
-  const diagnosis = _.get(patient, ['profile', 'patient', 'diagnosisDate'], '');
-  if (diagnosis) {
-    return utcFormat('%b %-d, %Y')(Date.parse(diagnosis));
-  }
-  return '';
+  return format(`.${places}f`)(val);
 }

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -15,6 +15,25 @@
  * == BSD2 LICENSE ==
  */
 
+/*
+ * Guidelines for these utilities:
+ *
+ * 1. Only "workhorse" functions used in 2+ places should be here.
+ * 1a. A function used in multiple components for one view should live
+ * in view-specific utils: src/utils/[view]/format.js
+ * 1b. A function used in only one component should just be part of that component,
+ * potentially as a named export if tests are deemed important to have.
+ * 1c. This set of utilities is ONLY for NON-datetime related formatting. Any functions
+ * used for formatting dates and/or times should go in src/utils/datetime.js
+ *
+ * 2. Function naming scheme: the main verb here is `format`. Start all function names with that.
+ *
+ * 3. Try to be consistent in how params are used:
+ * (e.g., always pass in `bgPrefs`) rather than some (subset) of bgUnits and/or bgBounds
+ * and try to copy & paste JSDoc @param descriptions for common params.
+ *
+ */
+
 import _ from 'lodash';
 import { format } from 'd3-format';
 // using d3-time-format because time is time of data access in

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,0 +1,34 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import _ from 'lodash';
+
+/**
+ * getPatientFullName
+ * @param {Object} patient - Tidepool patient object containing profile
+ *
+ * @return {String} PwD's full name
+ */
+export function getPatientFullName(patient) {
+  const profile = _.get(patient, ['profile'], {});
+  const patientInfo = profile.patient || {};
+
+  if (patientInfo.isOtherPerson) {
+    return patientInfo.fullName;
+  }
+  return profile.fullName;
+}

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -21,7 +21,7 @@ import _ from 'lodash';
  * getPatientFullName
  * @param {Object} patient - Tidepool patient object containing profile
  *
- * @return {String} PwD's full name
+ * @return {String} PwD's full name (first & last)
  */
 export function getPatientFullName(patient) {
   const profile = _.get(patient, ['profile'], {});

--- a/src/utils/settings/data.js
+++ b/src/utils/settings/data.js
@@ -47,7 +47,7 @@ function getBasalRate(scheduleData, startTime) {
   if (noData(rate)) {
     return '';
   }
-  return format.displayDecimal(rate, DISPLAY_PRECISION_PLACES);
+  return format.formatDecimalNumber(rate, DISPLAY_PRECISION_PLACES);
 }
 
 /**
@@ -121,7 +121,7 @@ export function getTotalBasalRates(scheduleData) {
     const amount = parseFloat(scheduleData[i].rate.toFixed(DISPLAY_PRECISION_PLACES)) * hrs;
     total += parseFloat(amount.toFixed(DISPLAY_PRECISION_PLACES));
   }
-  return format.displayDecimal(total, DISPLAY_PRECISION_PLACES);
+  return format.formatDecimalNumber(total, DISPLAY_PRECISION_PLACES);
 }
 
 /**

--- a/src/utils/settings/data.js
+++ b/src/utils/settings/data.js
@@ -85,7 +85,7 @@ function getBloodGlucoseValue(scheduleData, fieldName, startTime, units) {
   if (noData(bgValue)) {
     return '';
   }
-  return format.displayBgValue(bgValue, units);
+  return format.formatBgValue(bgValue, { bgUnits: units });
 }
 
 /**

--- a/src/utils/settings/textData.js
+++ b/src/utils/settings/textData.js
@@ -24,7 +24,8 @@ import { timeFormat } from 'd3-time-format';
 import * as tandemData from './tandemData';
 import * as nonTandemData from './nonTandemData';
 
-import { patientFullName, birthday, diagnosisDate } from '../format';
+import { birthday, diagnosisDate } from '../format';
+import { getPatientFullName } from '../misc';
 
 
 /**
@@ -107,7 +108,7 @@ function formatTitle(patient) {
   `Exported from Tidepool: ${timeFormat('%b %-d, %Y')(new Date())}`;
   const bday = `Date of birth: ${birthday(patient)}`;
   const diagnosis = `Date of diagnosis: ${diagnosisDate(patient)}`;
-  const fullname = patientFullName(patient);
+  const fullname = getPatientFullName(patient);
   return `${fullname}\n${bday}\n${diagnosis}\n${exported}\n`;
 }
 

--- a/src/utils/settings/textData.js
+++ b/src/utils/settings/textData.js
@@ -24,7 +24,7 @@ import { timeFormat } from 'd3-time-format';
 import * as tandemData from './tandemData';
 import * as nonTandemData from './nonTandemData';
 
-import { birthday, diagnosisDate } from '../format';
+import { formatBirthdate, formatDiagnosisDate } from '../datetime';
 import { getPatientFullName } from '../misc';
 
 
@@ -106,8 +106,8 @@ function buildTextTable(name, rows, columns) {
 function formatTitle(patient) {
   const exported =
   `Exported from Tidepool: ${timeFormat('%b %-d, %Y')(new Date())}`;
-  const bday = `Date of birth: ${birthday(patient)}`;
-  const diagnosis = `Date of diagnosis: ${diagnosisDate(patient)}`;
+  const bday = `Date of birth: ${formatBirthdate(patient)}`;
+  const diagnosis = `Date of diagnosis: ${formatDiagnosisDate(patient)}`;
   const fullname = getPatientFullName(patient);
   return `${fullname}\n${bday}\n${diagnosis}\n${exported}\n`;
 }

--- a/test/components/settings/NonTandem.test.js
+++ b/test/components/settings/NonTandem.test.js
@@ -208,10 +208,12 @@ describe('NonTandem', () => {
         const bgTargetTable = wrapper.find('table')
           .filterWhere(n => (n.text().search('BG Target') !== -1));
         expect(bgTargetTable.someWhere(
-          n => (n.text().search(formatDecimalNumber(animasMultiRateData.bgTarget[0].target), 1) !== -1)
+          n => (n.text()
+            .search(formatDecimalNumber(animasMultiRateData.bgTarget[0].target), 1) !== -1)
         )).to.be.true;
         expect(bgTargetTable.someWhere(
-          n => (n.text().search(formatDecimalNumber(animasMultiRateData.bgTarget[0].range), 1) !== -1)
+          n => (n.text()
+            .search(formatDecimalNumber(animasMultiRateData.bgTarget[0].range), 1) !== -1)
         )).to.be.true;
       });
 

--- a/test/components/settings/NonTandem.test.js
+++ b/test/components/settings/NonTandem.test.js
@@ -24,7 +24,7 @@ import { mount, shallow } from 'enzyme';
 import CollapsibleContainer from '../../../src/components/settings/common/CollapsibleContainer';
 import NonTandem from '../../../src/components/settings/NonTandem';
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../src/utils/constants';
-import { displayDecimal } from '../../../src/utils/format';
+import { formatDecimalNumber } from '../../../src/utils/format';
 
 import { formatClassesAsSelector } from '../../helpers/cssmodules';
 import styles from '../../../src/components/settings/NonTandem.css';
@@ -187,7 +187,7 @@ describe('NonTandem', () => {
         const isfTable = wrapper.find('table').filterWhere(n => (n.text().search('ISF') !== -1));
         expect(isfTable.someWhere(
           n => (n.text().search(
-            displayDecimal(animasMultiRateData.insulinSensitivity[0].amount, 1)
+            formatDecimalNumber(animasMultiRateData.insulinSensitivity[0].amount, 1)
           ) !== -1)
         )).to.be.true;
       });
@@ -208,10 +208,10 @@ describe('NonTandem', () => {
         const bgTargetTable = wrapper.find('table')
           .filterWhere(n => (n.text().search('BG Target') !== -1));
         expect(bgTargetTable.someWhere(
-          n => (n.text().search(displayDecimal(animasMultiRateData.bgTarget[0].target), 1) !== -1)
+          n => (n.text().search(formatDecimalNumber(animasMultiRateData.bgTarget[0].target), 1) !== -1)
         )).to.be.true;
         expect(bgTargetTable.someWhere(
-          n => (n.text().search(displayDecimal(animasMultiRateData.bgTarget[0].range), 1) !== -1)
+          n => (n.text().search(formatDecimalNumber(animasMultiRateData.bgTarget[0].range), 1) !== -1)
         )).to.be.true;
       });
 
@@ -356,7 +356,7 @@ describe('NonTandem', () => {
           .filterWhere(n => (n.text().search('Correction factor') !== -1));
         expect(isfTable.someWhere(
           n => (n.text().search(
-            displayDecimal(omnipodMultiRateData.insulinSensitivity[0].amount, 1)
+            formatDecimalNumber(omnipodMultiRateData.insulinSensitivity[0].amount, 1)
           ) !== -1)
         )).to.be.true;
       });
@@ -379,11 +379,11 @@ describe('NonTandem', () => {
 
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(omnipodMultiRateData.bgTarget[0].target), 1) !== -1)
+            formatDecimalNumber(omnipodMultiRateData.bgTarget[0].target), 1) !== -1)
         )).to.be.true;
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(omnipodMultiRateData.bgTarget[0].high), 1) !== -1)
+            formatDecimalNumber(omnipodMultiRateData.bgTarget[0].high), 1) !== -1)
         )).to.be.true;
       });
 
@@ -586,7 +586,7 @@ describe('NonTandem', () => {
           .filterWhere(n => (n.text().search('Sensitivity') !== -1));
         expect(isfTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.insulinSensitivity[0].amount, 1)
+            formatDecimalNumber(medtronicMultiRateData.insulinSensitivity[0].amount, 1)
           ) !== -1)
         )).to.be.true;
       });
@@ -609,33 +609,33 @@ describe('NonTandem', () => {
 
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.bgTarget[0].low), 1)
+            formatDecimalNumber(medtronicMultiRateData.bgTarget[0].low), 1)
           ) !== -1)
         ).to.be.true;
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.bgTarget[0].high), 1)
+            formatDecimalNumber(medtronicMultiRateData.bgTarget[0].high), 1)
           ) !== -1)
         ).to.be.true;
 
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.bgTarget[1].low), 1)
+            formatDecimalNumber(medtronicMultiRateData.bgTarget[1].low), 1)
           ) !== -1)
         ).to.be.true;
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.bgTarget[1].high), 1)
+            formatDecimalNumber(medtronicMultiRateData.bgTarget[1].high), 1)
           ) !== -1)
         ).to.be.true;
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.bgTarget[2].low), 1)
+            formatDecimalNumber(medtronicMultiRateData.bgTarget[2].low), 1)
           ) !== -1)
         ).to.be.true;
         expect(bgTargetTable.someWhere(
           n => (n.text().search(
-            displayDecimal(medtronicMultiRateData.bgTarget[2].high), 1)
+            formatDecimalNumber(medtronicMultiRateData.bgTarget[2].high), 1)
           ) !== -1)
         ).to.be.true;
       });

--- a/test/components/settings/Tandem.test.js
+++ b/test/components/settings/Tandem.test.js
@@ -23,7 +23,7 @@ import { mount, shallow } from 'enzyme';
 import CollapsibleContainer from '../../../src/components/settings/common/CollapsibleContainer';
 import Tandem from '../../../src/components/settings/Tandem';
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../src/utils/constants';
-import { displayDecimal } from '../../../src/utils/format';
+import { formatDecimalNumber } from '../../../src/utils/format';
 
 import { formatClassesAsSelector } from '../../helpers/cssmodules';
 import styles from '../../../src/components/settings/Tandem.css';
@@ -134,25 +134,27 @@ describe('Tandem', () => {
 
     it('should surface the expected basal rate value', () => {
       expect(sickProfileTable.someWhere(
-        n => (n.text().search(displayDecimal(flatrateData.basalSchedules[1].value[0].rate, 1)))
+        n => (n.text().search(formatDecimalNumber(flatrateData.basalSchedules[1].value[0].rate, 1)))
       )).to.be.true;
     });
 
     it('should surface the expected target BG value', () => {
       expect(sickProfileTable.someWhere(
-        n => (n.text().search(displayDecimal(flatrateData.bgTargets.sick[0].target, 1)))
+        n => (n.text().search(formatDecimalNumber(flatrateData.bgTargets.sick[0].target, 1)))
       )).to.be.true;
     });
 
     it('should surface the expected carb ratio value', () => {
       expect(sickProfileTable.someWhere(
-        n => (n.text().search(displayDecimal(flatrateData.carbRatios.sick[0].target, 1)))
+        n => (n.text().search(formatDecimalNumber(flatrateData.carbRatios.sick[0].target, 1)))
       )).to.be.true;
     });
 
     it('should surface the expected correction factor value', () => {
       expect(sickProfileTable.someWhere(
-        n => (n.text().search(displayDecimal(flatrateData.insulinSensitivities.sick[0].target, 1)))
+        n => (n.text().search(
+          formatDecimalNumber(flatrateData.insulinSensitivities.sick[0].target, 1),
+        ))
       )).to.be.true;
     });
   });

--- a/test/components/settings/common/PumpSettingsContainer.test.js
+++ b/test/components/settings/common/PumpSettingsContainer.test.js
@@ -22,15 +22,15 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { PumpSettingsContainer, mapStateToProps, mapDispatchToProps }
-  from '../../../src/containers/settings/PumpSettingsContainer';
-import NonTandem from '../../../src/components/settings/NonTandem';
-import Tandem from '../../../src/components/settings/Tandem';
-import { MGDL_UNITS } from '../../../src/utils/constants';
+  from '../../../../src/components/settings/common/PumpSettingsContainer';
+import NonTandem from '../../../../src/components/settings/NonTandem';
+import Tandem from '../../../../src/components/settings/Tandem';
+import { MGDL_UNITS } from '../../../../src/utils/constants';
 
-const animasSettings = require('../../../data/pumpSettings/animas/multirate.json');
-const medtronicSettings = require('../../../data/pumpSettings/medtronic/multirate.json');
-const omnipodSettings = require('../../../data/pumpSettings/omnipod/multirate.json');
-const tandemSettings = require('../../../data/pumpSettings/tandem/multirate.json');
+const animasSettings = require('../../../../data/pumpSettings/animas/multirate.json');
+const medtronicSettings = require('../../../../data/pumpSettings/medtronic/multirate.json');
+const omnipodSettings = require('../../../../data/pumpSettings/omnipod/multirate.json');
+const tandemSettings = require('../../../../data/pumpSettings/tandem/multirate.json');
 
 describe('PumpSettingsContainer', () => {
   const user = {

--- a/test/components/trends/cbg/CBGDateTracesAnimationContainer.test.js
+++ b/test/components/trends/cbg/CBGDateTracesAnimationContainer.test.js
@@ -20,11 +20,11 @@ import React from 'react';
 import TransitionGroupPlus from 'react-transition-group-plus';
 import { shallow } from 'enzyme';
 
-import bgBounds from '../../helpers/bgBounds';
-import CBGDateTraceAnimated from '../../../src/components/trends/cbg/CBGDateTraceAnimated';
+import bgBounds from '../../../helpers/bgBounds';
+import CBGDateTraceAnimated from '../../../../src/components/trends/cbg/CBGDateTraceAnimated';
 
 import CBGDateTracesAnimationContainer
-  from '../../../src/containers/trends/CBGDateTracesAnimationContainer';
+  from '../../../../src/components/trends/cbg/CBGDateTracesAnimationContainer';
 
 describe('CBGDateTracesAnimationContainer', () => {
   const props = {

--- a/test/components/trends/cbg/CBGSlicesContainer.test.js
+++ b/test/components/trends/cbg/CBGSlicesContainer.test.js
@@ -20,19 +20,19 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 
-import * as scales from '../../helpers/scales';
+import * as scales from '../../../helpers/scales';
 const {
   trendsWidth: width,
   trendsHeight: height,
   trendsXScale: xScale,
   trendsYScale: yScale,
 } = scales.trends;
-import bgBounds from '../../helpers/bgBounds';
+import bgBounds from '../../../helpers/bgBounds';
 
-import { THREE_HRS, TWENTY_FOUR_HRS } from '../../../src/utils/datetime';
+import { THREE_HRS, TWENTY_FOUR_HRS } from '../../../../src/utils/datetime';
 import CBGSlicesContainer
-  from '../../../src/containers/trends/CBGSlicesContainer';
-import CBGSliceAnimated from '../../../src/components/trends/cbg/CBGSliceAnimated';
+  from '../../../../src/components/trends/cbg/CBGSlicesContainer';
+import CBGSliceAnimated from '../../../../src/components/trends/cbg/CBGSliceAnimated';
 
 describe('CBGSlicesContainer', () => {
   let wrapper;

--- a/test/components/trends/common/FocusedRangeLabels.test.js
+++ b/test/components/trends/common/FocusedRangeLabels.test.js
@@ -27,7 +27,9 @@ import styles from '../../../../src/components/trends/common/FocusedRangeLabels.
 
 describe('FocusedRangeLabels', () => {
   const props = {
-    bgUnits: MGDL_UNITS,
+    bgPrefs: {
+      bgUnits: MGDL_UNITS,
+    },
     focusedKeys: null,
     focusedRange: null,
     focusedSlice: null,

--- a/test/components/trends/common/TrendsContainer.test.js
+++ b/test/components/trends/common/TrendsContainer.test.js
@@ -24,9 +24,9 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../../src/utils/constants';
-import { getLocalizedCeiling } from '../../../src/utils/datetime';
-import DummyComponent from '../../helpers/DummyComponent';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../../src/utils/constants';
+import { getLocalizedCeiling } from '../../../../src/utils/datetime';
+import DummyComponent from '../../../helpers/DummyComponent';
 
 import {
   TrendsContainer,
@@ -35,8 +35,8 @@ import {
   getLocalizedOffset,
   mapStateToProps,
   mapDispatchToProps,
-} from '../../../src/containers/trends/TrendsContainer';
-import TrendsSVGContainer from '../../../src/containers/trends/TrendsSVGContainer';
+} from '../../../../src/components/trends/common/TrendsContainer';
+import TrendsSVGContainer from '../../../../src/components/trends/common/TrendsSVGContainer';
 
 describe('TrendsContainer', () => {
   // stubbing console.warn gets rid of the annoying warnings from react-dimensions

--- a/test/components/trends/common/TrendsSVGContainer.test.js
+++ b/test/components/trends/common/TrendsSVGContainer.test.js
@@ -20,22 +20,22 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import bgBounds from '../../helpers/bgBounds';
+import bgBounds from '../../../helpers/bgBounds';
 
-import { TrendsSVGContainer } from '../../../src/containers/trends/TrendsSVGContainer';
+import { TrendsSVGContainer } from '../../../../src/components/trends/common/TrendsSVGContainer';
 
-import { MGDL_UNITS } from '../../../src/utils/constants';
+import { MGDL_UNITS } from '../../../../src/utils/constants';
 import Background
-  from '../../../src/components/trends/common/Background';
+  from '../../../../src/components/trends/common/Background';
 import CBGSlicesContainer
-  from '../../../src/containers/trends/CBGSlicesContainer';
+  from '../../../../src/components/trends/cbg/CBGSlicesContainer';
 import SMBGRangeAvgContainer
-  from '../../../src/containers/trends/SMBGRangeAvgContainer';
-import NoData from '../../../src/components/trends/common/NoData';
-import TargetRangeLines from '../../../src/components/trends/common/TargetRangeLines';
-import XAxisLabels from '../../../src/components/trends/common/XAxisLabels';
-import XAxisTicks from '../../../src/components/trends/common/XAxisTicks';
-import YAxisLabelsAndTicks from '../../../src/components/trends/common/YAxisLabelsAndTicks';
+  from '../../../../src/components/trends/smbg/SMBGRangeAvgContainer';
+import NoData from '../../../../src/components/trends/common/NoData';
+import TargetRangeLines from '../../../../src/components/trends/common/TargetRangeLines';
+import XAxisLabels from '../../../../src/components/trends/common/XAxisLabels';
+import XAxisTicks from '../../../../src/components/trends/common/XAxisTicks';
+import YAxisLabelsAndTicks from '../../../../src/components/trends/common/YAxisLabelsAndTicks';
 
 function makeScale(scale) {
   // eslint-disable-next-line no-param-reassign

--- a/test/components/trends/common/YAxisLabelsAndTicks.test.js
+++ b/test/components/trends/common/YAxisLabelsAndTicks.test.js
@@ -34,8 +34,10 @@ import YAxisLabelsAndTicks from '../../../../src/components/trends/common/YAxisL
 describe('YAxisLabelsAndTicks', () => {
   let wrapper;
   const props = {
-    bgBounds,
-    bgUnits: MGDL_UNITS,
+    bgPrefs: {
+      bgBounds,
+      bgUnits: MGDL_UNITS,
+    },
     margins: {
       top: 0,
       right: 0,
@@ -56,19 +58,19 @@ describe('YAxisLabelsAndTicks', () => {
   it('should render three tick lines and three text labels', () => {
     const lines = wrapper.find('line');
     expect(lines).to.have.length(4);
-    expect(lines.at(0).prop('y1')).to.equal(yScale(props.bgBounds.targetLowerBound));
-    expect(lines.at(0).prop('y2')).to.equal(yScale(props.bgBounds.targetLowerBound));
-    expect(lines.at(1).prop('y1')).to.equal(yScale(props.bgBounds.targetUpperBound));
-    expect(lines.at(1).prop('y2')).to.equal(yScale(props.bgBounds.targetUpperBound));
-    expect(lines.at(2).prop('y1')).to.equal(yScale(props.bgBounds.veryHighThreshold));
-    expect(lines.at(2).prop('y2')).to.equal(yScale(props.bgBounds.veryHighThreshold));
-    expect(lines.at(3).prop('y1')).to.equal(yScale(props.bgBounds.veryLowThreshold));
-    expect(lines.at(3).prop('y2')).to.equal(yScale(props.bgBounds.veryLowThreshold));
+    expect(lines.at(0).prop('y1')).to.equal(yScale(props.bgPrefs.bgBounds.targetLowerBound));
+    expect(lines.at(0).prop('y2')).to.equal(yScale(props.bgPrefs.bgBounds.targetLowerBound));
+    expect(lines.at(1).prop('y1')).to.equal(yScale(props.bgPrefs.bgBounds.targetUpperBound));
+    expect(lines.at(1).prop('y2')).to.equal(yScale(props.bgPrefs.bgBounds.targetUpperBound));
+    expect(lines.at(2).prop('y1')).to.equal(yScale(props.bgPrefs.bgBounds.veryHighThreshold));
+    expect(lines.at(2).prop('y2')).to.equal(yScale(props.bgPrefs.bgBounds.veryHighThreshold));
+    expect(lines.at(3).prop('y1')).to.equal(yScale(props.bgPrefs.bgBounds.veryLowThreshold));
+    expect(lines.at(3).prop('y2')).to.equal(yScale(props.bgPrefs.bgBounds.veryLowThreshold));
     const labels = wrapper.find('text');
     expect(labels).to.have.length(4);
-    expect(labels.at(0).prop('y')).to.equal(yScale(props.bgBounds.targetLowerBound));
-    expect(labels.at(1).prop('y')).to.equal(yScale(props.bgBounds.targetUpperBound));
-    expect(labels.at(2).prop('y')).to.equal(yScale(props.bgBounds.veryHighThreshold));
-    expect(labels.at(3).prop('y')).to.equal(yScale(props.bgBounds.veryLowThreshold));
+    expect(labels.at(0).prop('y')).to.equal(yScale(props.bgPrefs.bgBounds.targetLowerBound));
+    expect(labels.at(1).prop('y')).to.equal(yScale(props.bgPrefs.bgBounds.targetUpperBound));
+    expect(labels.at(2).prop('y')).to.equal(yScale(props.bgPrefs.bgBounds.veryHighThreshold));
+    expect(labels.at(3).prop('y')).to.equal(yScale(props.bgPrefs.bgBounds.veryLowThreshold));
   });
 });

--- a/test/components/trends/smbg/FocusedSMBGPointLabel.test.js
+++ b/test/components/trends/smbg/FocusedSMBGPointLabel.test.js
@@ -63,7 +63,9 @@ describe('FocusedSMBGPointLabel', () => {
   describe('when no focused datum', () => {
     it('should render nothing', () => {
       const minimalProps = {
-        bgUnits: MMOLL_UNITS,
+        bgPrefs: {
+          bgUnits: MMOLL_UNITS,
+        },
       };
       const wrapper = mount(
         <FocusedSMBGPointLabel {...minimalProps} />
@@ -78,7 +80,7 @@ describe('FocusedSMBGPointLabel', () => {
     before(() => {
       wrapper = mount(
         <FocusedSMBGPointLabel
-          bgUnits={MGDL_UNITS}
+          bgPrefs={{ bgUnits: MGDL_UNITS }}
           focusedPoint={focusedPoint}
           lines={false}
           grouped
@@ -101,7 +103,7 @@ describe('FocusedSMBGPointLabel', () => {
     before(() => {
       wrapper = mount(
         <FocusedSMBGPointLabel
-          bgUnits={MGDL_UNITS}
+          bgPrefs={{ bgUnits: MGDL_UNITS }}
           focusedPoint={focusedPoint}
           lines={false}
           grouped={false}
@@ -124,7 +126,7 @@ describe('FocusedSMBGPointLabel', () => {
     before(() => {
       wrapper = mount(
         <FocusedSMBGPointLabel
-          bgUnits={MGDL_UNITS}
+          bgPrefs={{ bgUnits: MGDL_UNITS }}
           focusedPoint={focusedPoint}
           lines
           grouped
@@ -147,7 +149,7 @@ describe('FocusedSMBGPointLabel', () => {
     before(() => {
       wrapper = mount(
         <FocusedSMBGPointLabel
-          bgUnits={MGDL_UNITS}
+          bgPrefs={{ bgUnits: MGDL_UNITS }}
           focusedPoint={focusedPoint}
           lines
           grouped={false}

--- a/test/components/trends/smbg/SMBGRangeAvgContainer.test.js
+++ b/test/components/trends/smbg/SMBGRangeAvgContainer.test.js
@@ -19,17 +19,17 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import * as scales from '../../helpers/scales';
+import * as scales from '../../../helpers/scales';
 const {
   trendsXScale: xScale,
   trendsYScale: yScale,
 } = scales.trends;
-import bgBounds from '../../helpers/bgBounds';
-import { THREE_HRS } from '../../../src/utils/datetime';
+import bgBounds from '../../../helpers/bgBounds';
+import { THREE_HRS } from '../../../../src/utils/datetime';
 import SMBGRangeAvgContainer
-  from '../../../src/containers/trends/SMBGRangeAvgContainer';
+  from '../../../../src/components/trends/smbg/SMBGRangeAvgContainer';
 import SMBGRangeAnimated
-  from '../../../src/components/trends/smbg/SMBGRangeAnimated';
+  from '../../../../src/components/trends/smbg/SMBGRangeAnimated';
 
 describe('SMBGRangeAvgContainer', () => {
   let wrapper;

--- a/test/components/trends/smbg/SMBGsByDateContainer.test.js
+++ b/test/components/trends/smbg/SMBGsByDateContainer.test.js
@@ -20,20 +20,20 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { THREE_HRS } from '../../../src/utils/datetime';
+import { THREE_HRS } from '../../../../src/utils/datetime';
 
-import bgBounds from '../../helpers/bgBounds';
-import * as scales from '../../helpers/scales';
+import bgBounds from '../../../helpers/bgBounds';
+import * as scales from '../../../helpers/scales';
 const {
   trendsXScale: xScale,
   trendsYScale: yScale,
 } = scales.trends;
 
-import SMBGDateLineAnimated from '../../../src/components/trends/smbg/SMBGDateLineAnimated';
-import SMBGDatePointsAnimated from '../../../src/components/trends/smbg/SMBGDatePointsAnimated';
+import SMBGDateLineAnimated from '../../../../src/components/trends/smbg/SMBGDateLineAnimated';
+import SMBGDatePointsAnimated from '../../../../src/components/trends/smbg/SMBGDatePointsAnimated';
 
 import SMBGsByDateContainer
-  from '../../../src/containers/trends/SMBGsByDateContainer';
+  from '../../../../src/components/trends/smbg/SMBGsByDateContainer';
 
 describe('SMBGsByDateContainer', () => {
   let wrapper;

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -231,21 +231,25 @@ describe('TrendsContainer', () => {
     };
 
     const mgdl = {
-      bgUnits: MGDL_UNITS,
-      bgBounds: {
-        veryHighThreshold: 300,
-        targetUpperBound: 180,
-        targetLowerBound: 80,
-        veryLowThreshold: 60,
+      bgPrefs: {
+        bgUnits: MGDL_UNITS,
+        bgBounds: {
+          veryHighThreshold: 300,
+          targetUpperBound: 180,
+          targetLowerBound: 80,
+          veryLowThreshold: 60,
+        },
       },
     };
     const mmoll = {
-      bgUnits: MMOLL_UNITS,
-      bgBounds: {
-        veryHighThreshold: 30,
-        targetUpperBound: 10,
-        targetLowerBound: 4.4,
-        veryLowThreshold: 3.5,
+      bgPrefs: {
+        bgUnits: MMOLL_UNITS,
+        bgBounds: {
+          veryHighThreshold: 30,
+          targetUpperBound: 10,
+          targetLowerBound: 4.4,
+          veryLowThreshold: 3.5,
+        },
       },
     };
 
@@ -462,7 +466,9 @@ describe('TrendsContainer', () => {
         it('should have a minimum yScale domain: [targetLowerBound, yScaleClampTop]', () => {
           const { yScale } = minimalData.state();
           expect(yScale.domain())
-            .to.deep.equal([mgdl.bgBounds.targetLowerBound, props.yScaleClampTop[MGDL_UNITS]]);
+            .to.deep.equal(
+              [mgdl.bgPrefs.bgBounds.targetLowerBound, props.yScaleClampTop[MGDL_UNITS]]
+            );
         });
 
         it('should have a maximum yScale domain: [lowest generated value, yScaleClampTop]', () => {
@@ -490,7 +496,9 @@ describe('TrendsContainer', () => {
         it('should have a minimum yScale domain: [targetLowerBound, yScaleClampTop]', () => {
           const { yScale } = minimalDataMmol.state();
           expect(yScale.domain())
-            .to.deep.equal([mmoll.bgBounds.targetLowerBound, props.yScaleClampTop[MMOLL_UNITS]]);
+            .to.deep.equal(
+              [mmoll.bgPrefs.bgBounds.targetLowerBound, props.yScaleClampTop[MMOLL_UNITS]]
+            );
         });
 
         it('should have a maximum yScale domain: [lowest generated value, yScaleClampTop]', () => {

--- a/test/containers/trends/TrendsContainer.test.js
+++ b/test/containers/trends/TrendsContainer.test.js
@@ -686,6 +686,10 @@ describe('TrendsContainer', () => {
         });
 
         describe('selectDate', () => {
+          afterEach(() => {
+            props.onSelectDate.reset();
+          });
+
           it('should exist and be a function', () => {
             assert.isFunction(minimalData.instance().selectDate);
           });
@@ -693,19 +697,22 @@ describe('TrendsContainer', () => {
           const dstBegin = '2016-03-13';
           const dstEnd = '2016-11-06';
 
-          it('should return `2016-09-23T19:00:00.000Z` given `2016-09-23`', () => {
+          it('should call `onSelectDate` with `2016-09-23T19:00:00.000Z` on `2016-09-23`', () => {
             const midDayForDate = minimalData.instance().selectDate();
-            expect(midDayForDate(localDate)).to.equal('2016-09-23T19:00:00.000Z');
+            midDayForDate(localDate);
+            expect(props.onSelectDate.firstCall.args[0]).to.equal('2016-09-23T19:00:00.000Z');
           });
 
-          it('should return `2016-03-13T20:00:00.000Z` given `2016-03-13`', () => {
+          it('should call `onSelectDate` with `2016-03-13T20:00:00.000Z` on `2016-03-13`', () => {
             const midDayForDate = minimalData.instance().selectDate();
-            expect(midDayForDate(dstBegin)).to.equal('2016-03-13T20:00:00.000Z');
+            midDayForDate(dstBegin);
+            expect(props.onSelectDate.firstCall.args[0]).to.equal('2016-03-13T20:00:00.000Z');
           });
 
-          it('should return `2016-11-06T19:00:00.000Z` given `2016-11-06`', () => {
+          it('should call `onSelectDate` with `2016-11-06T19:00:00.000Z` on `2016-11-06`', () => {
             const midDayForDate = minimalData.instance().selectDate();
-            expect(midDayForDate(dstEnd)).to.equal('2016-11-06T19:00:00.000Z');
+            midDayForDate(dstEnd);
+            expect(props.onSelectDate.firstCall.args[0]).to.equal('2016-11-06T19:00:00.000Z');
           });
         });
       });

--- a/test/containers/trends/TrendsSVGContainer.test.js
+++ b/test/containers/trends/TrendsSVGContainer.test.js
@@ -54,8 +54,10 @@ describe('TrendsSVGContainer', () => {
       saturday: false,
       sunday: false,
     },
-    bgBounds,
-    bgUnits: MGDL_UNITS,
+    bgPrefs: {
+      bgBounds,
+      bgUnits: MGDL_UNITS,
+    },
     // normally provided by react-dimensions wrapper but we test w/o that
     containerHeight: 520,
     // normally provided by react-dimensions wrapper but we test w/o that

--- a/test/utils/datetime.test.js
+++ b/test/utils/datetime.test.js
@@ -18,6 +18,28 @@
 import * as datetime from '../../src/utils/datetime';
 
 describe('datetime', () => {
+  const patient = {
+    profile: {
+      fullName: 'Mary Smith',
+      patient: {
+        diagnosisDate: '1990-01-31',
+        birthday: '1983-01-31',
+      },
+    },
+  };
+
+  const fakeChildAcct = {
+    profile: {
+      fullName: 'Mary Smith',
+      patient: {
+        isOtherPerson: true,
+        fullName: 'My Kid',
+        diagnosisDate: '1990-01-31',
+        birthday: '1983-01-31',
+      },
+    },
+  };
+
   describe('THIRTY_MINS', () => {
     assert.isNumber(datetime.THIRTY_MINS);
   });
@@ -88,31 +110,15 @@ describe('datetime', () => {
     });
   });
 
-  describe('getLocalizedCeiling', () => {
-    const timePrefs = { timezoneAware: true, timezoneName: 'US/Pacific' };
+  describe('formatBirthdate', () => {
     it('should be a function', () => {
-      assert.isFunction(datetime.getLocalizedCeiling);
+      assert.isFunction(datetime.formatBirthdate);
     });
-
-    it('should error if passed a JavaScript Date for the `utc` param', () => {
-      const fn = () => { datetime.getLocalizedCeiling(new Date()); };
-      expect(fn)
-        .to.throw('`utc` must be a ISO-formatted String timestamp or integer hammertime!');
+    it('returns child name when isOtherPerson', () => {
+      expect(datetime.formatBirthdate(fakeChildAcct)).to.equal('Jan 31, 1983');
     });
-
-    it('should return the ceiling (= next midnight) for a datetime in a given timezone', () => {
-      const dt = '2016-03-15T14:25:00.000Z';
-      expect(datetime.getLocalizedCeiling(dt, timePrefs).toISOString())
-        .to.equal('2016-03-16T07:00:00.000Z');
-      const asInteger = Date.parse(dt);
-      expect(datetime.getLocalizedCeiling(asInteger, timePrefs).toISOString())
-        .to.equal('2016-03-16T07:00:00.000Z');
-    });
-
-    it('should return the same datetime if it already is a midnight in given timezone', () => {
-      const dt = '2016-03-15T07:00:00.000Z';
-      expect(datetime.getLocalizedCeiling(dt, timePrefs).toISOString())
-        .to.equal(dt);
+    it('returns child name when isOtherPerson', () => {
+      expect(datetime.formatBirthdate(fakeChildAcct)).to.equal('Jan 31, 1983');
     });
   });
 
@@ -154,6 +160,18 @@ describe('datetime', () => {
     it('should use a custom format string passed as second arg', () => {
       expect(datetime.formatClocktimeFromMsPer24(twoTwentyAfternoonMs, 'kk🙃mm'))
         .to.equal('14🙃20');
+    });
+  });
+
+  describe('formatDiagnosisDate', () => {
+    it('should be a function', () => {
+      assert.isFunction(datetime.formatDiagnosisDate);
+    });
+    it('returns child name when isOtherPerson', () => {
+      expect(datetime.formatDiagnosisDate(patient)).to.equal('Jan 31, 1990');
+    });
+    it('returns child name when isOtherPerson', () => {
+      expect(datetime.formatDiagnosisDate(patient)).to.equal('Jan 31, 1990');
     });
   });
 
@@ -281,6 +299,34 @@ describe('datetime', () => {
       expect(fn).to.throw(
         'Check your input datum; could not parse `time` or `deviceTime` with Date.parse.'
       );
+    });
+  });
+
+  describe('getLocalizedCeiling', () => {
+    const timePrefs = { timezoneAware: true, timezoneName: 'US/Pacific' };
+    it('should be a function', () => {
+      assert.isFunction(datetime.getLocalizedCeiling);
+    });
+
+    it('should error if passed a JavaScript Date for the `utc` param', () => {
+      const fn = () => { datetime.getLocalizedCeiling(new Date()); };
+      expect(fn)
+        .to.throw('`utc` must be a ISO-formatted String timestamp or integer hammertime!');
+    });
+
+    it('should return the ceiling (= next midnight) for a datetime in a given timezone', () => {
+      const dt = '2016-03-15T14:25:00.000Z';
+      expect(datetime.getLocalizedCeiling(dt, timePrefs).toISOString())
+        .to.equal('2016-03-16T07:00:00.000Z');
+      const asInteger = Date.parse(dt);
+      expect(datetime.getLocalizedCeiling(asInteger, timePrefs).toISOString())
+        .to.equal('2016-03-16T07:00:00.000Z');
+    });
+
+    it('should return the same datetime if it already is a midnight in given timezone', () => {
+      const dt = '2016-03-15T07:00:00.000Z';
+      expect(datetime.getLocalizedCeiling(dt, timePrefs).toISOString())
+        .to.equal(dt);
     });
   });
 });

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -34,78 +34,81 @@ describe('format', () => {
     });
   });
 
-  describe('displayBgValue', () => {
+  describe('formatBgValue', () => {
     it('should be a function', () => {
-      assert.isFunction(format.displayBgValue);
+      assert.isFunction(format.formatBgValue);
     });
 
     describe('no recogizable units provided', () => {
       it('should return a String integer by default (no recogizable `units` provided)', () => {
-        expect(format.displayBgValue(120.5)).to.equal('121');
-        expect(format.displayBgValue(120.5, 'foo')).to.equal('121');
+        expect(format.formatBgValue(120.5)).to.equal('121');
+        expect(format.formatBgValue(120.5, 'foo')).to.equal('121');
       });
     });
 
     describe('when units are `mg/dL`', () => {
       it('should return a String integer', () => {
-        expect(format.displayBgValue(120.5, MGDL_UNITS)).to.equal('121');
+        expect(format.formatBgValue(120.5, { bgUnits: MGDL_UNITS })).to.equal('121');
       });
 
       it('should give no decimals', () => {
-        expect(format.displayBgValue(352, MGDL_UNITS)).to.equal('352');
+        expect(format.formatBgValue(352, { bgUnits: MGDL_UNITS })).to.equal('352');
       });
 
       it('should round', () => {
-        expect(format.displayBgValue(352.77, MGDL_UNITS)).to.equal('353');
+        expect(format.formatBgValue(352.77, { bgUnits: MGDL_UNITS })).to.equal('353');
       });
 
       describe('when `outOfRangeThresholds` provided', () => {
         it('should return the String High if value over the high threshold', () => {
-          expect(format.displayBgValue(401, MGDL_UNITS, { high: 400 })).to.equal(BG_HIGH);
+          expect(format.formatBgValue(401, { bgUnits: MGDL_UNITS }, { high: 400 }))
+            .to.equal(BG_HIGH);
         });
 
         it('should return normal String integer if value NOT over the high threshold', () => {
-          expect(format.displayBgValue(399, MGDL_UNITS, { high: 400 })).to.equal('399');
+          expect(format.formatBgValue(399, { bgUnits: MGDL_UNITS }, { high: 400 })).to.equal('399');
         });
 
         it('should return the String Low if value under the low threshold', () => {
-          expect(format.displayBgValue(39, MGDL_UNITS, { low: 40 })).to.equal(BG_LOW);
+          expect(format.formatBgValue(39, { bgUnits: MGDL_UNITS }, { low: 40 })).to.equal(BG_LOW);
         });
 
         it('should return normal String integer if value NOT under the low threshold', () => {
-          expect(format.displayBgValue(41, MGDL_UNITS, { low: 40 })).to.equal('41');
+          expect(format.formatBgValue(41, { bgUnits: MGDL_UNITS }, { low: 40 })).to.equal('41');
         });
       });
     });
 
     describe('when units are `mmol/L`', () => {
       it('should return a String number', () => {
-        expect(format.displayBgValue(6.6886513292098675, MMOLL_UNITS)).to.equal('6.7');
+        expect(format.formatBgValue(6.6886513292098675, { bgUnits: MMOLL_UNITS })).to.equal('6.7');
       });
 
       it('should give one decimal place', () => {
-        expect(format.displayBgValue(12.52, MMOLL_UNITS)).to.equal('12.5');
+        expect(format.formatBgValue(12.52, { bgUnits: MMOLL_UNITS })).to.equal('12.5');
       });
 
       it('should round', () => {
-        expect(format.displayBgValue(12.77, MMOLL_UNITS)).to.equal('12.8');
+        expect(format.formatBgValue(12.77, { bgUnits: MMOLL_UNITS })).to.equal('12.8');
       });
 
       describe('when `outOfRangeThresholds` provided', () => {
         it('should return the String High if value over the high threshold', () => {
-          expect(format.displayBgValue(23.1, MMOLL_UNITS, { high: 400 })).to.equal(BG_HIGH);
+          expect(format.formatBgValue(23.1, { bgUnits: MMOLL_UNITS }, { high: 400 }))
+            .to.equal(BG_HIGH);
         });
 
         it('should return normal String number if value NOT over the high threshold', () => {
-          expect(format.displayBgValue(22.0, MMOLL_UNITS, { high: 400 })).to.equal('22.0');
+          expect(format.formatBgValue(22.0, { bgUnits: MMOLL_UNITS }, { high: 400 }))
+            .to.equal('22.0');
         });
 
         it('should return the String Low if value under the low threshold', () => {
-          expect(format.displayBgValue(2.1, MMOLL_UNITS, { low: 40 })).to.equal(BG_LOW);
+          expect(format.formatBgValue(2.1, { bgUnits: MMOLL_UNITS }, { low: 40 })).to.equal(BG_LOW);
         });
 
         it('should return normal String number if value NOT under the low threshold', () => {
-          expect(format.displayBgValue(3.36, MMOLL_UNITS, { low: 40 })).to.equal('3.4');
+          expect(format.formatBgValue(3.36, { bgUnits: MMOLL_UNITS }, { low: 40 })).to.equal('3.4');
         });
       });
     });

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -20,17 +20,17 @@ import { BG_HIGH, BG_LOW, MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/consta
 import * as format from '../../src/utils/format';
 
 describe('format', () => {
-  describe('displayDecimal', () => {
+  describe('formatDecimalNumber', () => {
     it('should give no places when none specified', () => {
-      expect(format.displayDecimal(9.3328)).to.equal('9');
+      expect(format.formatDecimalNumber(9.3328)).to.equal('9');
     });
 
     it('should give no places when zero specified', () => {
-      expect(format.displayDecimal(9.3328, 0)).to.equal('9');
+      expect(format.formatDecimalNumber(9.3328, 0)).to.equal('9');
     });
 
     it('should give the number of places when they are specified', () => {
-      expect(format.displayDecimal(9.3328, 1)).to.equal('9.3');
+      expect(format.formatDecimalNumber(9.3328, 1)).to.equal('9.3');
     });
   });
 

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -124,7 +124,7 @@ describe('format', () => {
     },
   };
 
-  const patientKid = {
+  const fakeChildAcct = {
     profile: {
       fullName: 'Mary Smith',
       patient: {
@@ -136,29 +136,15 @@ describe('format', () => {
     },
   };
 
-  describe('patientFullName', () => {
-    it('should be a function', () => {
-      assert.isFunction(format.patientFullName);
-    });
-
-    it('returns patient name', () => {
-      expect(format.patientFullName(patient)).to.equal(patient.profile.fullName);
-    });
-
-    it('returns child name when isOtherPerson', () => {
-      expect(format.patientFullName(patientKid)).to.equal(patientKid.profile.patient.fullName);
-    });
-  });
-
   describe('birthday', () => {
     it('should be a function', () => {
       assert.isFunction(format.birthday);
     });
     it('returns child name when isOtherPerson', () => {
-      expect(format.birthday(patientKid)).to.equal('Jan 31, 1983');
+      expect(format.birthday(fakeChildAcct)).to.equal('Jan 31, 1983');
     });
     it('returns child name when isOtherPerson', () => {
-      expect(format.birthday(patientKid)).to.equal('Jan 31, 1983');
+      expect(format.birthday(fakeChildAcct)).to.equal('Jan 31, 1983');
     });
   });
 

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -20,20 +20,6 @@ import { BG_HIGH, BG_LOW, MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/consta
 import * as format from '../../src/utils/format';
 
 describe('format', () => {
-  describe('formatDecimalNumber', () => {
-    it('should give no places when none specified', () => {
-      expect(format.formatDecimalNumber(9.3328)).to.equal('9');
-    });
-
-    it('should give no places when zero specified', () => {
-      expect(format.formatDecimalNumber(9.3328, 0)).to.equal('9');
-    });
-
-    it('should give the number of places when they are specified', () => {
-      expect(format.formatDecimalNumber(9.3328, 1)).to.equal('9.3');
-    });
-  });
-
   describe('formatBgValue', () => {
     it('should be a function', () => {
       assert.isFunction(format.formatBgValue);
@@ -114,49 +100,17 @@ describe('format', () => {
     });
   });
 
-  const patient = {
-    profile: {
-      fullName: 'Mary Smith',
-      patient: {
-        diagnosisDate: '1990-01-31',
-        birthday: '1983-01-31',
-      },
-    },
-  };
+  describe('formatDecimalNumber', () => {
+    it('should give no places when none specified', () => {
+      expect(format.formatDecimalNumber(9.3328)).to.equal('9');
+    });
 
-  const fakeChildAcct = {
-    profile: {
-      fullName: 'Mary Smith',
-      patient: {
-        isOtherPerson: true,
-        fullName: 'My Kid',
-        diagnosisDate: '1990-01-31',
-        birthday: '1983-01-31',
-      },
-    },
-  };
+    it('should give no places when zero specified', () => {
+      expect(format.formatDecimalNumber(9.3328, 0)).to.equal('9');
+    });
 
-  describe('birthday', () => {
-    it('should be a function', () => {
-      assert.isFunction(format.birthday);
-    });
-    it('returns child name when isOtherPerson', () => {
-      expect(format.birthday(fakeChildAcct)).to.equal('Jan 31, 1983');
-    });
-    it('returns child name when isOtherPerson', () => {
-      expect(format.birthday(fakeChildAcct)).to.equal('Jan 31, 1983');
-    });
-  });
-
-  describe('diagnosisDate', () => {
-    it('should be a function', () => {
-      assert.isFunction(format.diagnosisDate);
-    });
-    it('returns child name when isOtherPerson', () => {
-      expect(format.diagnosisDate(patient)).to.equal('Jan 31, 1990');
-    });
-    it('returns child name when isOtherPerson', () => {
-      expect(format.diagnosisDate(patient)).to.equal('Jan 31, 1990');
+    it('should give the number of places when they are specified', () => {
+      expect(format.formatDecimalNumber(9.3328, 1)).to.equal('9.3');
     });
   });
 });

--- a/test/utils/misc.test.js
+++ b/test/utils/misc.test.js
@@ -1,0 +1,57 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import * as misc from '../../src/utils/misc';
+
+describe('misc utility functions', () => {
+  describe('getPatientFullName', () => {
+    const patient = {
+      profile: {
+        fullName: 'Mary Smith',
+        patient: {
+          diagnosisDate: '1990-01-31',
+          birthday: '1983-01-31',
+        },
+      },
+    };
+
+    const fakeChildAcct = {
+      profile: {
+        fullName: 'Mary Smith',
+        patient: {
+          isOtherPerson: true,
+          fullName: 'My Kid',
+          diagnosisDate: '1990-01-31',
+          birthday: '1983-01-31',
+        },
+      },
+    };
+
+    it('should be a function', () => {
+      assert.isFunction(misc.getPatientFullName);
+    });
+
+    it('returns patient name', () => {
+      expect(misc.getPatientFullName(patient)).to.equal(patient.profile.fullName);
+    });
+
+    it('returns child name when isOtherPerson', () => {
+      expect(misc.getPatientFullName(fakeChildAcct))
+        .to.equal(fakeChildAcct.profile.patient.fullName);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,7 +154,7 @@ acorn@^2.1.0, acorn@^2.4.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
-acorn@^3.0.0, acorn@^3.0.4:
+acorn@^3.0.0, acorn@^3.0.4, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
@@ -210,6 +210,12 @@ andlog@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/andlog/-/andlog-1.0.0.tgz#25b39047ac9c1e5f6b2c8e4cdb5e7bf9e65e534b"
 
+ansi-escape-sequences@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz#1c18394b6af9b76ff9a63509fa497669fd2ce53e"
+  dependencies:
+    array-back "^1.0.3"
+
 ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -245,6 +251,15 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
+app-usage-stats@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/app-usage-stats/-/app-usage-stats-0.5.1.tgz#6547c5db9bab0aa5f5b2c560eacc8af20d0ab13b"
+  dependencies:
+    array-back "^1.0.4"
+    home-path "^1.0.3"
+    test-value "^2.1.0"
+    usage-stats "^0.9.0"
+
 aproba@^1.0.3, aproba@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.0.4.tgz#2713680775e7614c8ba186c065d4e2e52d1072c0"
@@ -275,6 +290,12 @@ arr-diff@^2.0.0:
 arr-flatten@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
+
+array-back@^1.0.2, array-back@^1.0.3, array-back@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-1.0.4.tgz#644ba7f095f7ffcf7c43b5f0dc39d3c1f03c063b"
+  dependencies:
+    typical "^2.6.0"
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -1461,6 +1482,10 @@ bluebird@^3.3.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
+bluebird@~3.4.6:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+
 body-parser@^1.12.4:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.17.1.tgz#75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47"
@@ -1566,6 +1591,14 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
+cache-point@^0.4.0, cache-point@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cache-point/-/cache-point-0.4.0.tgz#2797f68055970757c87e89b464978e74e11047b0"
+  dependencies:
+    array-back "^1.0.4"
+    fs-then-native "^2.0.0"
+    mkdirp "~0.5.1"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1619,6 +1652,12 @@ caseless@~0.11.0:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+catharsis@~0.8.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.8.tgz#693479f43aac549d806bd73e924cd0d944951a06"
+  dependencies:
+    underscore-contrib "~0.3.0"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -1763,6 +1802,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collect-all@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/collect-all/-/collect-all-1.0.2.tgz#39450f1e7aa6086570a006bce93ccf1218a77ea1"
+  dependencies:
+    stream-connect "^1.0.2"
+    stream-via "^1.0.3"
+
 color-convert@^1.3.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
@@ -1818,6 +1864,33 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-line-args@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-4.0.4.tgz#6b9ab497cfe82d2c1ce1e47d6c18a85382f5d9fe"
+  dependencies:
+    array-back "^1.0.4"
+    find-replace "^1.0.3"
+    typical "^2.6.0"
+
+command-line-tool@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/command-line-tool/-/command-line-tool-0.7.0.tgz#ca80792ae2069cf7caa562c0cbc2cd11811122a0"
+  dependencies:
+    ansi-escape-sequences "^3.0.0"
+    array-back "^1.0.4"
+    command-line-args "^4.0.1"
+    command-line-usage "^4.0.0"
+    typical "^2.6.0"
+
+command-line-usage@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-4.0.0.tgz#816b32788b58f9feba44d1e6dac60fcaeb29b5ea"
+  dependencies:
+    ansi-escape-sequences "^3.0.0"
+    array-back "^1.0.4"
+    table-layout "^0.4.0"
+    typical "^2.6.0"
+
 commander@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
@@ -1827,6 +1900,10 @@ commander@2.9.0, commander@^2.8.1, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+common-sequence@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/common-sequence/-/common-sequence-1.0.2.tgz#30e07f3f8f6f7f9b3dee854f20b2d39eee086de8"
 
 common-tags@^1.3.1:
   version "1.4.0"
@@ -1880,6 +1957,12 @@ config-chain@~1.1.10:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
+
+config-master@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/config-master/-/config-master-3.1.0.tgz#667663590505a283bf26a484d68489d74c5485da"
+  dependencies:
+    walk-back "^2.0.1"
 
 configstore@^2.0.0:
   version "2.1.0"
@@ -2288,7 +2371,7 @@ deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
-deep-extend@~0.4.0:
+deep-extend@~0.4.0, deep-extend@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
 
@@ -2301,6 +2384,10 @@ defaults@^1.0.3:
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
   dependencies:
     clone "^1.0.2"
+
+defer-promise@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/defer-promise/-/defer-promise-1.0.1.tgz#1ca6ffeddbcef1715dd7aae25c7616f9ae22932f"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -2365,6 +2452,23 @@ di@^0.0.1:
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+dmd@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dmd/-/dmd-3.0.4.tgz#8a641518a7e2641f95777e046b5c4f085a9ec9b5"
+  dependencies:
+    array-back "^1.0.4"
+    cache-point "^0.4.0"
+    common-sequence "^1.0.2"
+    file-set "^1.1.1"
+    handlebars "3.0.3"
+    marked "^0.3.6"
+    object-get "^2.1.0"
+    reduce-flatten "^1.0.1"
+    reduce-unique "^1.0.0"
+    reduce-without "^1.0.1"
+    test-value "^2.1.0"
+    walk-back "^3.0.0"
 
 doctrine@1.2.x, doctrine@^1.2.2:
   version "1.2.3"
@@ -2643,7 +2747,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2774,6 +2878,13 @@ espree@^3.1.6:
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.2.tgz#38dbdedbedc95b8961a1fbf04734a8f6a9c8c592"
   dependencies:
     acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
+
+espree@~3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.1.7.tgz#fd5deec76a97a5120a9cd3a7cb1177a0923b11d2"
+  dependencies:
+    acorn "^3.3.0"
     acorn-jsx "^3.0.0"
 
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
@@ -2971,6 +3082,12 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+feature-detect-es6@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz#f888736af9cb0c91f55663bfa4762eb96ee7047f"
+  dependencies:
+    array-back "^1.0.3"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2990,6 +3107,13 @@ file-loader@^0.9.0:
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.9.0.tgz#1d2daddd424ce6d1b07cfe3f79731bed3617ab42"
   dependencies:
     loader-utils "~0.2.5"
+
+file-set@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/file-set/-/file-set-1.1.1.tgz#d3ec70c080ec8f18f204ba1de106780c9056926b"
+  dependencies:
+    array-back "^1.0.3"
+    glob "^7.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -3024,6 +3148,13 @@ find-cache-dir@^0.1.1:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
+
+find-replace@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-1.0.3.tgz#b88e7364d2d9c959559f388c66670d6130441fa0"
+  dependencies:
+    array-back "^1.0.4"
+    test-value "^2.1.0"
 
 find-up@^1.0.0, find-up@^1.1.2:
   version "1.1.2"
@@ -3143,6 +3274,10 @@ fs-extra@~0.30.0:
 fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
+
+fs-then-native@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fs-then-native/-/fs-then-native-2.0.0.tgz#19a124d94d90c22c8e045f2e8dd6ebea36d48c67"
 
 fs-vacuum@~1.2.7, fs-vacuum@~1.2.9:
   version "1.2.10"
@@ -3325,7 +3460,7 @@ glob@^5.0.15, glob@^5.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3390,6 +3525,15 @@ growl@1.9.2:
 gsap@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/gsap/-/gsap-1.19.0.tgz#f36b78c6b1a449028d89efbb4c161db29f5991dd"
+
+handlebars@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-3.0.3.tgz#0e09651a2f0fb3c949160583710d551f92e6d2ad"
+  dependencies:
+    optimist "^0.6.1"
+    source-map "^0.1.40"
+  optionalDependencies:
+    uglify-js "~2.3"
 
 handlebars@^4.0.1:
   version "4.0.6"
@@ -3487,6 +3631,10 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+home-path@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
 
 hosted-git-info@^2.1.4, hosted-git-info@~2.1.4, hosted-git-info@~2.1.5:
   version "2.1.5"
@@ -3928,9 +4076,74 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
+js2xmlparser@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-1.0.0.tgz#5a170f2e8d6476ce45405e04823242513782fe30"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdoc-75lb@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz#a807119528b4009ccbcab49b7522f63fec6cd0bd"
+  dependencies:
+    bluebird "~3.4.6"
+    catharsis "~0.8.8"
+    escape-string-regexp "~1.0.5"
+    espree "~3.1.7"
+    js2xmlparser "~1.0.0"
+    klaw "~1.3.0"
+    marked "~0.3.6"
+    mkdirp "~0.5.1"
+    requizzle "~0.2.1"
+    strip-json-comments "~2.0.1"
+    taffydb "2.6.2"
+    underscore "~1.8.3"
+
+jsdoc-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-api/-/jsdoc-api-3.0.0.tgz#0d52700235f865bd4a8bad5ebc1efb562fc8ad2a"
+  dependencies:
+    array-back "^1.0.4"
+    cache-point "~0.4.0"
+    collect-all "^1.0.2"
+    file-set "^1.1.1"
+    fs-then-native "^2.0.0"
+    jsdoc-75lb "^3.6.0"
+    object-to-spawn-args "^1.1.0"
+    temp-path "^1.0.0"
+    walk-back "^2.0.1"
+
+jsdoc-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-parse/-/jsdoc-parse-3.0.0.tgz#271531d88f19df2520b1632a7f6c989441a87fde"
+  dependencies:
+    array-back "^1.0.4"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    reduce-extract "^1.0.0"
+    sort-array "^1.1.1"
+    test-value "^2.1.0"
+
+jsdoc-to-markdown@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-to-markdown/-/jsdoc-to-markdown-3.0.0.tgz#cc8a94f1f412ac1da4bac1657475b0975ee8161a"
+  dependencies:
+    array-back "^1.0.4"
+    command-line-tool "^0.7.0"
+    config-master "^3.0.0"
+    dmd "^3.0.0"
+    jsdoc-api "^3.0.0"
+    jsdoc-parse "^3.0.0"
+    jsdoc2md-stats "^2.0.0"
+    walk-back "^2.0.1"
+
+jsdoc2md-stats@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsdoc2md-stats/-/jsdoc2md-stats-2.0.1.tgz#bd8343734cfe69ea8050a17931251293f0d9047b"
+  dependencies:
+    app-usage-stats "^0.5.0"
 
 jsdom@^7.0.2:
   version "7.2.2"
@@ -4133,7 +4346,7 @@ kind-of@^3.0.2:
   dependencies:
     is-buffer "^1.1.5"
 
-klaw@^1.0.0:
+klaw@^1.0.0, klaw@~1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
   optionalDependencies:
@@ -4380,11 +4593,15 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
 lodash.pad@^4.1.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash.pad/-/lodash.pad-4.5.1.tgz#4330949a833a7c8da22cc20f6a26c4d59debba70"
 
-lodash.padend@^4.1.0:
+lodash.padend@^4.1.0, lodash.padend@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
 
@@ -4515,6 +4732,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
+marked@^0.3.6, marked@~0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.16"
@@ -5146,6 +5367,10 @@ object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
+object-get@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/object-get/-/object-get-2.1.0.tgz#722bbdb60039efa47cad3c6dc2ce51a85c02c5ae"
+
 object-invariant-test-helper@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/object-invariant-test-helper/-/object-invariant-test-helper-0.1.1.tgz#4bfbd68f3790ff4570a5e77f8e830613111af008"
@@ -5157,6 +5382,10 @@ object-is@^1.0.1:
 object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-to-spawn-args@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-to-spawn-args/-/object-to-spawn-args-1.1.0.tgz#031a200e37db2c3dfc9b98074a0d69a5be253c1c"
 
 object.assign@^4.0.3:
   version "4.0.4"
@@ -5229,6 +5458,12 @@ optimist@0.6.1, optimist@^0.6.1, optimist@~0.6.0:
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
     minimist "~0.0.1"
+    wordwrap "~0.0.2"
+
+optimist@~0.3.5:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
+  dependencies:
     wordwrap "~0.0.2"
 
 optionator@^0.8.1:
@@ -6235,11 +6470,31 @@ reduce-css-calc@^1.2.6:
     math-expression-evaluator "^1.2.14"
     reduce-function-call "^1.0.1"
 
+reduce-extract@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-extract/-/reduce-extract-1.0.0.tgz#67f2385beda65061b5f5f4312662e8b080ca1525"
+  dependencies:
+    test-value "^1.0.1"
+
+reduce-flatten@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
+
 reduce-function-call@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+reduce-unique@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-unique/-/reduce-unique-1.0.0.tgz#7e586bcf87a4e32b6d7abd8277fad6cdec9f4803"
+
+reduce-without@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-without/-/reduce-without-1.0.1.tgz#68ad0ead11855c9a37d4e8256c15bbf87972fc8c"
+  dependencies:
+    test-value "^2.0.0"
 
 redux-mock-store@1.2.1:
   version "1.2.1"
@@ -6332,6 +6587,16 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+req-then@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/req-then/-/req-then-0.5.1.tgz#31c6e0b56f4ddd2acd6de0ba1bcea77b6079dfdf"
+  dependencies:
+    array-back "^1.0.3"
+    defer-promise "^1.0.0"
+    feature-detect-es6 "^1.3.1"
+    lodash.pick "^4.4.0"
+    typical "^2.6.0"
 
 request-progress@~2.0.1:
   version "2.0.1"
@@ -6440,6 +6705,12 @@ requireindex@~1.1.0:
 requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
+requizzle@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
+  dependencies:
+    underscore "~1.6.0"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -6727,6 +6998,14 @@ socket.io@1.4.7:
     socket.io-client "1.4.6"
     socket.io-parser "2.2.6"
 
+sort-array@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-array/-/sort-array-1.1.2.tgz#b88986053c0170a7f9de63f18a49ec79c24c3e64"
+  dependencies:
+    array-back "^1.0.4"
+    object-get "^2.1.0"
+    typical "^2.6.0"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -6751,7 +7030,7 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
-source-map@^0.1.41:
+source-map@^0.1.40, source-map@^0.1.41, source-map@~0.1.7:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -6832,6 +7111,16 @@ stream-combiner@~0.0.4:
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
   dependencies:
     duplexer "~0.1.1"
+
+stream-connect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-connect/-/stream-connect-1.0.2.tgz#18bc81f2edb35b8b5d9a8009200a985314428a97"
+  dependencies:
+    array-back "^1.0.2"
+
+stream-via@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stream-via/-/stream-via-1.0.3.tgz#cebd32a5a59d74b3b68e3404942e867184ad4ac9"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -6950,6 +7239,16 @@ symbol-observable@^0.2.3:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+table-layout@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.4.0.tgz#c70ff0455d9add63b91f7c15a77926295c0e0e7d"
+  dependencies:
+    array-back "^1.0.4"
+    deep-extend "~0.4.1"
+    lodash.padend "^4.6.1"
+    typical "^2.6.0"
+    wordwrapjs "^2.0.0"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -6960,6 +7259,10 @@ table@^3.7.8:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
+
+taffydb@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"
@@ -6986,6 +7289,10 @@ tar@^2.0.0, tar@^2.2.1, tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-path/-/temp-path-1.0.0.tgz#24b1543973ab442896d9ad367dd9cbdbfafe918b"
+
 test-exclude@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-2.1.3.tgz#a8d8968e1da83266f9864f2852c55e220f06434a"
@@ -6995,6 +7302,20 @@ test-exclude@^2.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+test-value@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-1.1.0.tgz#a09136f72ec043d27c893707c2b159bfad7de93f"
+  dependencies:
+    array-back "^1.0.2"
+    typical "^2.4.2"
+
+test-value@^2.0.0, test-value@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-2.1.0.tgz#11da6ff670f3471a73b625ca4f3fdcf7bb748291"
+  dependencies:
+    array-back "^1.0.3"
+    typical "^2.6.0"
 
 text-table@0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -7110,6 +7431,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typical@^2.4.2, typical@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.0.tgz#89d51554ab139848a65bcc2c8772f8fb450c40ed"
+
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
@@ -7122,6 +7447,14 @@ uglify-js@^2.6, uglify-js@~2.6.0:
     source-map "~0.5.1"
     uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
+
+uglify-js@~2.3:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.3.6.tgz#fa0984770b428b7a9b2a8058f46355d14fef211a"
+  dependencies:
+    async "~0.2.6"
+    optimist "~0.3.5"
+    source-map "~0.1.7"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -7138,6 +7471,20 @@ ultron@1.0.x:
 umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
+
+underscore-contrib@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
+  dependencies:
+    underscore "1.6.0"
+
+underscore@1.6.0, underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
+underscore@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 uniq@^1.0.1:
   version "1.0.1"
@@ -7183,6 +7530,17 @@ url@~0.10.1:
     punycode "1.3.2"
     querystring "0.2.0"
 
+usage-stats@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/usage-stats/-/usage-stats-0.9.0.tgz#a763f6116859f769925e75b5f92e4e3b47a374fd"
+  dependencies:
+    array-back "^1.0.4"
+    home-path "^1.0.3"
+    mkdirp "^0.5.1"
+    req-then "^0.5.1"
+    typical "^2.6.0"
+    uuid "^3.0.1"
+
 user-home@2.0.0, user-home@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
@@ -7226,7 +7584,7 @@ uuid@^2.0.1, uuid@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
@@ -7278,6 +7636,14 @@ vm-browserify@0.0.4:
 void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+
+walk-back@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-2.0.1.tgz#554e2a9d874fac47a8cb006bf44c2f0c4998a0a4"
+
+walk-back@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-3.0.0.tgz#2358787a35da91032dad5e92f80b12370d8795c5"
 
 watchpack@^0.2.1:
   version "0.2.9"
@@ -7383,6 +7749,15 @@ wordwrap@^1.0.0, wordwrap@~1.0.0:
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+
+wordwrapjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-2.0.0.tgz#ab55f695e6118da93858fdd70c053d1c5e01ac20"
+  dependencies:
+    array-back "^1.0.3"
+    feature-detect-es6 "^1.3.1"
+    reduce-flatten "^1.0.1"
+    typical "^2.6.0"
 
 wrappy@1, wrappy@~1.0.1, wrappy@~1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Again as planned @krystophv 

The last commit isn't the greatest because I re-alphabetized (for ease of comparing across source and test files to make sure everything's covered), but otherwise commit-by-commit would be a good strategy for review I'd imagine.

There is [a blip PR](https://github.com/tidepool-org/blip/pull/413) that will depend on this since I standardized on passing through entire `bgPrefs` to the `TrendsContainer` and Trends tooltip components.