### PR TITLE
render target agnostic bolus rendering

### DIFF
--- a/data/bolus/fixtures.js
+++ b/data/bolus/fixtures.js
@@ -1,0 +1,313 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+/*
+ * NB: the fixtures here are *not* accurate Tidepool data model references
+ * rather, they are minimal viable post-processed fixtures
+ * including all & only the properties/values necessary for rendering
+ *
+ * for tests and stories, we use a scale (e.g., detailBolusScale exported fromtest/helpers/scales)
+ * with a range of 0 to 15, so new fixtures should be limited to a max value of no more than 15
+ */
+
+const ONE_AM = Date.parse('1970-01-01T01:00:00.000Z');
+const ONE_HR = 36e5;
+
+export const normal = {
+  type: 'bolus',
+  normal: 6.25,
+  utc: ONE_AM,
+  id: '61b4d2ffc5a74d2b80b5a9ef44bf5c35',
+};
+
+export const interruptedNormal = {
+  type: 'bolus',
+  normal: 5,
+  expectedNormal: 6.25,
+  utc: ONE_AM,
+  id: 'a30ebc79aab0453097182cb0b456f511',
+};
+
+export const underrideNormal = {
+  type: 'wizard',
+  recommended: {
+    net: 10,
+    carb: 8,
+    correction: 2,
+  },
+  id: 'bbb9b4f9b58040e48c685066b0a28ec0',
+  bolus: {
+    normal: 8,
+    utc: ONE_AM,
+    id: '9ebaa1c5ecc44e96be0abd20a213ae33',
+  },
+};
+
+export const zeroUnderride = {
+  type: 'wizard',
+  recommended: {
+    net: 2,
+    carb: 2,
+    correction: 0,
+  },
+  id: 'b50524a4dcf44841affb7ad79a43f5ca',
+  bolus: {
+    type: 'bolus',
+    normal: 0,
+    utc: ONE_AM,
+    id: '20ed9117f14146eca5eeb65744fb8b3b',
+  },
+};
+
+export const overrideNormal = {
+  type: 'wizard',
+  recommended: {
+    net: 0.5,
+    carb: 2,
+    correction: -1.5,
+  },
+  id: '986d84dfbca845bcbd4fbd99018008f2',
+  bolus: {
+    type: 'bolus',
+    normal: 2,
+    utc: ONE_AM,
+    id: '3f9d0429e7dd4c2e8d9de1f3d64b1d79',
+  },
+};
+
+export const zeroOverride = {
+  type: 'wizard',
+  recommended: {
+    net: 0,
+    carb: 2,
+    correction: -2.5,
+  },
+  id: '32913fb32282410a8bc646a7cdecec96',
+  bolus: {
+    type: 'bolus',
+    normal: 2,
+    utc: ONE_AM,
+    id: '604447fccdf64ae097fa5626bceb83a7',
+  },
+};
+
+export const underrideAndInterruptedNormal = {
+  type: 'wizard',
+  recommended: {
+    net: 10,
+    carb: 8,
+    correction: 2,
+  },
+  id: '9605a117c8794d3daf6e8999470001c9',
+  bolus: {
+    type: 'bolus',
+    normal: 5,
+    expectedNormal: 8,
+    utc: ONE_AM,
+    id: '492b727fc81444c1ace8a680fe9d9d84',
+  },
+};
+
+export const overrideAndInterruptedNormal = {
+  type: 'wizard',
+  recommended: {
+    net: 5,
+    carb: 6,
+    correction: -1,
+  },
+  id: '340fb65556c9483d904c590b48075334',
+  bolus: {
+    type: 'bolus',
+    normal: 3,
+    expectedNormal: 6.5,
+    utc: ONE_AM,
+    id: '34fb3ee442b9417f9cb75ad2159d0ce4',
+  },
+};
+
+export const normalNextToExtended = {
+  type: 'bolus',
+  normal: 4.5,
+  utc: ONE_AM - ONE_HR,
+  id: 'a3267d29badc4a6290865efb85e514f8',
+};
+
+export const extended = {
+  type: 'bolus',
+  extended: 4.5,
+  duration: ONE_HR * 2,
+  utc: ONE_AM,
+  id: 'e7315de43ca640c39c6d96e632ad1597',
+};
+
+export const normalNextToInterruptedExtended = {
+  type: 'bolus',
+  normal: 2,
+  utc: ONE_AM - ONE_HR,
+  id: 'a3267d29badc4a6290865efb85e514f8',
+};
+
+export const interruptedExtended = {
+  type: 'bolus',
+  extended: 2,
+  expectedExtended: 4.5,
+  duration: (4 / 9) * ONE_HR * 2,
+  expectedDuration: ONE_HR * 2,
+  utc: ONE_AM,
+  id: '394920ee271d4d4f9698f218eacab93e',
+};
+
+export const overrideExtended = {
+  type: 'wizard',
+  recommended: {
+    carb: 4,
+    correction: 0,
+    net: 4,
+  },
+  id: '34ca42f0b98e4449b2b0c3571c9179d2',
+  bolus: {
+    type: 'bolus',
+    extended: 5,
+    duration: ONE_HR,
+    utc: ONE_AM,
+    id: 'caab15e17371454fb33394fce298da4f',
+  },
+};
+
+export const underrideExtended = {
+  type: 'wizard',
+  recommended: {
+    carb: 4,
+    correction: 0,
+    net: 4,
+  },
+  id: '34ca42f0b98e4449b2b0c3571c9179d2',
+  bolus: {
+    type: 'bolus',
+    extended: 2,
+    duration: ONE_HR,
+    utc: ONE_AM,
+    id: 'caab15e17371454fb33394fce298da4f',
+  },
+};
+
+export const interruptedUnderrideExtended = {
+  type: 'wizard',
+  recommended: {
+    carb: 4,
+    correction: 0,
+    net: 4,
+  },
+  id: '562f9c0526114185a43cd811abccd580',
+  bolus: {
+    type: 'bolus',
+    extended: 1.5,
+    expectedExtended: 2,
+    duration: ONE_HR * (3 / 4),
+    expectedDuration: ONE_HR,
+    utc: ONE_AM,
+    id: '6fff287cea9f4dd6b5804fbc5427e78d',
+  },
+};
+
+export const combo = {
+  type: 'bolus',
+  normal: 4,
+  extended: 2,
+  duration: ONE_HR * 2,
+  utc: ONE_AM,
+  id: 'c9a88ae2fa004577b17d1fb53d918635',
+};
+
+export const interruptedDuringNormalCombo = {
+  type: 'bolus',
+  normal: 2,
+  expectedNormal: 4,
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: ONE_HR * 2,
+  utc: ONE_AM,
+  id: 'd96f44a8a6884e2ca358cd76ba1cf9db',
+};
+
+export const interruptedDuringExtendedCombo = {
+  type: 'bolus',
+  normal: 4,
+  extended: 2,
+  expectedExtended: 3,
+  duration: ONE_HR * 2,
+  expectedDuration: ONE_HR * 3,
+  utc: ONE_AM,
+  id: 'd0f343a8878749eab89a6d02bc6d8c4f',
+};
+
+export const underrideCombo = {
+  type: 'wizard',
+  recommended: {
+    carb: 8,
+    correction: 1.25,
+    net: 8.75,
+  },
+  id: '284e8de0ad1b481fb5e47657bc5ad20b',
+  bolus: {
+    type: 'bolus',
+    normal: 4.75,
+    extended: 2,
+    duration: ONE_HR,
+    utc: ONE_AM,
+    id: '873c0c9e96f842a889621f3107cacc3c',
+  },
+};
+
+export const overrideCombo = {
+  type: 'wizard',
+  recommended: {
+    carb: 8,
+    correction: 1.25,
+    net: 8.75,
+  },
+  id: '2ed2af071b354d80b89a00435f077ba1',
+  bolus: {
+    type: 'bolus',
+    normal: 5.75,
+    extended: 5,
+    duration: ONE_HR,
+    utc: ONE_AM,
+    id: '4f052761d63b4787a532ee7f906d2e86',
+  },
+};
+
+export const interruptedOverrideCombo = {
+  type: 'wizard',
+  recommended: {
+    carb: 8,
+    correction: 1.25,
+    net: 8.75,
+  },
+  id: 'cf73a3732a254583ae4fa1a20003be4d',
+  bolus: {
+    type: 'bolus',
+    normal: 5.75,
+    extended: 2.5,
+    expectedExtended: 5,
+    duration: ONE_HR * 2,
+    expectedDuration: ONE_HR * 4,
+    utc: ONE_AM,
+    id: '85b9f452e9534f399390040e326d6dc2',
+  },
+};

--- a/src/components/common/data/Bolus.css
+++ b/src/components/common/data/Bolus.css
@@ -15,32 +15,14 @@
  * == BSD2 LICENSE ==
  */
 
-.bgLow {
-  color: var(--bg-low);
-  fill: var(--bg-low);
+.interrupted {
+  composes: bolusInterrupted from '../../../styles/diabetes.css';
 }
 
-.bgTarget {
-  color: var(--bg-target);
-  fill: var(--bg-target);
+.normal {
+  composes: bolus from '../../../styles/diabetes.css';
 }
 
-.bgHigh {
-  color: var(--bg-high);
-  fill: var(--bg-high);
-}
-
-.bolus {
-  color: var(--bolus);
-  fill: var(--bolus);
-}
-
-.bolusInterrupted {
-  color: var(--bolus--interrupted);
-  fill: var(--bolus--interrupted);
-}
-
-.bolusUndelivered {
-  color: var(--bolus--undelivered);
-  fill: var(--bolus--undelivered);
+.undelivered {
+  composes: bolusUndelivered from '../../../styles/diabetes.css';
 }

--- a/src/components/common/data/Bolus.css
+++ b/src/components/common/data/Bolus.css
@@ -15,14 +15,57 @@
  * == BSD2 LICENSE ==
  */
 
+.noStroke {
+  stroke: none;
+  stroke-width: 0;
+}
+
+.delivered {
+  composes: noStroke;
+  composes: bolusDelivered from '../../../styles/diabetes.css';
+}
+
+.extendedExpectationPath {
+  composes: bolusExtendedPath bolusUndelivered from '../../../styles/diabetes.css';
+}
+
+.extendedInterrupted {
+  composes: bolusInterrupted from '../../../styles/diabetes.css';
+}
+
+.extendedPath {
+  composes: bolusDelivered bolusExtendedPath from '../../../styles/diabetes.css';
+}
+
+.extendedTriangle {
+  composes: noStroke;
+  composes: bolusDelivered from '../../../styles/diabetes.css';
+}
+
+.extendedTriangleInterrupted {
+  composes: noStroke;
+  composes: bolusUndelivered from '../../../styles/diabetes.css';
+}
+
 .interrupted {
   composes: bolusInterrupted from '../../../styles/diabetes.css';
 }
 
-.normal {
-  composes: bolus from '../../../styles/diabetes.css';
+.programmed {
+  composes: bolusProgrammed from '../../../styles/diabetes.css';
+}
+
+.triangle {
+  composes: noStroke;
+  composes: bolusRideTriangle from '../../../styles/diabetes.css';
 }
 
 .undelivered {
+  composes: noStroke;
   composes: bolusUndelivered from '../../../styles/diabetes.css';
+}
+
+.underride {
+  composes: noStroke;
+  composes: bolusUnderride from '../../../styles/diabetes.css';
 }

--- a/src/components/common/data/Bolus.js
+++ b/src/components/common/data/Bolus.js
@@ -18,10 +18,29 @@
 import _ from 'lodash';
 import React, { PropTypes } from 'react';
 
+import { getBolusFromInsulinEvent } from '../../../utils/bolus';
+import getBolusPaths from '../../../modules/render/bolus';
+
 import styles from './Bolus.css';
 
 const Bolus = (props) => {
-  const { bolus, paths } = props;
+  const {
+    insulinEvent,
+    bolusWidth,
+    extendedLineThickness,
+    interruptedLineThickness,
+    triangleHeight,
+    xScale,
+    yScale,
+  } = props;
+  const bolus = getBolusFromInsulinEvent(insulinEvent);
+  const paths = getBolusPaths(insulinEvent, xScale, yScale, {
+    bolusWidth, extendedLineThickness, interruptedLineThickness, triangleHeight,
+  });
+  if (_.isEmpty(paths)) {
+    return null;
+  }
+
   return (
     <g id={`bolus-${bolus.id}`}>
       {_.map(paths, (path) => (<path className={styles[path.type]} d={path.d} key={path.key} />))}
@@ -29,14 +48,53 @@ const Bolus = (props) => {
   );
 };
 
+Bolus.defaultProps = {
+  bolusWidth: 12,
+  extendedLineThickness: 2,
+  interruptedLineThickness: 2,
+  triangleHeight: 5,
+};
+
 Bolus.propTypes = {
-  bolus: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }).isRequired,
-  paths: PropTypes.arrayOf(PropTypes.shape({
-    d: PropTypes.string.isRequired,
-    key: PropTypes.string.isRequired,
-  })).isRequired,
+  insulinEvent: PropTypes.oneOfType([
+    PropTypes.shape({
+      normal: PropTypes.number,
+      expectedNormal: PropTypes.number,
+      extended: PropTypes.number,
+      expectedExtended: PropTypes.number,
+      duration: PropTypes.number,
+      expectedDuration: PropTypes.number,
+      id: PropTypes.string.isRequired,
+      type: PropTypes.oneOf(['bolus']).isRequired,
+      utc: PropTypes.number.isRequired,
+    }).isRequired,
+    PropTypes.shape({
+      bolus: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        normal: PropTypes.number,
+        expectedNormal: PropTypes.number,
+        extended: PropTypes.number,
+        expectedExtended: PropTypes.number,
+        duration: PropTypes.number,
+        expectedDuration: PropTypes.number,
+        type: PropTypes.oneOf(['bolus']).isRequired,
+        utc: PropTypes.number.isRequired,
+      }).isRequired,
+      recommended: PropTypes.shape({
+        carb: PropTypes.number,
+        correction: PropTypes.number,
+        net: PropTypes.number,
+      }).isRequired,
+      id: PropTypes.string.isRequired,
+      type: PropTypes.oneOf(['wizard']).isRequired,
+    }).isRequired,
+  ]).isRequired,
+  bolusWidth: PropTypes.number.isRequired,
+  extendedLineThickness: PropTypes.number.isRequired,
+  interruptedLineThickness: PropTypes.number.isRequired,
+  triangleHeight: PropTypes.number.isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
 };
 
 export default Bolus;

--- a/src/components/common/data/Bolus.js
+++ b/src/components/common/data/Bolus.js
@@ -15,32 +15,28 @@
  * == BSD2 LICENSE ==
  */
 
-.bgLow {
-  color: var(--bg-low);
-  fill: var(--bg-low);
-}
+import _ from 'lodash';
+import React, { PropTypes } from 'react';
 
-.bgTarget {
-  color: var(--bg-target);
-  fill: var(--bg-target);
-}
+import styles from './Bolus.css';
 
-.bgHigh {
-  color: var(--bg-high);
-  fill: var(--bg-high);
-}
+const Bolus = (props) => {
+  const { bolus, paths } = props;
+  return (
+    <g id={`bolus-${bolus.id}`}>
+      {_.map(paths, (path) => (<path className={styles[path.type]} d={path.d} key={path.key} />))}
+    </g>
+  );
+};
 
-.bolus {
-  color: var(--bolus);
-  fill: var(--bolus);
-}
+Bolus.propTypes = {
+  bolus: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  paths: PropTypes.arrayOf(PropTypes.shape({
+    d: PropTypes.string.isRequired,
+    key: PropTypes.string.isRequired,
+  })).isRequired,
+};
 
-.bolusInterrupted {
-  color: var(--bolus--interrupted);
-  fill: var(--bolus--interrupted);
-}
-
-.bolusUndelivered {
-  color: var(--bolus--undelivered);
-  fill: var(--bolus--undelivered);
-}
+export default Bolus;

--- a/src/modules/render/bolus.js
+++ b/src/modules/render/bolus.js
@@ -15,29 +15,46 @@
  * == BSD2 LICENSE ==
  */
 
-import { getBolusFromInsulinEvent } from '../../utils/bolus';
+import * as bolusUtils from '../../utils/bolus';
 
-export function isInterruptedBolus(bolus) {
-  return bolus.normal &&
-    bolus.expectedNormal &&
-    bolus.expectedNormal > 0 &&
-    bolus.normal !== bolus.expectedNormal;
+/**
+ * formatBolusRectPath
+ * @param {Object} bolusEdges - object containing `left`, `right`, `top`, `bottom` edges
+ *
+ * @return {String} SVG path data string defining a bolus rectangle
+ */
+function formatBolusRectPath({ left, right, top, bottom }) {
+  // PDFKit will not render path definitions with line breaks properly
+  // do NOT forget to remove the newlines!
+  return `
+    M ${left},${bottom}
+    L ${left},${top}
+    L ${right},${top}
+    L ${right},${bottom} Z
+  `.replace('\n', '');
 }
 
-export function makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, bolusHeight) {
+/**
+ * getBolusEdges
+ * @param {Number} bolusWidth - width of a bolus (rendering-platform specific)
+ * @param {Number} bolusCenter - scaled center of the bolus on the x (i.e., time) axis
+ * @param {Number} bolusBottom - scaled bottom of the bolus on the y-axis
+ * @param {Number} bolusHeight - scaled height of the bolus
+ *
+ * @return {Object} object containing `left`, `right`, `top`, `bottom` edges for a bolus rectangle
+ */
+export function getBolusEdges(bolusWidth, bolusCenter, bolusBottom, bolusHeight) {
   const halfWidth = bolusWidth / 2;
 
   const leftX = bolusCenter - halfWidth;
   const rightX = bolusCenter + halfWidth;
 
-  // PDFKit will not render path definitions with line breaks properly
-  // do NOT forget to remove the newlines!
-  return `
-    M ${leftX},${bolusBottom}
-    L ${leftX},${bolusHeight}
-    L ${rightX},${bolusHeight}
-    L ${rightX},${bolusBottom} Z
-  `.replace('\n', '');
+  return {
+    left: leftX,
+    right: rightX,
+    top: bolusHeight,
+    bottom: bolusBottom,
+  };
 }
 
 /**
@@ -50,50 +67,207 @@ export function makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, bol
  * @return {Array} paths - Object of component paths to draw a bolus
  */
 export default function getBolusPaths(insulinEvent, xScale, yScale, {
-  bolusWidth, interruptedLineThickness,
+  bolusWidth,
+  extendedLineThickness,
+  interruptedLineThickness,
+  triangleHeight,
 }) {
-  const bolus = getBolusFromInsulinEvent(insulinEvent);
+  const bolus = bolusUtils.getBolusFromInsulinEvent(insulinEvent);
   const paths = [];
 
   const bolusBottom = yScale.range()[0];
   const bolusCenter = xScale(bolus.utc);
 
-  // the backmost layer is any undelivered bolus insulin (in the case of interruption or underride)
-  if (isInterruptedBolus(bolus)) {
-    const undeliveredY = yScale(bolus.expectedNormal);
-    const path = makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, undeliveredY);
+  const isNonTrivialUnderride = bolusUtils.isUnderride(insulinEvent) &&
+    bolusUtils.getDelivered(insulinEvent);
+  const isNonTrivialOverride = bolusUtils.isOverride(insulinEvent) &&
+    bolusUtils.getDelivered(insulinEvent);
+
+  // the backmost layer is any undelivered bolus insulin
+  // (in the case of interruption/cancellation/suspension)
+  // this is a (partial) port of tideline's js/plot/util/drawbolus.js: suspended
+  if (bolusUtils.isInterruptedBolus(insulinEvent)) {
+    const undeliveredY = yScale(bolusUtils.getMaxValue(insulinEvent));
+    const edges = getBolusEdges(bolusWidth, bolusCenter, bolusBottom, undeliveredY);
+    const { left, right } = edges;
+    const path = formatBolusRectPath(edges);
 
     paths.push({
       d: path,
-      key: `undeliveredNormal-${bolus.id}`,
+      key: `undelivered-${bolus.id}`,
       type: 'undelivered',
     });
-  }
 
-  if (bolus.normal && bolus.normal > 0) {
-    const maxY = yScale(bolus.normal);
-    const path = makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, maxY);
+    const programmedY = yScale(bolusUtils.getProgrammed(insulinEvent));
+    const deliveredY = yScale(bolusUtils.getDelivered(insulinEvent));
+    // NB: JFC, Chrome uses a constant offset no matter the stroke-width :(((
+    // TODO: test in different browsers and adjust
+    const fractionStroke = 0.5;
 
+    // TODO: figure out how to make this agnostic to browser and render target
     paths.push({
-      d: path,
-      key: `normal-${bolus.id}`,
-      type: 'normal',
+      d: `
+        M ${left + fractionStroke},${deliveredY}
+        L ${left + fractionStroke},${programmedY + fractionStroke}
+        L ${right - fractionStroke},${programmedY + fractionStroke}
+        L ${right - fractionStroke},${deliveredY}
+      `.replace('\n', ''),
+      key: `programmed-${bolus.id}`,
+      type: 'programmed',
     });
+  // the rectangle for undelivered includes an underride if the insulinEvent
+  // was *both* an underride and interrupted/cancelled/suspended
+  } else {
+    // this is a (partial) port of tideline's js/plot/util/drawbolus.js: underride
+    if (isNonTrivialUnderride) {
+      const recommendedY = yScale(bolusUtils.getRecommended(insulinEvent));
+      const path = formatBolusRectPath(
+        getBolusEdges(bolusWidth, bolusCenter, bolusBottom, recommendedY)
+      );
+
+      paths.push({
+        d: path,
+        key: `underride-${insulinEvent.id}`,
+        type: 'underride',
+      });
+    }
   }
 
-  // the red line indicating interruption appears on top
-  if (isInterruptedBolus(bolus)) {
-    const bottomOfInterruptedLine = yScale(bolus.normal);
-    const path = makeBolusRectanglePath(
-      bolusWidth,
-      bolusCenter,
-      bottomOfInterruptedLine,
-      bottomOfInterruptedLine + interruptedLineThickness,
+  // this is a port of tideline's js/plot/util/drawbolus.js: bolus
+  if (bolusUtils.getDelivered(insulinEvent) || bolusUtils.getProgrammed((insulinEvent))) {
+    const maxY = yScale(bolusUtils.getDelivered(insulinEvent));
+    const path = formatBolusRectPath(
+      getBolusEdges(bolusWidth, bolusCenter, bolusBottom, maxY)
     );
 
     paths.push({
       d: path,
-      key: `interruptedNormal-${bolus.id}`,
+      key: `delivered-${bolus.id}`,
+      type: 'delivered',
+    });
+  }
+
+  // this is a port of tideline's js/plot/util/drawbolus.js: extended
+  // it does the straight part of the "arm" representing the extended part of the bolus
+  // and also the triangle at the end of the "arm"
+  if (bolusUtils.hasExtended(insulinEvent)) {
+    const extendedVal = bolusUtils.getExtended(insulinEvent);
+    // yes, 4.5 is a magic number that matches the first tideline implementation
+    // the benefit of 4.5 * extendedLineThickness is that
+    // it scales with various settings for line thickness, which may vary based on render target
+    const triangleSize = 4.5 * extendedLineThickness;
+    const halfTriangle = triangleSize / 2;
+    const startOfTriangle = xScale(bolus.utc + bolusUtils.getMaxDuration(insulinEvent))
+      - triangleSize;
+    const extendedY = yScale(extendedVal) + (extendedLineThickness / 2);
+
+    if (extendedVal > 0) {
+      paths.push({
+        d: `
+          M ${bolusCenter},${extendedY}
+          L ${startOfTriangle + extendedLineThickness},${extendedY}
+        `.replace('\n', ''),
+        key: `extendedPath-${bolus.id}`,
+        type: 'extendedPath',
+      });
+    }
+
+    const interruptedExtended = bolusUtils.isInterruptedBolus(insulinEvent) && extendedVal > 0;
+
+    if (interruptedExtended) {
+      const startOfInterrupted = xScale(bolus.utc + bolusUtils.getDuration(insulinEvent));
+
+      paths.push({
+        d: `
+          M ${startOfInterrupted},${extendedY}
+          L ${startOfTriangle + extendedLineThickness},${extendedY}
+        `.replace('\n', ''),
+        key: `extendedExpectationPath-${bolus.id}`,
+        type: 'extendedExpectationPath',
+      });
+
+      const halfInterrupted = interruptedLineThickness / 2;
+
+      paths.push({
+        d: `
+          M ${startOfInterrupted},${extendedY - halfInterrupted}
+          L ${startOfInterrupted - interruptedLineThickness * 2},${extendedY - halfInterrupted}
+          L ${startOfInterrupted - interruptedLineThickness * 2},${extendedY + halfInterrupted}
+          L ${startOfInterrupted},${extendedY + halfInterrupted} Z
+        `.replace('\n', ''),
+        key: `extendedInterrupted-${bolus.id}`,
+        type: 'extendedInterrupted',
+      });
+    }
+
+    if (extendedVal > 0) {
+      paths.push({
+        d: `
+          M ${startOfTriangle + triangleSize},${extendedY - halfTriangle}
+          L ${startOfTriangle + triangleSize},${extendedY + halfTriangle}
+          L ${startOfTriangle},${extendedY} Z
+        `.replace('\n', ''),
+        key: `extendedTriangle-${bolus.id}`,
+        type: `extendedTriangle${interruptedExtended ? 'Interrupted' : ''}`,
+      });
+    }
+  }
+
+  // this is a (partial) port of tideline's js/plot/util/drawbolus.js: underride
+  // it does the triangle for an underride of a calculator recommendation
+  if (isNonTrivialUnderride) {
+    const programmedY = yScale(bolusUtils.getProgrammed(insulinEvent));
+    const edges = getBolusEdges(
+      bolusWidth, bolusCenter, bolusBottom, programmedY,
+    );
+    const { left, right } = edges;
+
+    paths.push({
+      d: `
+        M ${left},${programmedY}
+        L ${left + bolusWidth / 2},${programmedY + triangleHeight}
+        L ${right},${programmedY} Z
+      `.replace('\n', ''),
+      key: `underrideTriangle-${insulinEvent.id}`,
+      type: 'underrideTriangle',
+    });
+  }
+
+  // this is a (partial) port of tideline's js/plot/util/drawbolus.js: override
+  // it does the triangle for an override of a calculator recommendation
+  if (isNonTrivialOverride) {
+    const recommendedY = yScale(bolusUtils.getRecommended(insulinEvent));
+    const edges = getBolusEdges(
+      bolusWidth, bolusCenter, bolusBottom, recommendedY,
+    );
+    const { left, right } = edges;
+
+    paths.push({
+      d: `
+        M ${left},${recommendedY}
+        L ${left + bolusWidth / 2},${recommendedY - triangleHeight}
+        L ${right},${recommendedY} Z
+      `.replace('\n', ''),
+      key: `overrideTriangle-${insulinEvent.id}`,
+      type: 'overrideTriangle',
+    });
+  }
+
+  // the red line indicating interruption/cancellation/suspension appears on top
+  // this is a (partial) port of tideline's js/plot/util/drawbolus.js: suspended
+  if (bolusUtils.isInterruptedBolus(insulinEvent)) {
+    const bottomOfInterruptedLine = yScale(bolusUtils.getDelivered(insulinEvent));
+    const path = formatBolusRectPath(
+      getBolusEdges(
+        bolusWidth,
+        bolusCenter,
+        bottomOfInterruptedLine,
+        bottomOfInterruptedLine + interruptedLineThickness,
+    ));
+
+    paths.push({
+      d: path,
+      key: `interrupted-${bolus.id}`,
       type: 'interrupted',
     });
   }

--- a/src/modules/render/bolus.js
+++ b/src/modules/render/bolus.js
@@ -1,0 +1,102 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import { getBolusFromInsulinEvent } from '../../utils/bolus';
+
+export function isInterruptedBolus(bolus) {
+  return bolus.normal &&
+    bolus.expectedNormal &&
+    bolus.expectedNormal > 0 &&
+    bolus.normal !== bolus.expectedNormal;
+}
+
+export function makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, bolusHeight) {
+  const halfWidth = bolusWidth / 2;
+
+  const leftX = bolusCenter - halfWidth;
+  const rightX = bolusCenter + halfWidth;
+
+  // PDFKit will not render path definitions with line breaks properly
+  // do NOT forget to remove the newlines!
+  return `
+    M ${leftX},${bolusBottom}
+    L ${leftX},${bolusHeight}
+    L ${rightX},${bolusHeight}
+    L ${rightX},${bolusBottom} Z
+  `.replace('\n', '');
+}
+
+/**
+ * getBolusPaths
+ * @param {Object} insulinEvent - a Tidepool wizard (with embedded bolus) or bolus datum
+ * @param {Function} xScale - xScale preconfigured with domain & range
+ * @param {Function} yScale - yScale preconfigured with domain & range
+ * @param {Object} opts - bolus rendering options such as width
+ *
+ * @return {Array} paths - Object of component paths to draw a bolus
+ */
+export default function getBolusPaths(insulinEvent, xScale, yScale, {
+  bolusWidth, interruptedLineThickness,
+}) {
+  const bolus = getBolusFromInsulinEvent(insulinEvent);
+  const paths = [];
+
+  const bolusBottom = yScale.range()[0];
+  const bolusCenter = xScale(bolus.utc);
+
+  // the backmost layer is any undelivered bolus insulin (in the case of interruption or underride)
+  if (isInterruptedBolus(bolus)) {
+    const undeliveredY = yScale(bolus.expectedNormal);
+    const path = makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, undeliveredY);
+
+    paths.push({
+      d: path,
+      key: `undeliveredNormal-${bolus.id}`,
+      type: 'undelivered',
+    });
+  }
+
+  if (bolus.normal && bolus.normal > 0) {
+    const maxY = yScale(bolus.normal);
+    const path = makeBolusRectanglePath(bolusWidth, bolusCenter, bolusBottom, maxY);
+
+    paths.push({
+      d: path,
+      key: `normal-${bolus.id}`,
+      type: 'normal',
+    });
+  }
+
+  // the red line indicating interruption appears on top
+  if (isInterruptedBolus(bolus)) {
+    const bottomOfInterruptedLine = yScale(bolus.normal);
+    const path = makeBolusRectanglePath(
+      bolusWidth,
+      bolusCenter,
+      bottomOfInterruptedLine,
+      bottomOfInterruptedLine + interruptedLineThickness,
+    );
+
+    paths.push({
+      d: path,
+      key: `interruptedNormal-${bolus.id}`,
+      type: 'interrupted',
+    });
+  }
+
+  return paths;
+}

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -19,6 +19,7 @@
   --basal: #19A0D7;
   --bolus: #7CD0F0;
   --bolus--interrupted: #FF8B7C;
+  --bolus--override: #107EA8;
   --bolus--undelivered: #BCECFA;
   --collapsible--border: #EDEDED;
   --table-stripe--light: #F7F7F7;

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -18,6 +18,8 @@
 :root {
   --basal: #19A0D7;
   --bolus: #7CD0F0;
+  --bolus--interrupted: #FF8B7C;
+  --bolus--undelivered: #BCECFA;
   --collapsible--border: #EDEDED;
   --table-stripe--light: #F7F7F7;
   --table-stripe--dark: #ECECEC;
@@ -51,4 +53,10 @@
   --blue-green-light: #12d3d8;
   --gray-dark: #989897;
   --white: #ffffff;
+}
+
+:export {
+  low: #FF8B7C;
+  target: #76D3A6;
+  high: #BB9AE7;
 }

--- a/src/styles/diabetes.css
+++ b/src/styles/diabetes.css
@@ -15,6 +15,10 @@
  * == BSD2 LICENSE ==
  */
 
+:root {
+  --bolus-stroke: 1;
+}
+
 .bgLow {
   color: var(--bg-low);
   fill: var(--bg-low);
@@ -30,9 +34,14 @@
   fill: var(--bg-high);
 }
 
-.bolus {
+.bolusDelivered {
   color: var(--bolus);
   fill: var(--bolus);
+  stroke: var(--bolus);
+}
+
+.bolusExtendedPath {
+  stroke-width: 2;
 }
 
 .bolusInterrupted {
@@ -40,7 +49,25 @@
   fill: var(--bolus--interrupted);
 }
 
+.bolusProgrammed {
+  fill: none;
+  stroke: var(--bolus);
+  stroke-dasharray: 3, 2;
+  stroke-width: var(--bolus-stroke);
+}
+
+.bolusRideTriangle {
+  fill: var(--bolus--override);
+}
+
 .bolusUndelivered {
   color: var(--bolus--undelivered);
   fill: var(--bolus--undelivered);
+  stroke: var(--bolus--undelivered);
+}
+
+.bolusUnderride {
+  color: var(--bolus--undelivered);
+  fill: var(--bolus--undelivered);
+  stroke: var(--bolus--undelivered);
 }

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -129,6 +129,43 @@ export function getDelivered(insulinEvent) {
 }
 
 /**
+ * getDuration
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} duration value in milliseconds
+ */
+export function getDuration(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+  }
+  // don't want truthiness here because want to return duration
+  // from a bolus interrupted immediately (duration = 0)
+  if (bolus.duration == null) {
+    return NaN;
+  }
+  return bolus.duration;
+}
+
+/**
+ * getExtended
+ * @param {Object} insulinEvent - a Tidepool wizard or bolus object
+ *
+ * @return {Number} units of insulin delivered over an extended duration
+ */
+export function getExtended(insulinEvent) {
+  const bolus = getBolusFromInsulinEvent(insulinEvent);
+
+  // don't want truthiness here because want to return expectedExtended
+  // from a bolus interrupted immediately (extended = 0)
+  if (bolus.extended == null) {
+    return NaN;
+  }
+
+  return bolus.extended;
+}
+
+/**
  * getMaxDuration
  * @param {Object} insulinEvent - a Tidepool bolus or wizard object
  *
@@ -164,6 +201,20 @@ export function getMaxValue(insulinEvent) {
   const programmed = getProgrammed(bolus);
   const recommended = getRecommended(insulinEvent) || 0;
   return (recommended > programmed) ? recommended : programmed;
+}
+
+/**
+ * hasExtended
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Boolean} whether the bolus has an extended delivery portion
+ */
+export function hasExtended(insulinEvent) {
+  const bolus = getBolusFromInsulinEvent(insulinEvent);
+
+  // NB: intentionally invoking truthiness here
+  // a bolus with `extended` value 0 and `expectedExtended` value 0 is pointless to render
+  return Boolean(bolus.extended || bolus.expectedExtended) || false;
 }
 
 /**

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -141,7 +141,7 @@ export function getDuration(insulinEvent) {
   }
   // don't want truthiness here because want to return duration
   // from a bolus interrupted immediately (duration = 0)
-  if (bolus.duration == null) {
+  if (!_.inRange(bolus.duration, Infinity)) {
     return NaN;
   }
   return bolus.duration;
@@ -158,7 +158,7 @@ export function getExtended(insulinEvent) {
 
   // don't want truthiness here because want to return expectedExtended
   // from a bolus interrupted immediately (extended = 0)
-  if (bolus.extended == null) {
+  if (!_.inRange(bolus.extended, Infinity)) {
     return NaN;
   }
 
@@ -178,7 +178,7 @@ export function getMaxDuration(insulinEvent) {
   }
   // don't want truthiness here because want to return expectedDuration
   // from a bolus interrupted immediately (duration = 0)
-  if (bolus.duration == null) {
+  if (!_.inRange(bolus.duration, Infinity)) {
     return NaN;
   }
   return bolus.expectedDuration || bolus.duration;

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -175,8 +175,23 @@ export function getMaxValue(insulinEvent) {
 export function isInterruptedBolus(insulinEvent) {
   const bolus = getBolusFromInsulinEvent(insulinEvent);
 
-  return bolus.normal &&
+  const cancelledDuringNormal = Boolean(
+    bolus.normal != null &&
     bolus.expectedNormal &&
-    bolus.expectedNormal > 0 &&
-    bolus.normal !== bolus.expectedNormal;
+    bolus.normal !== bolus.expectedNormal
+  );
+
+  const cancelledDuringExtended = Boolean(
+    bolus.extended != null &&
+    bolus.expectedExtended &&
+    bolus.extended !== bolus.expectedExtended
+  );
+
+  if (bolus.normal) {
+    if (!bolus.extended) {
+      return cancelledDuringNormal;
+    }
+    return cancelledDuringNormal || cancelledDuringExtended;
+  }
+  return cancelledDuringExtended;
 }

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -195,3 +195,23 @@ export function isInterruptedBolus(insulinEvent) {
   }
   return cancelledDuringExtended;
 }
+
+/**
+ * isOverride
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Boolean} whether the bolus programmed was larger than the calculated recommendation
+ */
+export function isOverride(insulinEvent) {
+  return getRecommended(insulinEvent) < getProgrammed(insulinEvent);
+}
+
+/**
+ * isUnderride
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Boolean} whether the bolus programmed was smaller than the calculated recommendation
+ */
+export function isUnderride(insulinEvent) {
+  return getRecommended(insulinEvent) > getProgrammed(insulinEvent);
+}

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -47,29 +47,6 @@ export function getBolusFromInsulinEvent(insulinEvent) {
 }
 
 /**
- * getDelivered
- * @param {Object} insulinEvent - a Tidepool bolus or wizard object
- *
- * @return {Number} units of insulin delivered in this insulinEvent
- */
-export function getDelivered(insulinEvent) {
-  let bolus = insulinEvent;
-  if (_.get(insulinEvent, 'type') === 'wizard') {
-    bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus.normal && !bolus.extended) {
-      return NaN;
-    }
-  }
-  if (bolus.extended != null) {
-    if (bolus.normal != null) {
-      return fixFloatingPoint(bolus.extended + bolus.normal);
-    }
-    return bolus.extended;
-  }
-  return bolus.normal;
-}
-
-/**
  * getProgrammed
  * @param {Object} insulinEvent - a Tidepool bolus or wizard object
  *
@@ -126,6 +103,29 @@ export function getRecommended(insulinEvent) {
   rec += _.get(insulinEvent, ['recommended', 'correction'], 0);
 
   return fixFloatingPoint(rec);
+}
+
+/**
+ * getDelivered
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Number} units of insulin delivered in this insulinEvent
+ */
+export function getDelivered(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+    if (!bolus.normal && !bolus.extended) {
+      return NaN;
+    }
+  }
+  if (bolus.extended != null) {
+    if (bolus.normal != null) {
+      return fixFloatingPoint(bolus.extended + bolus.normal);
+    }
+    return bolus.extended;
+  }
+  return bolus.normal;
 }
 
 /**

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -165,3 +165,18 @@ export function getMaxValue(insulinEvent) {
   const recommended = getRecommended(insulinEvent) || 0;
   return (recommended > programmed) ? recommended : programmed;
 }
+
+/**
+ * isInterruptedBolus
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {Boolean} whether the bolus was interrupted or not
+ */
+export function isInterruptedBolus(insulinEvent) {
+  const bolus = getBolusFromInsulinEvent(insulinEvent);
+
+  return bolus.normal &&
+    bolus.expectedNormal &&
+    bolus.expectedNormal > 0 &&
+    bolus.normal !== bolus.expectedNormal;
+}

--- a/stories/components/common/data/Bolus.js
+++ b/stories/components/common/data/Bolus.js
@@ -21,47 +21,258 @@ import { scaleLinear } from 'd3-scale';
 import { storiesOf } from '@kadira/storybook';
 import { WithNotes } from '@kadira/storybook-addon-notes';
 
-import getBolusPaths from '../../../../src/modules/render/bolus';
 import Bolus from '../../../../src/components/common/data/Bolus';
 
 import SixHrScaleSVGDecorator, { HEIGHT, xScale } from '../../../helpers/SixHrScaleSVGDecorator';
 
-const yScale = scaleLinear().domain([0, 10]).range([HEIGHT, 0]);
+const yScale = scaleLinear().domain([0, 15]).range([HEIGHT, 0]);
 
-const ONE_AM = Date.parse('1970-01-01T01:00:00.000Z');
-
-const BOLUS_OPTS = { bolusWidth: 12, interruptedLineThickness: 2 };
+import * as boluses from '../../../../data/bolus/fixtures';
 
 storiesOf('Bolus', module)
   .addDecorator(SixHrScaleSVGDecorator)
-  .add('normal bolus', () => {
-    const bolus = {
-      type: 'bolus',
-      subType: 'normal',
-      normal: 6.25,
-      utc: ONE_AM,
-      id: '61b4d2ffc5a74d2b80b5a9ef44bf5c35',
-    };
-    const paths = getBolusPaths(bolus, xScale, yScale, BOLUS_OPTS);
+  .add('normal bolus', () => (
+    <WithNotes notes="Just a normal bolus that hasn't been interrupted or over/under-ridden...">
+      <Bolus insulinEvent={boluses.normal} xScale={xScale} yScale={yScale} />
+    </WithNotes>
+  ))
+  .add('interrupted bolus', () => (
+    <WithNotes notes="A normal bolus that was interrupted at 5 out of 6.25 units programmed.">
+      <Bolus insulinEvent={boluses.interruptedNormal} xScale={xScale} yScale={yScale} />
+    </WithNotes>
+  ))
+  .add('underride on a normal bolus', () => {
+    const notes = `A normal bolus where only 8 out of 10 recommended units were
+     programmed and delivered.`;
     return (
-      <WithNotes notes="Just a normal bolus that hasn't been interrupted or over/under-ridden...">
-        <Bolus bolus={bolus} paths={paths} />
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus insulinEvent={boluses.underrideNormal} xScale={xScale} yScale={yScale} />
       </WithNotes>
     );
   })
-  .add('interrupted bolus', () => {
-    const bolus = {
-      type: 'bolus',
-      subType: 'normal',
-      normal: 5,
-      expectedNormal: 6.25,
-      utc: ONE_AM,
-      id: 'a30ebc79aab0453097182cb0b456f511',
-    };
-    const paths = getBolusPaths(bolus, xScale, yScale, BOLUS_OPTS);
+  .add('not rendered: zero underride on a normal bolus', () => {
+    const notes = `A normal bolus where zero units were delivered of a 2 unit
+     delivery recommendation.`;
     return (
-      <WithNotes notes="A normal bolus that was interrupted at 5 out of 6.25 units requested.">
-        <Bolus bolus={bolus} paths={paths} />
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus insulinEvent={boluses.zeroUnderride} xScale={xScale} yScale={yScale} />
+      </WithNotes>
+    );
+  })
+  .add('override on a normal bolus', () => {
+    const notes = `A normal bolus where half a unit was recommended and 2 were
+     programmed and delivered`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus insulinEvent={boluses.overrideNormal} xScale={xScale} yScale={yScale} />
+      </WithNotes>
+    );
+  })
+  .add('zero override on a normal bolus', () => {
+    const notes = `A normal bolus where zero units of insulin were recommended
+     but a bolus of 2 units was programmed & delivered.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus insulinEvent={boluses.zeroOverride} xScale={xScale} yScale={yScale} />
+      </WithNotes>
+    );
+  })
+  .add('underride and interrupt a normal bolus', () => {
+    const notes = `A normal bolus where only 8 out of 10 recommended units were
+     programmed and the bolus was interrupted after 5 untis of delivery.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.underrideAndInterruptedNormal}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('override and interrupt on a normal bolus', () => {
+    const notes = `A normal bolus where 5 units were recommended, 6.5 were programmed,
+     and only 3 were delivered.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.overrideAndInterruptedNormal}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('extended ("square") bolus', () => {
+    const notes = `A bolus consisting entirely of 4.5 units of extended delivery,
+     plus a 4.5 unit normal bolus for height comparison.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <g>
+          <Bolus
+            insulinEvent={boluses.normalNextToExtended}
+            xScale={xScale}
+            yScale={yScale}
+          />
+          <Bolus
+            insulinEvent={boluses.extended}
+            xScale={xScale}
+            yScale={yScale}
+          />
+        </g>
+      </WithNotes>
+    );
+  })
+  .add('interrupted extended ("square") bolus', () => {
+    const notes = `A bolus consisting entirely of 4.5 units of extended delivery
+     that was interrupted after 2 units of delivery,
+     plus a 2 unit normal bolus for height comparison.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <g>
+          <Bolus
+            insulinEvent={boluses.normalNextToInterruptedExtended}
+            xScale={xScale}
+            yScale={yScale}
+          />
+          <Bolus
+            insulinEvent={boluses.interruptedExtended}
+            xScale={xScale}
+            yScale={yScale}
+          />
+        </g>
+      </WithNotes>
+    );
+  })
+  .add('override on an extended ("square") bolus', () => {
+    const notes = `A bolus consisting entirely of 5 units of extended delivery
+     where only 4 units of insulin were recommended for delivery.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.overrideExtended}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('underride on an extended ("square") bolus', () => {
+    const notes = `A bolus consisting entirely of 2 units of extended delivery
+     where 4 units of insulin were recommended for delivery.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.underrideExtended}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('interrupted underride on an extended bolus', () => {
+    const notes = `A bolus consisting of 2 programmed units of extended delivery
+     where 4 units of insulin were recommended and the bolus was interrupted
+     after 1.5 units of delivery.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.interruptedUnderrideExtended}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('combo bolus', () => {
+    const notes = `A bolus consisting of 4 units of immediately delivered insulin
+     and 2 units of delivery extended over two hours.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.combo}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('interrupted combo bolus (during the immediately delievered portion)', () => {
+    const notes = `A combo bolus consisting of 4 units of programmed immediately delivered
+     insulin and 2 units of extended delivery that was interrupted after only 2 units
+     of the immediate delivery.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.interruptedDuringNormalCombo}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('interrupted combo bolus (during the extended delivery portion)', () => {
+    const notes = `A combo bolus consisting of 4 units of programmed immediately delivered
+     insulin and 3 units of extended delivery that was interrupted after all the
+     immediate delivery completed and two thirds of the extended delivery completed.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <Bolus
+          insulinEvent={boluses.interruptedDuringExtendedCombo}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('underride on a combo bolus', () => {
+    const notes = `A combo bolus consisting of 4.75 units of immediately delivered insulin
+     and 2 units of extended delivery insulin, while 8.75 total units of insulin were
+     recommended for delivery, an "underride" of 2 units,
+     plus a 2 unit normal bolus for height comparison.`;
+    return (
+      <WithNotes notes={notes.replace('\n', '')}>
+        <g>
+          <Bolus
+            insulinEvent={boluses.normalNextToInterruptedExtended}
+            xScale={xScale}
+            yScale={yScale}
+          />
+          <Bolus
+            insulinEvent={boluses.underrideCombo}
+            xScale={xScale}
+            yScale={yScale}
+          />
+        </g>
+      </WithNotes>
+    );
+  })
+  .add('override on a combo bolus', () => {
+    const notes = `A combo bolus consisting of 5.75 units of immediately delivered insulin
+     and 5 units of extended delivery insulin, while only 8.75 total units of insulin were
+     recommended for delivery.`;
+    return (
+      <WithNotes notes={notes.replace('/n', '')}>
+        <Bolus
+          insulinEvent={boluses.overrideCombo}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </WithNotes>
+    );
+  })
+  .add('override on a combo bolus interrupted during extended delivery', () => {
+    const notes = `A combo bolus consisting of 5.75 units of immediately delivered insulin
+     and 5 programmed units of extended delivery insulin, while only 8.75 total units of insulin
+     were recommended for delivery, and the delivery was interrupted after 2.5 units of
+     extended delivery.`;
+    return (
+      <WithNotes notes={notes.replace('/n', '')}>
+        <Bolus
+          insulinEvent={boluses.interruptedOverrideCombo}
+          xScale={xScale}
+          yScale={yScale}
+        />
       </WithNotes>
     );
   });

--- a/stories/components/common/data/Bolus.js
+++ b/stories/components/common/data/Bolus.js
@@ -1,0 +1,67 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React from 'react';
+import { scaleLinear } from 'd3-scale';
+
+import { storiesOf } from '@kadira/storybook';
+import { WithNotes } from '@kadira/storybook-addon-notes';
+
+import getBolusPaths from '../../../../src/modules/render/bolus';
+import Bolus from '../../../../src/components/common/data/Bolus';
+
+import SixHrScaleSVGDecorator, { HEIGHT, xScale } from '../../../helpers/SixHrScaleSVGDecorator';
+
+const yScale = scaleLinear().domain([0, 10]).range([HEIGHT, 0]);
+
+const ONE_AM = Date.parse('1970-01-01T01:00:00.000Z');
+
+const BOLUS_OPTS = { bolusWidth: 12, interruptedLineThickness: 2 };
+
+storiesOf('Bolus', module)
+  .addDecorator(SixHrScaleSVGDecorator)
+  .add('normal bolus', () => {
+    const bolus = {
+      type: 'bolus',
+      subType: 'normal',
+      normal: 6.25,
+      utc: ONE_AM,
+      id: '61b4d2ffc5a74d2b80b5a9ef44bf5c35',
+    };
+    const paths = getBolusPaths(bolus, xScale, yScale, BOLUS_OPTS);
+    return (
+      <WithNotes notes="Just a normal bolus that hasn't been interrupted or over/under-ridden...">
+        <Bolus bolus={bolus} paths={paths} />
+      </WithNotes>
+    );
+  })
+  .add('interrupted bolus', () => {
+    const bolus = {
+      type: 'bolus',
+      subType: 'normal',
+      normal: 5,
+      expectedNormal: 6.25,
+      utc: ONE_AM,
+      id: 'a30ebc79aab0453097182cb0b456f511',
+    };
+    const paths = getBolusPaths(bolus, xScale, yScale, BOLUS_OPTS);
+    return (
+      <WithNotes notes="A normal bolus that was interrupted at 5 out of 6.25 units requested.">
+        <Bolus bolus={bolus} paths={paths} />
+      </WithNotes>
+    );
+  });

--- a/test/components/common/data/Bolus.test.js
+++ b/test/components/common/data/Bolus.test.js
@@ -1,0 +1,52 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { detail } from '../../../helpers/scales';
+const { detailXScale, detailBolusScale } = detail;
+
+import Bolus from '../../../../src/components/common/data/Bolus';
+import getBolusPaths from '../../../../src/modules/render/bolus';
+
+import { normal, zeroUnderride } from '../../../../data/bolus/fixtures';
+
+const BOLUS_OPTS = {
+  bolusWidth: 12,
+  extendedLineThickness: 2,
+  interruptedLineThickness: 2,
+  triangleHeight: 5,
+};
+
+describe('Bolus', () => {
+  it('should return `null` if no paths calculated from insulinEvent', () => {
+    const wrapper = shallow(
+      <Bolus insulinEvent={zeroUnderride} xScale={detailXScale} yScale={detailBolusScale} />
+    );
+    expect(wrapper.html()).to.be.null;
+  });
+
+  it('should return a `<g>` with as many `<path>s` as are calculated for the insulinEvent', () => {
+    const paths = getBolusPaths(normal, detailXScale, detailBolusScale, BOLUS_OPTS);
+    const wrapper = shallow(
+      <Bolus insulinEvent={normal} xScale={detailXScale} yScale={detailBolusScale} />
+    );
+    expect(wrapper.find(`#bolus-${normal.id}`).length).to.equal(1);
+    expect(wrapper.find('path').length).to.equal(paths.length);
+  });
+});

--- a/test/helpers/scales.js
+++ b/test/helpers/scales.js
@@ -31,4 +31,17 @@ const trendsYScale = scaleLinear()
 
 const trends = { trendsWidth, trendsHeight, trendsXScale, trendsYScale };
 
-export { trends };
+const detailWidth = 864;
+const detailHeight = 100;
+
+const detailXScale = scaleLinear()
+  .domain([0, 864e5])
+  .range([0, detailWidth]);
+
+const detailBolusScale = scaleLinear()
+  .domain([0, 15])
+  .range([detailHeight, 0]);
+
+const detail = { detailWidth, detailHeight, detailXScale, detailBolusScale };
+
+export { detail, trends };

--- a/test/modules/render/bolus.test.js
+++ b/test/modules/render/bolus.test.js
@@ -1,0 +1,293 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2017, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import * as boluses from '../../../data/bolus/fixtures';
+import { detail } from '../../helpers/scales';
+const { detailXScale, detailBolusScale } = detail;
+
+import getBolusPaths, { getBolusEdges } from '../../../src/modules/render/bolus';
+
+const BOLUS_OPTS = {
+  bolusWidth: 12,
+  extendedLineThickness: 2,
+  interruptedLineThickness: 2,
+  triangleHeight: 5,
+};
+
+describe('bolus path generators', () => {
+  describe('getBolusEdges', () => {
+    it('should be a function', () => {
+      assert.isFunction(getBolusEdges);
+    });
+
+    it(`should calculate left and right edges for the bolus half a bolus width to the left and right
+      of the bolus\'s center on the x-axis`, () => {
+      const edges = getBolusEdges(4, 10, 50, 25);
+      expect(edges.left).to.equal(8);
+      expect(edges.right).to.equal(12);
+    });
+
+    it('should return the `bolusBottom` as `bottom` and `bolusHeight` as `top`', () => {
+      const edges = getBolusEdges(4, 10, 50, 25);
+      expect(edges.top).to.equal(25);
+      expect(edges.bottom).to.equal(50);
+    });
+  });
+
+  describe('getBolusPaths', () => {
+    it('should be a function', () => {
+      assert.isFunction(getBolusPaths);
+    });
+
+    describe('normal boluses', () => {
+      it('should calculate one path for a normal bolus', () => {
+        const paths = getBolusPaths(boluses.normal, detailXScale, detailBolusScale, BOLUS_OPTS);
+        expect(paths.length).to.equal(1);
+        expect(paths[0].type).to.equal('delivered');
+      });
+
+      it('should calculate four paths for an interrupted normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.interruptedNormal, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(4);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('interrupted');
+      });
+
+      it('should calculate three paths for an underride on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.underrideNormal, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(3);
+        expect(paths[0].type).to.equal('underride');
+        expect(paths[1].type).to.equal('delivered');
+        expect(paths[2].type).to.equal('underrideTriangle');
+      });
+
+      it('should calculate four paths for an interrupted underride on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.underrideAndInterruptedNormal, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(5);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('underrideTriangle');
+        expect(paths[4].type).to.equal('interrupted');
+      });
+
+      it('should calculate no paths for a zero underride on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.zeroUnderride, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(0);
+      });
+
+      it('should calculate two paths for an override on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.overrideNormal, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(2);
+        expect(paths[0].type).to.equal('delivered');
+        expect(paths[1].type).to.equal('overrideTriangle');
+      });
+
+      it('should calculate two paths for a zero override on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.zeroOverride, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(2);
+        expect(paths[0].type).to.equal('delivered');
+        expect(paths[1].type).to.equal('overrideTriangle');
+      });
+
+      it('should calculate five paths for an interrupted underride on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.underrideAndInterruptedNormal, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(5);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('underrideTriangle');
+        expect(paths[4].type).to.equal('interrupted');
+      });
+
+      it('should calculate five paths for an interrupted override on a normal bolus', () => {
+        const paths = getBolusPaths(
+          boluses.overrideAndInterruptedNormal, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(5);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('overrideTriangle');
+        expect(paths[4].type).to.equal('interrupted');
+      });
+    });
+
+    describe('extended ("square") boluses', () => {
+      it('should calculate three paths for an extended bolus', () => {
+        const paths = getBolusPaths(
+          boluses.extended, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(3);
+        expect(paths[0].type).to.equal('delivered');
+        expect(paths[1].type).to.equal('extendedPath');
+        expect(paths[2].type).to.equal('extendedTriangle');
+      });
+
+      it('should calculate eight paths for an interrupted extended bolus', () => {
+        const paths = getBolusPaths(
+          boluses.interruptedExtended, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(8);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('extendedPath');
+        expect(paths[4].type).to.equal('extendedExpectationPath');
+        expect(paths[5].type).to.equal('extendedInterrupted');
+        expect(paths[6].type).to.equal('extendedTriangleInterrupted');
+        expect(paths[7].type).to.equal('interrupted');
+      });
+
+      it('should calculate four paths for an override on an extended bolus', () => {
+        const paths = getBolusPaths(
+          boluses.overrideExtended, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(4);
+        expect(paths[0].type).to.equal('delivered');
+        expect(paths[1].type).to.equal('extendedPath');
+        expect(paths[2].type).to.equal('extendedTriangle');
+        expect(paths[3].type).to.equal('overrideTriangle');
+      });
+
+      it('should calculate five paths for an underride on an extended bolus', () => {
+        const paths = getBolusPaths(
+          boluses.underrideExtended, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(5);
+        expect(paths[0].type).to.equal('underride');
+        expect(paths[1].type).to.equal('delivered');
+        expect(paths[2].type).to.equal('extendedPath');
+        expect(paths[3].type).to.equal('extendedTriangle');
+        expect(paths[4].type).to.equal('underrideTriangle');
+      });
+
+      it(`should calculate nine paths for an interruption of an underride on
+        an extended bolus`, () => {
+        const paths = getBolusPaths(
+          boluses.interruptedUnderrideExtended, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(9);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('extendedPath');
+        expect(paths[4].type).to.equal('extendedExpectationPath');
+        expect(paths[5].type).to.equal('extendedInterrupted');
+        expect(paths[6].type).to.equal('extendedTriangleInterrupted');
+        expect(paths[7].type).to.equal('underrideTriangle');
+        expect(paths[8].type).to.equal('interrupted');
+      });
+    });
+
+    describe('combo boluses', () => {
+      it('should calculate three paths for a combo bolus', () => {
+        const paths = getBolusPaths(
+          boluses.combo, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(3);
+        expect(paths[0].type).to.equal('delivered');
+        expect(paths[1].type).to.equal('extendedPath');
+        expect(paths[2].type).to.equal('extendedTriangle');
+      });
+
+      it(`should calculate four paths for a combo bolus interrupted
+        during \`normal\` delivery`, () => {
+        const paths = getBolusPaths(
+          boluses.interruptedDuringNormalCombo, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(4);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('interrupted');
+      });
+
+      it(`should calculate eight paths for a combo bolus interrupted
+        during \`extended\` delivery`, () => {
+        const paths = getBolusPaths(
+          boluses.interruptedDuringExtendedCombo, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(8);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('extendedPath');
+        expect(paths[4].type).to.equal('extendedExpectationPath');
+        expect(paths[5].type).to.equal('extendedInterrupted');
+        expect(paths[6].type).to.equal('extendedTriangleInterrupted');
+        expect(paths[7].type).to.equal('interrupted');
+      });
+
+      it('should calculate five paths for an underride on a combo bolus', () => {
+        const paths = getBolusPaths(
+          boluses.underrideCombo, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(5);
+        expect(paths[0].type).to.equal('underride');
+        expect(paths[1].type).to.equal('delivered');
+        expect(paths[2].type).to.equal('extendedPath');
+        expect(paths[3].type).to.equal('extendedTriangle');
+        expect(paths[4].type).to.equal('underrideTriangle');
+      });
+
+      it('should calculate four paths for an override on a combo bolus', () => {
+        const paths = getBolusPaths(
+          boluses.overrideCombo, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(4);
+        expect(paths[0].type).to.equal('delivered');
+        expect(paths[1].type).to.equal('extendedPath');
+        expect(paths[2].type).to.equal('extendedTriangle');
+        expect(paths[3].type).to.equal('overrideTriangle');
+      });
+
+      it(`should calculate nine paths for an interruption of an override on
+        a combo bolus`, () => {
+        const paths = getBolusPaths(
+          boluses.interruptedOverrideCombo, detailXScale, detailBolusScale, BOLUS_OPTS
+        );
+        expect(paths.length).to.equal(9);
+        expect(paths[0].type).to.equal('undelivered');
+        expect(paths[1].type).to.equal('programmed');
+        expect(paths[2].type).to.equal('delivered');
+        expect(paths[3].type).to.equal('extendedPath');
+        expect(paths[4].type).to.equal('extendedExpectationPath');
+        expect(paths[5].type).to.equal('extendedInterrupted');
+        expect(paths[6].type).to.equal('extendedTriangleInterrupted');
+        expect(paths[7].type).to.equal('overrideTriangle');
+        expect(paths[8].type).to.equal('interrupted');
+      });
+    });
+  });
+});

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -487,4 +487,56 @@ describe('bolus utilities', () => {
       expect(bolusUtils.isInterruptedBolus(extendedUnderride)).to.be.false;
     });
   });
+
+  describe('isOverride', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.isOverride);
+    });
+
+    it('should return `false` on all non-override boluses', () => {
+      expect(bolusUtils.isOverride(normal)).to.be.false;
+      expect(bolusUtils.isOverride(cancelled)).to.be.false;
+      expect(bolusUtils.isOverride(underride)).to.be.false;
+      expect(bolusUtils.isOverride(combo)).to.be.false;
+      expect(bolusUtils.isOverride(cancelledInNormalCombo)).to.be.false;
+      expect(bolusUtils.isOverride(cancelledInExtendedCombo)).to.be.false;
+      expect(bolusUtils.isOverride(comboUnderrideCancelled)).to.be.false;
+      expect(bolusUtils.isOverride(extended)).to.be.false;
+      expect(bolusUtils.isOverride(cancelledExtended)).to.be.false;
+      expect(bolusUtils.isOverride(immediatelyCancelledExtended)).to.be.false;
+      expect(bolusUtils.isOverride(extendedUnderride)).to.be.false;
+      expect(bolusUtils.isOverride(withNetRec)).to.be.false;
+    });
+
+    it('should return `true` on all overridden boluses', () => {
+      expect(bolusUtils.isOverride(override)).to.be.true;
+      expect(bolusUtils.isOverride(comboOverride)).to.be.true;
+    });
+  });
+
+  describe('isUnderride', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.isUnderride);
+    });
+
+    it('should return `false` on all non-underride boluses', () => {
+      expect(bolusUtils.isOverride(normal)).to.be.false;
+      expect(bolusUtils.isOverride(cancelled)).to.be.false;
+      expect(bolusUtils.isOverride(override)).to.be.true;
+      expect(bolusUtils.isOverride(combo)).to.be.false;
+      expect(bolusUtils.isOverride(cancelledInNormalCombo)).to.be.false;
+      expect(bolusUtils.isOverride(cancelledInExtendedCombo)).to.be.false;
+      expect(bolusUtils.isOverride(comboOverride)).to.be.true;
+      expect(bolusUtils.isOverride(comboUnderrideCancelled)).to.be.false;
+      expect(bolusUtils.isOverride(extended)).to.be.false;
+      expect(bolusUtils.isOverride(cancelledExtended)).to.be.false;
+      expect(bolusUtils.isOverride(immediatelyCancelledExtended)).to.be.false;
+      expect(bolusUtils.isOverride(withNetRec)).to.be.false;
+    });
+
+    it('should return `true` on all underridden boluses', () => {
+      expect(bolusUtils.isOverride(underride)).to.be.false;
+      expect(bolusUtils.isOverride(extendedUnderride)).to.be.false;
+    });
+  });
 });

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -446,4 +446,45 @@ describe('bolus utilities', () => {
       expect(bolusUtils.getMaxValue(comboUnderrideCancelled)).to.equal(5);
     });
   });
+
+  describe('isInterruptedBolus', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.isInterruptedBolus);
+    });
+
+    it('should return `false` on a no-frills `normal` bolus', () => {
+      expect(bolusUtils.isInterruptedBolus(normal)).to.be.false;
+      expect(bolusUtils.isInterruptedBolus(withNetRec)).to.be.false;
+    });
+
+    it('should return `false` on a no-frills `extended` bolus', () => {
+      expect(bolusUtils.isInterruptedBolus(extended)).to.be.false;
+    });
+
+    it('should return `false` on a no-frills `combo` bolus', () => {
+      expect(bolusUtils.isInterruptedBolus(combo)).to.be.false;
+    });
+
+    it('should return `true` on a cancelled `normal` bolus', () => {
+      expect(bolusUtils.isInterruptedBolus(cancelled)).to.be.true;
+    });
+
+    it('should return `true` on all types of cancelled `extended` bolus', () => {
+      expect(bolusUtils.isInterruptedBolus(immediatelyCancelledExtended)).to.be.true;
+      expect(bolusUtils.isInterruptedBolus(cancelledExtended)).to.be.true;
+    });
+
+    it('should return `true` on all types of cancelled `combo` boluses', () => {
+      expect(bolusUtils.isInterruptedBolus(cancelledInNormalCombo)).to.be.true;
+      expect(bolusUtils.isInterruptedBolus(cancelledInExtendedCombo)).to.be.true;
+      expect(bolusUtils.isInterruptedBolus(comboUnderrideCancelled)).to.be.true;
+    });
+
+    it('should return `false` on an override or underride', () => {
+      expect(bolusUtils.isInterruptedBolus(override)).to.be.false;
+      expect(bolusUtils.isInterruptedBolus(underride)).to.be.false;
+      expect(bolusUtils.isInterruptedBolus(comboOverride)).to.be.false;
+      expect(bolusUtils.isInterruptedBolus(extendedUnderride)).to.be.false;
+    });
+  });
 });

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -349,6 +349,68 @@ describe('bolus utilities', () => {
     });
   });
 
+  describe('getDuration', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getDuration);
+    });
+
+    it('should return `NaN` on any bolus that only has `normal` delivery', () => {
+      expect(Number.isNaN(bolusUtils.getDuration(normal))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getDuration(cancelled))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getDuration(override))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getDuration(underride))).to.be.true;
+    });
+
+    it('should return the `duration` of any bolus with a `duration`', () => {
+      expect(bolusUtils.getDuration(combo)).to.equal(combo.duration);
+      expect(bolusUtils.getDuration(cancelledInExtendedCombo))
+        .to.equal(cancelledInExtendedCombo.duration);
+      expect(bolusUtils.getDuration(comboUnderrideCancelled))
+        .to.equal(comboUnderrideCancelled.bolus.duration);
+      expect(bolusUtils.getDuration(extended)).to.equal(extended.duration);
+      expect(bolusUtils.getDuration(cancelledExtended)).to.equal(cancelledExtended.duration);
+    });
+
+    it('should return a `duration` that is 0', () => {
+      expect(bolusUtils.getDuration(cancelledInNormalCombo))
+        .to.equal(0);
+      expect(bolusUtils.getDuration(immediatelyCancelledExtended))
+        .to.equal(0);
+    });
+  });
+
+  describe('getExtended', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getExtended);
+    });
+
+    it('should return `NaN` on any bolus that only has `normal` delivery', () => {
+      expect(Number.isNaN(bolusUtils.getExtended(normal))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtended(cancelled))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtended(override))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtended(underride))).to.be.true;
+    });
+
+    it('should return the `extended` or any bolus with an `extended` portion', () => {
+      expect(bolusUtils.getExtended(combo)).to.equal(combo.extended);
+      expect(bolusUtils.getExtended(cancelledInExtendedCombo))
+        .to.equal(cancelledInExtendedCombo.extended);
+      expect(bolusUtils.getExtended(comboOverride)).to.equal(comboOverride.bolus.extended);
+      expect(bolusUtils.getExtended(comboUnderrideCancelled))
+        .to.equal(comboUnderrideCancelled.bolus.extended);
+      expect(bolusUtils.getExtended(extended)).to.equal(extended.extended);
+      expect(bolusUtils.getExtended(cancelledExtended)).to.equal(cancelledExtended.extended);
+      expect(bolusUtils.getExtended(extendedUnderride)).to.equal(extendedUnderride.bolus.extended);
+    });
+
+    it('should return an `extended` value that is 0', () => {
+      expect(bolusUtils.getExtended(cancelledInNormalCombo))
+        .to.equal(0);
+      expect(bolusUtils.getExtended(immediatelyCancelledExtended))
+        .to.equal(0);
+    });
+  });
+
   describe('getMaxDuration', () => {
     it('should be a function', () => {
       assert.isFunction(bolusUtils.getMaxDuration);
@@ -444,6 +506,35 @@ describe('bolus utilities', () => {
 
     it('should return the net recommendation in the case of a cancelled `combo` underride', () => {
       expect(bolusUtils.getMaxValue(comboUnderrideCancelled)).to.equal(5);
+    });
+  });
+
+  describe('hasExtended', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.hasExtended);
+    });
+
+    it('should return `false` on any bolus that only has `normal` delivery', () => {
+      expect(bolusUtils.hasExtended(normal)).to.be.false;
+      expect(bolusUtils.hasExtended(cancelled)).to.be.false;
+      expect(bolusUtils.hasExtended(override)).to.be.false;
+      expect(bolusUtils.hasExtended(underride)).to.be.false;
+      expect(bolusUtils.hasExtended(withNetRec)).to.be.false;
+    });
+
+    it('should return `true` on any bolus that has non-zero `extended` delivery', () => {
+      expect(bolusUtils.hasExtended(combo)).to.be.true;
+      expect(bolusUtils.hasExtended(cancelledInExtendedCombo)).to.be.true;
+      expect(bolusUtils.hasExtended(comboOverride)).to.be.true;
+      expect(bolusUtils.hasExtended(comboUnderrideCancelled)).to.be.true;
+      expect(bolusUtils.hasExtended(extended)).to.be.true;
+      expect(bolusUtils.hasExtended(cancelledExtended)).to.be.true;
+      expect(bolusUtils.hasExtended(extendedUnderride)).to.be.true;
+    });
+
+    it('should return `true` on a bolus with zero `extended`, non-zero `expectedExtended`', () => {
+      expect(bolusUtils.hasExtended(cancelledInNormalCombo)).to.be.true;
+      expect(bolusUtils.hasExtended(immediatelyCancelledExtended)).to.be.true;
     });
   });
 

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -172,71 +172,6 @@ describe('bolus utilities', () => {
     });
   });
 
-  describe('getDelivered', () => {
-    it('should be a function', () => {
-      assert.isFunction(bolusUtils.getDelivered);
-    });
-
-    it('should return NaN if type `wizard` and no bolus attached', () => {
-      expect(Number.isNaN(bolusUtils.getDelivered({ type: 'wizard' }))).to.be.true;
-    });
-
-    it('should return the value of a no-frills `normal` bolus', () => {
-      expect(bolusUtils.getDelivered(normal)).to.equal(normal.normal);
-    });
-
-    it('should return the value of a no-frills `extended` bolus', () => {
-      expect(bolusUtils.getDelivered(extended)).to.equal(extended.extended);
-    });
-
-    it('should return the combined `normal` and `extended` of a no-frills `combo` bolus', () => {
-      expect(bolusUtils.getDelivered(combo)).to.equal(combo.normal + combo.extended);
-    });
-
-    it('should return the delivered of a cancelled `normal` bolus', () => {
-      expect(bolusUtils.getDelivered(cancelled)).to.equal(cancelled.normal);
-    });
-
-    it('should return the delivered of a cancelled `extended` bolus', () => {
-      expect(bolusUtils.getDelivered(cancelledExtended)).to.equal(cancelledExtended.extended);
-    });
-
-    it('should return the `normal` of a `normal`-cancelled `combo` bolus', () => {
-      expect(bolusUtils.getDelivered(cancelledInNormalCombo))
-        .to.equal(cancelledInNormalCombo.normal);
-    });
-
-    it('should return the `normal` & `extended` of an `extended`-cancelled `combo` bolus', () => {
-      expect(bolusUtils.getDelivered(cancelledInExtendedCombo)).to.equal(
-        cancelledInExtendedCombo.normal + cancelledInExtendedCombo.extended
-      );
-    });
-
-    it('should return the programmed & delivered of an underride', () => {
-      expect(bolusUtils.getDelivered(underride)).to.equal(underride.bolus.normal);
-    });
-
-    it('should return the programmed & delivered of an override', () => {
-      expect(bolusUtils.getDelivered(override)).to.equal(override.bolus.normal);
-    });
-
-    it('should return the programmed & delivered of an `extended` underride', () => {
-      expect(bolusUtils.getDelivered(extendedUnderride)).to.equal(extendedUnderride.bolus.extended);
-    });
-
-    it('should return the the `normal` & `extended` of a `combo` override', () => {
-      expect(bolusUtils.getDelivered(comboOverride)).to.equal(
-        comboOverride.bolus.normal + comboOverride.bolus.extended
-      );
-    });
-
-    it('should return the `normal` & `extended` of a cancelled `combo` underride', () => {
-      expect(bolusUtils.getDelivered(comboUnderrideCancelled)).to.equal(
-        comboUnderrideCancelled.bolus.normal + comboUnderrideCancelled.bolus.extended
-      );
-    });
-  });
-
   describe('getProgrammed', () => {
     it('should be a function', () => {
       assert.isFunction(bolusUtils.getProgrammed);
@@ -346,6 +281,71 @@ describe('bolus utilities', () => {
 
     it('should return 0 when no bolus recommended, even if overridden', () => {
       expect(bolusUtils.getRecommended(override)).to.equal(0);
+    });
+  });
+
+  describe('getDelivered', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getDelivered);
+    });
+
+    it('should return NaN if type `wizard` and no bolus attached', () => {
+      expect(Number.isNaN(bolusUtils.getDelivered({ type: 'wizard' }))).to.be.true;
+    });
+
+    it('should return the value of a no-frills `normal` bolus', () => {
+      expect(bolusUtils.getDelivered(normal)).to.equal(normal.normal);
+    });
+
+    it('should return the value of a no-frills `extended` bolus', () => {
+      expect(bolusUtils.getDelivered(extended)).to.equal(extended.extended);
+    });
+
+    it('should return the combined `normal` and `extended` of a no-frills `combo` bolus', () => {
+      expect(bolusUtils.getDelivered(combo)).to.equal(combo.normal + combo.extended);
+    });
+
+    it('should return the delivered of a cancelled `normal` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelled)).to.equal(cancelled.normal);
+    });
+
+    it('should return the delivered of a cancelled `extended` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelledExtended)).to.equal(cancelledExtended.extended);
+    });
+
+    it('should return the `normal` of a `normal`-cancelled `combo` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelledInNormalCombo))
+        .to.equal(cancelledInNormalCombo.normal);
+    });
+
+    it('should return the `normal` & `extended` of an `extended`-cancelled `combo` bolus', () => {
+      expect(bolusUtils.getDelivered(cancelledInExtendedCombo)).to.equal(
+        cancelledInExtendedCombo.normal + cancelledInExtendedCombo.extended
+      );
+    });
+
+    it('should return the programmed & delivered of an underride', () => {
+      expect(bolusUtils.getDelivered(underride)).to.equal(underride.bolus.normal);
+    });
+
+    it('should return the programmed & delivered of an override', () => {
+      expect(bolusUtils.getDelivered(override)).to.equal(override.bolus.normal);
+    });
+
+    it('should return the programmed & delivered of an `extended` underride', () => {
+      expect(bolusUtils.getDelivered(extendedUnderride)).to.equal(extendedUnderride.bolus.extended);
+    });
+
+    it('should return the the `normal` & `extended` of a `combo` override', () => {
+      expect(bolusUtils.getDelivered(comboOverride)).to.equal(
+        comboOverride.bolus.normal + comboOverride.bolus.extended
+      );
+    });
+
+    it('should return the `normal` & `extended` of a cancelled `combo` underride', () => {
+      expect(bolusUtils.getDelivered(comboUnderrideCancelled)).to.equal(
+        comboUnderrideCancelled.bolus.normal + comboUnderrideCancelled.bolus.extended
+      );
     });
   });
 


### PR DESCRIPTION
This is a port of tideline's bolus rendering (pretty much [this file](https://github.com/tidepool-org/tideline/blob/master/js/plot/util/drawbolus.js) and the filtering in [this one](https://github.com/tidepool-org/tideline/blob/master/js/plot/wizard.js)).

Still to come: the carb circles on calculator-accompanied ("wizard") insulin events. I thought this was enough to review for now.

The most important things to review here are the additions to the bolus utilities and the actual path generation. There is also a React component (& tests) to render bolus paths in SVG on the web for Storybook purposes (at present). The commits are fairly logically grouped sets of changes, but some may still be large sets of changes.

LMK if you have any questions of would like a walk-through @krystophv 