### PR TITLE
get rid of src/containers/ in favor of everything in src/components/

### DIFF
--- a/docs/DirectoryStructure.md
+++ b/docs/DirectoryStructure.md
@@ -16,7 +16,7 @@
 
 * * * * *
 
-As of November, 2016, the directory structure is as follows (although this may change as we continue to develop new code in this repository):
+As of May, 2017, the directory structure is as follows (although this may change as we continue to develop new code in this repository):
 
 <!-- to generate the directory structure below use `tree -d --matchdirs -I '_book|coverage|dist|node_modules|web'` -->
 ```
@@ -27,48 +27,52 @@ As of November, 2016, the directory structure is as follows (although this may c
 │       ├── omnipod
 │       └── tandem
 ├── docs
+│   ├── deps
+│   ├── misc
+│   └── views
+│       └── images
+├── local
 ├── src
 │   ├── components
 │   │   ├── common
-│   │   │   └── controls
+│   │   │   ├── controls
+│   │   │   └── tooltips
 │   │   ├── settings
 │   │   │   └── common
 │   │   └── trends
 │   │       ├── cbg
-│   │       └── common
-│   ├── containers
-│   │   ├── settings
-│   │   └── trends
+│   │       ├── common
+│   │       └── smbg
 │   ├── redux
 │   │   ├── actions
 │   │   ├── constants
 │   │   └── reducers
 │   ├── styles
 │   └── utils
+│       ├── apidocs
 │       ├── settings
 │       └── trends
 ├── stories
 │   ├── components
 │   │   ├── common
-│   │   │   └── controls
+│   │   │   ├── controls
+│   │   │   └── tooltips
 │   │   ├── settings
 │   │   └── trends
 │   │       └── common
-│   └── containers
-│       └── trends
+│   └── helpers
 ├── storybook
 └── test
     ├── components
     │   ├── common
-    │   │   └── controls
+    │   │   ├── controls
+    │   │   └── tooltip
     │   ├── settings
     │   │   └── common
     │   └── trends
     │       ├── cbg
-    │       └── common
-    ├── containers
-    │   ├── settings
-    │   └── trends
+    │       ├── common
+    │       └── smbg
     ├── helpers
     ├── redux
     │   ├── actions
@@ -85,7 +89,6 @@ All active, non-tooling code in the repository is contained in `src/`, and `src/
 ```
 └── src
     ├── components
-    ├── containers
     ├── redux
     ├── styles
     └── utils
@@ -96,6 +99,7 @@ All active, non-tooling code in the repository is contained in `src/`, and `src/
 ```
 └── redux
     ├── actions
+    ├── constants
     └── reducers
 ```
 
@@ -103,27 +107,30 @@ Within `src/redux/`, the `actions/` and `reducers/` contain the actions and redu
 
 In both `actions/` and `reducers/`, files should be grouped into sub-directories by ["view"](#views) or located in a directory called `common/` if the action(s) or reducer(s) is relevant to more than one view.
 
+The `src/redux/constants/` directory at present contains just the `actionTypes.js` file, which exports (as individual named exports) the action type constants for every action defined in `actions/` as well as those of blip's actions that are relevant to the viz reducers.
+
 ### React component directories
 
-Within `src/`, the `components/`, `containers/`, and (eventually) `views/` directories all contain the source for React components of various types and purposes.
+Within `src/`, the `components/` directory contains the source for React components of various types and purposes.
 
 Note that our convention for naming React component files is [PascalCase](https://en.wikipedia.org/wiki/PascalCase): `BGSlice`, `DailyContainer`, &c.
 
-#### components
+By convention, React components that meet most or all of the following criteria are considered "container" components and named as such—e.g., `TrendsContainer` and `CBGDateTracesAnimationContainer`.
 
-`components/` contains the lowest level of component. For the most part, these components should be stateless and (albeit with some rare exceptions) coded as [stateless functional components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components) rather than ES6 classes extending `React.Component`.
+- implemented as a `class` extension of `React.Component` or `React.PureComponent` (rather than a pure functional component)
+- needs only minimal or zero styles
+- primarily performs data munging or other "business logic" (or animation logic) in response to data (i.e., props) changes, potentially storing internal derived state as a result
+- renders other React components, *not* HTML or SVG elements
+
+The distinction between a "container" and a "pure" component is admittedly a bit fuzzy[^a], but generally the purpose of a container is to perform logic to *prepare* for rendering and then pass the resulting state to one or more stateless functional components for pure rendering. For example, for the trends view, the `TrendsContainer` determines the blood glucose and time domains on mount and on every update, preserving the current time domain in view and arrays of `cbg` and `smbg` currently in view (given the time domain) in its state. At the next level down, the `TrendsSVGContainer` sets up the rendering "canvas" (actually an SVG element) and scales for rendering (given the dimensions of the "canvas"). Another hallmark of "container" components is that they often do *not* have any associated styles since their purpose is computation and set up, not rendering.
+
+For the most part, *non*-"container" components should be stateless and (albeit with some rare exceptions) coded as [stateless functional components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components) rather than ES6 classes extending `React.Component` or `React.PureComponent`.
 
 Files should be grouped into sub-directories by ["view"](#views) and where necessary (because of a large number of components) into further sub-directories by datatype.
 
 Components used in more than one view should be located in `common/`. Examples of common components are controls like the BGM <-> CGM toggle used in both the basics and trends views and, potentially, animation containers like the header + child component (proposed for new device settings and potentially useful as well for sections in the basics view) that will slide the child component in and out on click of the header.
 
 CSS particular to a component should be written using [CSS modules](https://github.com/css-modules/css-modules) and contained in a file in the same directory and with the same name as the component, substituting the `.css` suffix for `.js`.
-
-#### containers
-
-`containers/` contains the mid-tier type of component. The distinction between a "container" and a "component" is a bit fuzzy, but generally the purpose of a container is to perform logic to *prepare* for rendering and then pass the resulting state to one or more stateless functional components for pure rendering. For example, for the trends view, the `TrendsContainer` determines the blood glucose and time domains on mount and on every update, preserving the current time domain in view and arrays of `cbg` and `smbg` currently in view (given the time domain) in its state. At the next level down, the `CBGTrendsContainer` sets up the rendering "canvas" (actually an SVG element) and scales for rendering (given the dimensions of the "canvas"). Another hallmark of "container" components is that they often do *not* have any associated styles since their purpose is computation and set up, not rendering.
-
-Files should be grouped into sub-directories by ["view"](#views) or located in a directory called `common/` if applicable to more than one view.
 
 #### views
 
@@ -150,3 +157,5 @@ In general, utilities should export individual constants, functions, &c, **not**
 ### The test directory
 
 The `test/` directory mirrors the structure of `src/`. Our convention for naming test files is to use the same names but insert `.test` before the `.js` suffix. For example, the tests for a component `BGSlice.js` should be in a file named `BGSlice.test.js`. The tests for a `datetime.js` utility file should be in a file named `datetime.test.js`.
+
+[^a]: Hence our decision to give up on organizing containers in a `src/containers/` directory distinct from `src/components/`.

--- a/docs/deps/React.md
+++ b/docs/deps/React.md
@@ -2,5 +2,5 @@
 
 Aside from [our general views on React best practices at Tidepool](http://developer.tidepool.io/docs/front-end/react/index.html 'Tidepool developer portal: React @ Tidepool'), to develop code in this repository you should:
 
-- understand our division between [components, containers, and views](../DirectoryStructure.md#react-component-directories)
+- understand our division between [components, "container" components, and views](../DirectoryStructure.md#react-component-directories)
 - understand [how we use D3 and React together]('./D3.md')

--- a/src/components/settings/common/PumpSettingsContainer.js
+++ b/src/components/settings/common/PumpSettingsContainer.js
@@ -20,12 +20,12 @@ import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import * as actions from '../../redux/actions/';
-import { MGDL_UNITS, MMOLL_UNITS } from '../../utils/constants';
+import * as actions from '../../../redux/actions/';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
 
-import NonTandem from '../../components/settings/NonTandem';
-import Tandem from '../../components/settings/Tandem';
-import { DISPLAY_VIEW, PRINT_VIEW } from '../../components/settings/constants';
+import NonTandem from '../NonTandem';
+import Tandem from '../Tandem';
+import { DISPLAY_VIEW, PRINT_VIEW } from '../../../components/settings/constants';
 
 export class PumpSettingsContainer extends PureComponent {
   static propTypes = {

--- a/src/components/trends/cbg/CBGDateTracesAnimationContainer.js
+++ b/src/components/trends/cbg/CBGDateTracesAnimationContainer.js
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import React, { PropTypes } from 'react';
 import TransitionGroupPlus from 'react-transition-group-plus';
 
-import CBGDateTraceAnimated from '../../components/trends/cbg/CBGDateTraceAnimated';
+import CBGDateTraceAnimated from './CBGDateTraceAnimated';
 
 const CBGDateTracesAnimationContainer = (props) => {
   const { bgBounds, data, dates, topMargin, xScale, yScale } = props;

--- a/src/components/trends/cbg/CBGSlicesContainer.js
+++ b/src/components/trends/cbg/CBGSlicesContainer.js
@@ -19,13 +19,13 @@ import _ from 'lodash';
 import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
-import { THIRTY_MINS, TWENTY_FOUR_HRS } from '../../utils/datetime';
+import { THIRTY_MINS, TWENTY_FOUR_HRS } from '../../../utils/datetime';
 import {
   findBinForTimeOfDay, findOutOfRangeAnnotations, calculateCbgStatsForBin,
-} from '../../utils/trends/data';
+} from '../../../utils/trends/data';
 
-import CBGMedianAnimated from '../../components/trends/cbg/CBGMedianAnimated';
-import CBGSliceAnimated from '../../components/trends/cbg/CBGSliceAnimated';
+import CBGMedianAnimated from './CBGMedianAnimated';
+import CBGSliceAnimated from './CBGSliceAnimated';
 
 export default class CBGSlicesContainer extends PureComponent {
   static propTypes = {

--- a/src/components/trends/common/TrendsContainer.js
+++ b/src/components/trends/common/TrendsContainer.js
@@ -27,13 +27,13 @@ import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import * as actions from '../../redux/actions/';
+import * as actions from '../../../redux/actions/';
 import TrendsSVGContainer from './TrendsSVGContainer';
 import {
   MGDL_CLAMP_TOP, MMOLL_CLAMP_TOP, MGDL_UNITS, MMOLL_UNITS, trends,
-} from '../../utils/constants';
+} from '../../../utils/constants';
 const { extentSizes: { ONE_WEEK, TWO_WEEKS, FOUR_WEEKS } } = trends;
-import * as datetime from '../../utils/datetime';
+import * as datetime from '../../../utils/datetime';
 
 /**
  * getAllDatesInRange

--- a/src/components/trends/common/TrendsSVGContainer.js
+++ b/src/components/trends/common/TrendsSVGContainer.js
@@ -43,23 +43,23 @@ import React, { PropTypes, PureComponent } from 'react';
 import dimensions from 'react-dimensions';
 import _ from 'lodash';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../utils/constants';
-import { THREE_HRS } from '../../utils/datetime';
-import { findDatesIntersectingWithCbgSliceSegment } from '../../utils/trends/data';
-import Background from '../../components/trends/common/Background';
-import CBGDateTracesAnimationContainer from './CBGDateTracesAnimationContainer';
-import CBGSlicesContainer from './CBGSlicesContainer';
-import FocusedCBGSliceSegment from '../../components/trends/cbg/FocusedCBGSliceSegment';
-import SMBGsByDateContainer from './SMBGsByDateContainer';
-import SMBGRangeAvgContainer from './SMBGRangeAvgContainer';
-import SMBGRangeAnimated from '../../components/trends/smbg/SMBGRangeAnimated';
-import SMBGMeanAnimated from '../../components/trends/smbg/SMBGMeanAnimated';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
+import { THREE_HRS } from '../../../utils/datetime';
+import { findDatesIntersectingWithCbgSliceSegment } from '../../../utils/trends/data';
+import Background from './Background';
+import CBGDateTracesAnimationContainer from '../cbg/CBGDateTracesAnimationContainer';
+import CBGSlicesContainer from '../cbg/CBGSlicesContainer';
+import FocusedCBGSliceSegment from '../cbg/FocusedCBGSliceSegment';
+import SMBGsByDateContainer from '../smbg/SMBGsByDateContainer';
+import SMBGRangeAvgContainer from '../smbg/SMBGRangeAvgContainer';
+import SMBGRangeAnimated from '../smbg/SMBGRangeAnimated';
+import SMBGMeanAnimated from '../smbg/SMBGMeanAnimated';
 
-import NoData from '../../components/trends/common/NoData';
-import TargetRangeLines from '../../components/trends/common/TargetRangeLines';
-import XAxisLabels from '../../components/trends/common/XAxisLabels';
-import XAxisTicks from '../../components/trends/common/XAxisTicks';
-import YAxisLabelsAndTicks from '../../components/trends/common/YAxisLabelsAndTicks';
+import NoData from './NoData';
+import TargetRangeLines from './TargetRangeLines';
+import XAxisLabels from './XAxisLabels';
+import XAxisTicks from './XAxisTicks';
+import YAxisLabelsAndTicks from './YAxisLabelsAndTicks';
 
 export class TrendsSVGContainer extends PureComponent {
   constructor(props) {

--- a/src/components/trends/smbg/SMBGRangeAvgContainer.js
+++ b/src/components/trends/smbg/SMBGRangeAvgContainer.js
@@ -19,10 +19,10 @@ import _ from 'lodash';
 import React, { PropTypes, PureComponent } from 'react';
 import { range } from 'd3-array';
 
-import { THREE_HRS, TWENTY_FOUR_HRS } from '../../utils/datetime';
+import { THREE_HRS, TWENTY_FOUR_HRS } from '../../../utils/datetime';
 import {
   findBinForTimeOfDay, findOutOfRangeAnnotations, calculateSmbgStatsForBin,
-} from '../../utils/trends/data';
+} from '../../../utils/trends/data';
 
 export default class SMBGRangeAvgContainer extends PureComponent {
   static propTypes = {

--- a/src/components/trends/smbg/SMBGsByDateContainer.js
+++ b/src/components/trends/smbg/SMBGsByDateContainer.js
@@ -18,8 +18,8 @@
 import React, { PropTypes } from 'react';
 import _ from 'lodash';
 
-import SMBGDatePointsAnimated from '../../components/trends/smbg/SMBGDatePointsAnimated';
-import SMBGDateLineAnimated from '../../components/trends/smbg/SMBGDateLineAnimated';
+import SMBGDatePointsAnimated from './SMBGDatePointsAnimated';
+import SMBGDateLineAnimated from './SMBGDateLineAnimated';
 
 const SMBGsByDateContainer = (props) => {
   const { data } = props;

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ import RangeSelect from './components/trends/cbg/RangeSelect';
 import TwoOptionToggle from './components/common/controls/TwoOptionToggle';
 
 import PumpSettingsContainer from './containers/settings/PumpSettingsContainer';
-import TrendsContainer from './containers/trends/TrendsContainer';
+import TrendsContainer from './components/trends/common/TrendsContainer';
 
 import vizReducer from './redux/reducers/';
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import RangeSelect from './components/trends/cbg/RangeSelect';
 
 import TwoOptionToggle from './components/common/controls/TwoOptionToggle';
 
-import PumpSettingsContainer from './containers/settings/PumpSettingsContainer';
+import PumpSettingsContainer from './components/settings/common/PumpSettingsContainer';
 import TrendsContainer from './components/trends/common/TrendsContainer';
 
 import vizReducer from './redux/reducers/';

--- a/test/components/settings/common/PumpSettingsContainer.test.js
+++ b/test/components/settings/common/PumpSettingsContainer.test.js
@@ -22,15 +22,15 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { PumpSettingsContainer, mapStateToProps, mapDispatchToProps }
-  from '../../../src/containers/settings/PumpSettingsContainer';
-import NonTandem from '../../../src/components/settings/NonTandem';
-import Tandem from '../../../src/components/settings/Tandem';
-import { MGDL_UNITS } from '../../../src/utils/constants';
+  from '../../../../src/components/settings/common/PumpSettingsContainer';
+import NonTandem from '../../../../src/components/settings/NonTandem';
+import Tandem from '../../../../src/components/settings/Tandem';
+import { MGDL_UNITS } from '../../../../src/utils/constants';
 
-const animasSettings = require('../../../data/pumpSettings/animas/multirate.json');
-const medtronicSettings = require('../../../data/pumpSettings/medtronic/multirate.json');
-const omnipodSettings = require('../../../data/pumpSettings/omnipod/multirate.json');
-const tandemSettings = require('../../../data/pumpSettings/tandem/multirate.json');
+const animasSettings = require('../../../../data/pumpSettings/animas/multirate.json');
+const medtronicSettings = require('../../../../data/pumpSettings/medtronic/multirate.json');
+const omnipodSettings = require('../../../../data/pumpSettings/omnipod/multirate.json');
+const tandemSettings = require('../../../../data/pumpSettings/tandem/multirate.json');
 
 describe('PumpSettingsContainer', () => {
   const user = {

--- a/test/components/trends/cbg/CBGDateTracesAnimationContainer.test.js
+++ b/test/components/trends/cbg/CBGDateTracesAnimationContainer.test.js
@@ -20,11 +20,11 @@ import React from 'react';
 import TransitionGroupPlus from 'react-transition-group-plus';
 import { shallow } from 'enzyme';
 
-import bgBounds from '../../helpers/bgBounds';
-import CBGDateTraceAnimated from '../../../src/components/trends/cbg/CBGDateTraceAnimated';
+import bgBounds from '../../../helpers/bgBounds';
+import CBGDateTraceAnimated from '../../../../src/components/trends/cbg/CBGDateTraceAnimated';
 
 import CBGDateTracesAnimationContainer
-  from '../../../src/containers/trends/CBGDateTracesAnimationContainer';
+  from '../../../../src/components/trends/cbg/CBGDateTracesAnimationContainer';
 
 describe('CBGDateTracesAnimationContainer', () => {
   const props = {

--- a/test/components/trends/cbg/CBGSlicesContainer.test.js
+++ b/test/components/trends/cbg/CBGSlicesContainer.test.js
@@ -20,19 +20,19 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 
-import * as scales from '../../helpers/scales';
+import * as scales from '../../../helpers/scales';
 const {
   trendsWidth: width,
   trendsHeight: height,
   trendsXScale: xScale,
   trendsYScale: yScale,
 } = scales.trends;
-import bgBounds from '../../helpers/bgBounds';
+import bgBounds from '../../../helpers/bgBounds';
 
-import { THREE_HRS, TWENTY_FOUR_HRS } from '../../../src/utils/datetime';
+import { THREE_HRS, TWENTY_FOUR_HRS } from '../../../../src/utils/datetime';
 import CBGSlicesContainer
-  from '../../../src/containers/trends/CBGSlicesContainer';
-import CBGSliceAnimated from '../../../src/components/trends/cbg/CBGSliceAnimated';
+  from '../../../../src/components/trends/cbg/CBGSlicesContainer';
+import CBGSliceAnimated from '../../../../src/components/trends/cbg/CBGSliceAnimated';
 
 describe('CBGSlicesContainer', () => {
   let wrapper;

--- a/test/components/trends/common/TrendsContainer.test.js
+++ b/test/components/trends/common/TrendsContainer.test.js
@@ -24,9 +24,9 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../../src/utils/constants';
-import { getLocalizedCeiling } from '../../../src/utils/datetime';
-import DummyComponent from '../../helpers/DummyComponent';
+import { MGDL_UNITS, MMOLL_UNITS } from '../../../../src/utils/constants';
+import { getLocalizedCeiling } from '../../../../src/utils/datetime';
+import DummyComponent from '../../../helpers/DummyComponent';
 
 import {
   TrendsContainer,
@@ -35,8 +35,8 @@ import {
   getLocalizedOffset,
   mapStateToProps,
   mapDispatchToProps,
-} from '../../../src/containers/trends/TrendsContainer';
-import TrendsSVGContainer from '../../../src/containers/trends/TrendsSVGContainer';
+} from '../../../../src/components/trends/common/TrendsContainer';
+import TrendsSVGContainer from '../../../../src/components/trends/common/TrendsSVGContainer';
 
 describe('TrendsContainer', () => {
   // stubbing console.warn gets rid of the annoying warnings from react-dimensions

--- a/test/components/trends/common/TrendsSVGContainer.test.js
+++ b/test/components/trends/common/TrendsSVGContainer.test.js
@@ -20,22 +20,22 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import bgBounds from '../../helpers/bgBounds';
+import bgBounds from '../../../helpers/bgBounds';
 
-import { TrendsSVGContainer } from '../../../src/containers/trends/TrendsSVGContainer';
+import { TrendsSVGContainer } from '../../../../src/components/trends/common/TrendsSVGContainer';
 
-import { MGDL_UNITS } from '../../../src/utils/constants';
+import { MGDL_UNITS } from '../../../../src/utils/constants';
 import Background
-  from '../../../src/components/trends/common/Background';
+  from '../../../../src/components/trends/common/Background';
 import CBGSlicesContainer
-  from '../../../src/containers/trends/CBGSlicesContainer';
+  from '../../../../src/components/trends/cbg/CBGSlicesContainer';
 import SMBGRangeAvgContainer
-  from '../../../src/containers/trends/SMBGRangeAvgContainer';
-import NoData from '../../../src/components/trends/common/NoData';
-import TargetRangeLines from '../../../src/components/trends/common/TargetRangeLines';
-import XAxisLabels from '../../../src/components/trends/common/XAxisLabels';
-import XAxisTicks from '../../../src/components/trends/common/XAxisTicks';
-import YAxisLabelsAndTicks from '../../../src/components/trends/common/YAxisLabelsAndTicks';
+  from '../../../../src/components/trends/smbg/SMBGRangeAvgContainer';
+import NoData from '../../../../src/components/trends/common/NoData';
+import TargetRangeLines from '../../../../src/components/trends/common/TargetRangeLines';
+import XAxisLabels from '../../../../src/components/trends/common/XAxisLabels';
+import XAxisTicks from '../../../../src/components/trends/common/XAxisTicks';
+import YAxisLabelsAndTicks from '../../../../src/components/trends/common/YAxisLabelsAndTicks';
 
 function makeScale(scale) {
   // eslint-disable-next-line no-param-reassign

--- a/test/components/trends/smbg/SMBGRangeAvgContainer.test.js
+++ b/test/components/trends/smbg/SMBGRangeAvgContainer.test.js
@@ -19,17 +19,17 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import * as scales from '../../helpers/scales';
+import * as scales from '../../../helpers/scales';
 const {
   trendsXScale: xScale,
   trendsYScale: yScale,
 } = scales.trends;
-import bgBounds from '../../helpers/bgBounds';
-import { THREE_HRS } from '../../../src/utils/datetime';
+import bgBounds from '../../../helpers/bgBounds';
+import { THREE_HRS } from '../../../../src/utils/datetime';
 import SMBGRangeAvgContainer
-  from '../../../src/containers/trends/SMBGRangeAvgContainer';
+  from '../../../../src/components/trends/smbg/SMBGRangeAvgContainer';
 import SMBGRangeAnimated
-  from '../../../src/components/trends/smbg/SMBGRangeAnimated';
+  from '../../../../src/components/trends/smbg/SMBGRangeAnimated';
 
 describe('SMBGRangeAvgContainer', () => {
   let wrapper;

--- a/test/components/trends/smbg/SMBGsByDateContainer.test.js
+++ b/test/components/trends/smbg/SMBGsByDateContainer.test.js
@@ -20,20 +20,20 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { THREE_HRS } from '../../../src/utils/datetime';
+import { THREE_HRS } from '../../../../src/utils/datetime';
 
-import bgBounds from '../../helpers/bgBounds';
-import * as scales from '../../helpers/scales';
+import bgBounds from '../../../helpers/bgBounds';
+import * as scales from '../../../helpers/scales';
 const {
   trendsXScale: xScale,
   trendsYScale: yScale,
 } = scales.trends;
 
-import SMBGDateLineAnimated from '../../../src/components/trends/smbg/SMBGDateLineAnimated';
-import SMBGDatePointsAnimated from '../../../src/components/trends/smbg/SMBGDatePointsAnimated';
+import SMBGDateLineAnimated from '../../../../src/components/trends/smbg/SMBGDateLineAnimated';
+import SMBGDatePointsAnimated from '../../../../src/components/trends/smbg/SMBGDatePointsAnimated';
 
 import SMBGsByDateContainer
-  from '../../../src/containers/trends/SMBGsByDateContainer';
+  from '../../../../src/components/trends/smbg/SMBGsByDateContainer';
 
 describe('SMBGsByDateContainer', () => {
   let wrapper;


### PR DESCRIPTION
I based this off #71 for expediency, but I'd review that first @krystophv to keep the diff sane. I've done a fair amount of running this locally to prove to myself that the reorganization hasn't broken anything, so I'm fairly confident we're good to go here.