### PR TITLE
relax node engine to avoid Yarn install failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This README is focused on just the nuts & bolts of getting the code in this repo
 
 ## Getting started
 
-After cloning this repository to your local machine, first make sure that you have node `6.x` and npm `3.x` installed. If you have a different major version of node installed, consider using [nvm](https://github.com/creationix/nvm 'GitHub: Node Version Manager') to manage and switch between multiple node (& npm) installations.
+After cloning this repository to your local machine, first make sure that you have at least node `6.x` and npm `4.x` installed. If you have a different major version of node installed, consider using [nvm](https://github.com/creationix/nvm 'GitHub: Node Version Manager') to manage and switch between multiple node (& npm) installations. If you have npm `3.x` installed (as it is by default with node `6.x`), then you can update to the latest npm `4.x` with `npm install -g npm@4`.
 
 It's not an absolute requirement, but it is preferable to have [Yarn](https://yarnpkg.com 'Yarn') installed, as it provides dependency management features above and beyond what npm provides. Just follow [Yarn's installation instructions](https://yarnpkg.com/en/docs/install 'Yarn installation instructions') (hint: for Mac users with Homebrew installed, it's just `brew install yarn`).
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/tidepool-org/viz.git"
   },
   "engines": {
-    "node": "6.x",
+    "node": ">=6.x",
     "npm": "3.x"
   },
   "license": "BSD-2-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.7.20",
+  "version": "0.8.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   "scripts": {
     "apidocs": "./node_modules/.bin/jsdoc2md",
     "browser-tests": "NODE_ENV=test ./node_modules/.bin/karma start --browsers Chrome",
-    "build": "NODE_ENV=production npm test && npm run clean && ./node_modules/.bin/webpack --config package.config.js --optimize-minimize",
+    "build": "NODE_ENV=production npm run clean && ./node_modules/.bin/webpack --config package.config.js --optimize-minimize",
     "build-docs": "./update-gh-pages.sh",
     "clean": "./node_modules/.bin/rimraf ./dist/*",
     "lint": "./node_modules/.bin/eslint .storybook/ src/ stories/ test/ *.js",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
+    "prepublishOnly": "./node_modules/.bin/rimraf ./node_modules && yarn install --frozen-lockfile && npm test && npm run build",
     "pretest": "npm run lint",
     "serve-docs": "./node_modules/.bin/gitbook serve",
     "start": "./node_modules/.bin/webpack --config package.config.js --watch",
@@ -27,7 +28,7 @@
   },
   "engines": {
     "node": ">=6.x",
-    "npm": "3.x"
+    "npm": "4.x"
   },
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"


### PR DESCRIPTION
See [this Travis build for blip](https://travis-ci.org/tidepool-org/blip/jobs/228490914) where Yarn failed out due to viz specifying a node engine of 6.x.

This is a dependency for [blip #414](https://github.com/tidepool-org/blip/pull/414).