### PR TITLE
bolus rendering tweaks + more ddata utils adds

### DIFF
--- a/src/components/common/data/Bolus.css
+++ b/src/components/common/data/Bolus.css
@@ -26,7 +26,7 @@
 }
 
 .extendedExpectationPath {
-  composes: bolusExtendedPath bolusUndelivered from '../../../styles/diabetes.css';
+  composes: bolusUndelivered from '../../../styles/diabetes.css';
 }
 
 .extendedInterrupted {
@@ -34,7 +34,8 @@
 }
 
 .extendedPath {
-  composes: bolusDelivered bolusExtendedPath from '../../../styles/diabetes.css';
+  composes: noStroke;
+  composes: bolusDelivered from '../../../styles/diabetes.css';
 }
 
 .extendedTriangle {

--- a/src/modules/render/bolus.js
+++ b/src/modules/render/bolus.js
@@ -164,8 +164,10 @@ export default function getBolusPaths(insulinEvent, xScale, yScale, {
     if (extendedVal > 0) {
       paths.push({
         d: `
-          M ${bolusCenter},${extendedY}
-          L ${startOfTriangle + extendedLineThickness},${extendedY}
+          M ${bolusCenter},${extendedY + extendedLineThickness / 2}
+          L ${bolusCenter},${extendedY - extendedLineThickness / 2}
+          L ${startOfTriangle + extendedLineThickness},${extendedY - extendedLineThickness / 2}
+          L ${startOfTriangle + extendedLineThickness},${extendedY + extendedLineThickness / 2} Z
         `.replace('\n', ''),
         key: `extendedPath-${bolus.id}`,
         type: 'extendedPath',
@@ -179,8 +181,10 @@ export default function getBolusPaths(insulinEvent, xScale, yScale, {
 
       paths.push({
         d: `
-          M ${startOfInterrupted},${extendedY}
-          L ${startOfTriangle + extendedLineThickness},${extendedY}
+          M ${startOfInterrupted},${extendedY + extendedLineThickness / 2}
+          L ${startOfInterrupted},${extendedY - extendedLineThickness / 2}
+          L ${startOfTriangle + extendedLineThickness},${extendedY - extendedLineThickness / 2}
+          L ${startOfTriangle + extendedLineThickness},${extendedY + extendedLineThickness / 2} Z
         `.replace('\n', ''),
         key: `extendedExpectationPath-${bolus.id}`,
         type: 'extendedExpectationPath',

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -19,7 +19,7 @@
   --basal: #19A0D7;
   --bolus: #7CD0F0;
   --bolus--interrupted: #FF8B7C;
-  --bolus--override: #107EA8;
+  --bolus--ride: #107EA8;
   --bolus--undelivered: #BCECFA;
   --collapsible--border: #EDEDED;
   --table-stripe--light: #F7F7F7;

--- a/src/styles/diabetes.css
+++ b/src/styles/diabetes.css
@@ -37,11 +37,6 @@
 .bolusDelivered {
   color: var(--bolus);
   fill: var(--bolus);
-  stroke: var(--bolus);
-}
-
-.bolusExtendedPath {
-  stroke-width: 2;
 }
 
 .bolusInterrupted {
@@ -57,17 +52,15 @@
 }
 
 .bolusRideTriangle {
-  fill: var(--bolus--override);
+  fill: var(--bolus--ride);
 }
 
 .bolusUndelivered {
   color: var(--bolus--undelivered);
   fill: var(--bolus--undelivered);
-  stroke: var(--bolus--undelivered);
 }
 
 .bolusUnderride {
   color: var(--bolus--undelivered);
   fill: var(--bolus--undelivered);
-  stroke: var(--bolus--undelivered);
 }

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -58,6 +58,23 @@ export function classifyBgValue(bgBounds, bgValue, classificationType = 'threeWa
 }
 
 /**
+ * calcBgPercentInCategories
+ * @param {Array} data - Array of Tidepool cbg or smbg data
+ * @param {Object} bgBounds - object describing boundaries for blood glucose categories
+ *
+ * @return {Object} bgPercentInCategories - object w/keys veryLow, low, target, high, veryHigh
+ *                  and 0.0 to 1.0 percentage values
+ */
+export function calcBgPercentInCategories(data, bgBounds) {
+  const bgPercentInCategories = {};
+  const grouped = _.groupBy(data, (d) => (classifyBgValue(bgBounds, d.value, 'fiveWay')));
+  _.each(['veryLow', 'low', 'target', 'high', 'veryHigh'], (key) => {
+    bgPercentInCategories[key] = ((grouped[key] && grouped[key].length) || 0) / data.length;
+  });
+  return bgPercentInCategories;
+}
+
+/**
  * convertToMmolL
  * @param {Number} bgVal - blood glucose value in mg/dL
  *

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -21,10 +21,11 @@ import _ from 'lodash';
  * classifyBgValue
  * @param {Object} bgBounds - object describing boundaries for blood glucose categories
  * @param {Number} bgValue - integer or float blood glucose value in either mg/dL or mmol/L
+ * @param {String} classificationType - 'threeWay' or 'fiveWay'
  *
  * @return {String} bgClassification - low, target, high
  */
-export function classifyBgValue(bgBounds, bgValue) {
+export function classifyBgValue(bgBounds, bgValue, classificationType = 'threeWay') {
   if (_.isEmpty(bgBounds) ||
     !_.isNumber(_.get(bgBounds, 'targetLowerBound')) ||
     !_.isNumber(_.get(bgBounds, 'targetUpperBound'))) {
@@ -35,7 +36,19 @@ export function classifyBgValue(bgBounds, bgValue) {
   if (!_.isNumber(bgValue) || !_.gt(bgValue, 0)) {
     throw new Error('You must provide a positive, numerical blood glucose value to categorize!');
   }
-  const { targetLowerBound, targetUpperBound } = bgBounds;
+  const { veryLowThreshold, targetLowerBound, targetUpperBound, veryHighThreshold } = bgBounds;
+  if (classificationType === 'fiveWay') {
+    if (bgValue < veryLowThreshold) {
+      return 'veryLow';
+    } else if (bgValue >= veryLowThreshold && bgValue < targetLowerBound) {
+      return 'low';
+    } else if (bgValue > targetUpperBound && bgValue <= veryHighThreshold) {
+      return 'high';
+    } else if (bgValue > veryHighThreshold) {
+      return 'veryHigh';
+    }
+    return 'target';
+  }
   if (bgValue < targetLowerBound) {
     return 'low';
   } else if (bgValue > targetUpperBound) {

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -20,7 +20,7 @@
 
 import _ from 'lodash';
 
-import { formatDecimalNumber } from './format';
+import { formatDecimalNumber, formatPercentage } from './format';
 
 /**
  * fixFloatingPoint
@@ -166,6 +166,25 @@ export function getExtended(insulinEvent) {
 }
 
 /**
+ * getExtendedPercentage
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {String} percentage of combo bolus delivered later
+ */
+export function getExtendedPercentage(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+  }
+  if (!bolus.normal || !(bolus.extended || bolus.expectedExtended)) {
+    return NaN;
+  }
+  const extended = bolus.expectedExtended || bolus.extended;
+  const programmed = getProgrammed(bolus);
+  return formatPercentage(extended / programmed);
+}
+
+/**
  * getMaxDuration
  * @param {Object} insulinEvent - a Tidepool bolus or wizard object
  *
@@ -201,6 +220,25 @@ export function getMaxValue(insulinEvent) {
   const programmed = getProgrammed(bolus);
   const recommended = getRecommended(insulinEvent) || 0;
   return (recommended > programmed) ? recommended : programmed;
+}
+
+/**
+ * getNormalPercentage
+ * @param {Object} insulinEvent - a Tidepool bolus or wizard object
+ *
+ * @return {String} percentage of combo bolus delivered immediately
+ */
+export function getNormalPercentage(insulinEvent) {
+  let bolus = insulinEvent;
+  if (_.get(insulinEvent, 'type') === 'wizard') {
+    bolus = getBolusFromInsulinEvent(insulinEvent);
+  }
+  if (!(bolus.normal || bolus.expectedNormal) || !(bolus.extended || bolus.expectedExtended)) {
+    return NaN;
+  }
+  const normal = bolus.expectedNormal || bolus.normal;
+  const programmed = getProgrammed(bolus);
+  return formatPercentage(normal / programmed);
 }
 
 /**

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -109,6 +109,45 @@ export function formatDiagnosisDate(patient) {
 }
 
 /**
+ * formatDuration
+ * @param {Number} duration - positive integer duration in milliseconds
+ *
+ * @return {String} formatted duration, e.g., '1¼ hr'
+ */
+export function formatDuration(duration) {
+  const momentDuration = moment.duration(duration);
+  const QUARTER = '¼';
+  const THIRD = '⅓';
+  const HALF = '½';
+  const TWO_THIRDS = '⅔';
+  const THREE_QUARTERS = '¾';
+  const hours = momentDuration.hours();
+  const minutes = momentDuration.minutes();
+
+  if (hours !== 0) {
+    const suffix = (hours === 1) ? 'hr' : 'hrs';
+    switch (minutes) {
+      case 0:
+        return `${hours} ${suffix}`;
+      case 15:
+        return `${hours}${QUARTER} ${suffix}`;
+      case 20:
+        return `${hours}${THIRD} ${suffix}`;
+      case 30:
+        return `${hours}${HALF} ${suffix}`;
+      case 40:
+        return `${hours}${TWO_THIRDS} ${suffix}`;
+      case 45:
+        return `${hours}${THREE_QUARTERS} ${suffix}`;
+      default:
+        return `${hours} ${suffix} ${minutes} min`;
+    }
+  } else {
+    return `${minutes} min`;
+  }
+}
+
+/**
  * formatLocalizedFromUTC
  * @param {String} utc - Zulu timestamp (Integer hammertime also OK)
  * @param {Object} timePrefs - object containing timezoneAware Boolean and timezoneName String

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -90,3 +90,23 @@ export function formatDecimalNumber(val, places) {
   }
   return format(`.${places}f`)(val);
 }
+
+/**
+ * formatPercentage
+ * @param {Number} val - raw decimal proportion, range of 0.0 to 1.0
+ *
+ * @return {String} percentage
+ */
+export function formatPercentage(val) {
+  return format('.0%')(val);
+}
+
+/**
+ * removeTrailingZeroes
+ * @param {String} - formatted decimal value, may have trailing zeroes
+ *
+ * @return {String} - formatted decimal value w/o trailing zero-indexes
+ */
+export function removeTrailingZeroes(val) {
+  return val.replace(/\.0+$/, '');
+}

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -20,8 +20,10 @@ import * as bgUtils from '../../src/utils/bloodglucose';
 describe('blood glucose utilities', () => {
   describe('classifyBgValue', () => {
     const bgBounds = {
+      veryHighThreshold: 300,
       targetUpperBound: 180,
       targetLowerBound: 70,
+      veryLowThreshold: 55,
     };
 
     it('should be a function', () => {
@@ -80,24 +82,64 @@ describe('blood glucose utilities', () => {
       expect(fn6).to.not.throw;
     });
 
-    it('should return `low` for a value < the `targetLowerBound`', () => {
-      expect(bgUtils.classifyBgValue(bgBounds, 69)).to.equal('low');
+    describe('three-way classification (low, target, high)', () => {
+      it('should return `low` for a value < the `targetLowerBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 69)).to.equal('low');
+      });
+
+      it('should return `target` for a value equal to the `targetLowerBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 70)).to.equal('target');
+      });
+
+      it('should return `target` for a value > `targetLowerBound` and < `targetUpperBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 100)).to.equal('target');
+      });
+
+      it('should return `target` for a value equal to the `targetUpperBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 180)).to.equal('target');
+      });
+
+      it('should return `high` for a value > the `targetUpperBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 181)).to.equal('high');
+      });
     });
 
-    it('should return `target` for a value equal to the `targetLowerBound`', () => {
-      expect(bgUtils.classifyBgValue(bgBounds, 70)).to.equal('target');
-    });
+    describe('five-way classification (veryLow, low, target, high, veryHigh)', () => {
+      it('should return `veryLow` for a value < the `veryLowThreshold`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 54, 'fiveWay')).to.equal('veryLow');
+      });
 
-    it('should return `target` for a value > `targetLowerBound` and < `targetUpperBound`', () => {
-      expect(bgUtils.classifyBgValue(bgBounds, 100)).to.equal('target');
-    });
+      it('should return `low` for a value equal to the `veryLowThreshold`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 55, 'fiveWay')).to.equal('low');
+      });
 
-    it('should return `target` for a value equal to the `targetUpperBound`', () => {
-      expect(bgUtils.classifyBgValue(bgBounds, 180)).to.equal('target');
-    });
+      it('should return `low` for a value < the `targetLowerBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 69, 'fiveWay')).to.equal('low');
+      });
 
-    it('should return `high` for a value > the `targetUpperBound`', () => {
-      expect(bgUtils.classifyBgValue(bgBounds, 181)).to.equal('high');
+      it('should return `target` for a value equal to the `targetLowerBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 70, 'fiveWay')).to.equal('target');
+      });
+
+      it('should return `target` for a value > `targetLowerBound` and < `targetUpperBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 100, 'fiveWay')).to.equal('target');
+      });
+
+      it('should return `target` for a value equal to the `targetUpperBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 180, 'fiveWay')).to.equal('target');
+      });
+
+      it('should return `high` for a value > the `targetUpperBound`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 181, 'fiveWay')).to.equal('high');
+      });
+
+      it('should return `high` for a value equal to the `veryHighThreshold`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 300, 'fiveWay')).to.equal('high');
+      });
+
+      it('should return `veryHigh` for a value > the `veryHighThreshold`', () => {
+        expect(bgUtils.classifyBgValue(bgBounds, 301, 'fiveWay')).to.equal('veryHigh');
+      });
     });
   });
 

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -18,14 +18,14 @@
 import * as bgUtils from '../../src/utils/bloodglucose';
 
 describe('blood glucose utilities', () => {
-  describe('classifyBgValue', () => {
-    const bgBounds = {
-      veryHighThreshold: 300,
-      targetUpperBound: 180,
-      targetLowerBound: 70,
-      veryLowThreshold: 55,
-    };
+  const bgBounds = {
+    veryHighThreshold: 300,
+    targetUpperBound: 180,
+    targetLowerBound: 70,
+    veryLowThreshold: 55,
+  };
 
+  describe('classifyBgValue', () => {
     it('should be a function', () => {
       assert.isFunction(bgUtils.classifyBgValue);
     });
@@ -139,6 +139,54 @@ describe('blood glucose utilities', () => {
 
       it('should return `veryHigh` for a value > the `veryHighThreshold`', () => {
         expect(bgUtils.classifyBgValue(bgBounds, 301, 'fiveWay')).to.equal('veryHigh');
+      });
+    });
+  });
+
+  describe('calcBgPercentInCategories', () => {
+    it('should be a function', () => {
+      assert.isFunction(bgUtils.calcBgPercentInCategories);
+    });
+
+    it('should calculate the percentage of values in each bg category', () => {
+      const data = [{
+        value: 54,
+      }, {
+        value: 69,
+      }, {
+        value: 100,
+      }, {
+        value: 181,
+      }, {
+        value: 301,
+      }];
+      expect(bgUtils.calcBgPercentInCategories(data, bgBounds)).to.deep.equal({
+        veryLow: 0.2,
+        low: 0.2,
+        target: 0.2,
+        high: 0.2,
+        veryHigh: 0.2,
+      });
+    });
+
+    it('should not error if there are zero values in one or more categories', () => {
+      const data = [{
+        value: 100,
+      }, {
+        value: 100,
+      }, {
+        value: 100,
+      }, {
+        value: 100,
+      }, {
+        value: 100,
+      }];
+      expect(bgUtils.calcBgPercentInCategories(data, bgBounds)).to.deep.equal({
+        veryLow: 0,
+        low: 0,
+        target: 1,
+        high: 0,
+        veryHigh: 0,
       });
     });
   });

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -411,6 +411,47 @@ describe('bolus utilities', () => {
     });
   });
 
+  describe('getExtendedPercentage', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getExtendedPercentage);
+    });
+
+    it('should return NaN on a non-combo bolus', () => {
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(normal))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(cancelled))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(override))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(underride))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(withNetRec))).to.be.true;
+    });
+
+    it('should return the extended percentage as a String with `%` suffix', () => {
+      expect(bolusUtils.getExtendedPercentage(combo)).to.equal('67%');
+      expect(bolusUtils.getExtendedPercentage(comboOverride)).to.equal('63%');
+    });
+
+    it('should calculate the extended percentage based on programmed values', () => {
+      expect(bolusUtils.getExtendedPercentage(cancelledInNormalCombo)).to.equal('67%');
+      expect(bolusUtils.getExtendedPercentage(cancelledInExtendedCombo)).to.equal('67%');
+      expect(bolusUtils.getExtendedPercentage(comboUnderrideCancelled)).to.equal('75%');
+    });
+
+    it('should return NaN for an extended-only ("square") bolus', () => {
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(extended))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(cancelledExtended))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(immediatelyCancelledExtended)))
+        .to.be.true;
+      expect(Number.isNaN(bolusUtils.getExtendedPercentage(extendedUnderride))).to.be.true;
+    });
+
+    it(`should throw an error on a \`normal\`-cancelled \`combo\` bolus
+        with no \`expectedExtended\``, () => {
+      const fn = () => { bolusUtils.getExtendedPercentage(doesNotExist); };
+      expect(fn).to.throw(
+        'Combo bolus found with a cancelled `normal` portion and non-cancelled `extended`!'
+      );
+    });
+  });
+
   describe('getMaxDuration', () => {
     it('should be a function', () => {
       assert.isFunction(bolusUtils.getMaxDuration);
@@ -506,6 +547,47 @@ describe('bolus utilities', () => {
 
     it('should return the net recommendation in the case of a cancelled `combo` underride', () => {
       expect(bolusUtils.getMaxValue(comboUnderrideCancelled)).to.equal(5);
+    });
+  });
+
+  describe('getNormalPercentage', () => {
+    it('should be a function', () => {
+      assert.isFunction(bolusUtils.getNormalPercentage);
+    });
+
+    it('should return NaN on a non-combo bolus', () => {
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(normal))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(cancelled))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(override))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(underride))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(withNetRec))).to.be.true;
+    });
+
+    it('should return the extended percentage as a String with `%` suffix', () => {
+      expect(bolusUtils.getNormalPercentage(combo)).to.equal('33%');
+      expect(bolusUtils.getNormalPercentage(comboOverride)).to.equal('38%');
+    });
+
+    it('should calculate the extended percentage based on programmed values', () => {
+      expect(bolusUtils.getNormalPercentage(cancelledInNormalCombo)).to.equal('33%');
+      expect(bolusUtils.getNormalPercentage(cancelledInExtendedCombo)).to.equal('33%');
+      expect(bolusUtils.getNormalPercentage(comboUnderrideCancelled)).to.equal('25%');
+    });
+
+    it('should return NaN for an extended-only ("square") bolus', () => {
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(extended))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(cancelledExtended))).to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(immediatelyCancelledExtended)))
+        .to.be.true;
+      expect(Number.isNaN(bolusUtils.getNormalPercentage(extendedUnderride))).to.be.true;
+    });
+
+    it(`should throw an error on a \`normal\`-cancelled \`combo\` bolus
+        with no \`expectedExtended\``, () => {
+      const fn = () => { bolusUtils.getNormalPercentage(doesNotExist); };
+      expect(fn).to.throw(
+        'Combo bolus found with a cancelled `normal` portion and non-cancelled `extended`!'
+      );
     });
   });
 

--- a/test/utils/datetime.test.js
+++ b/test/utils/datetime.test.js
@@ -114,10 +114,12 @@ describe('datetime', () => {
     it('should be a function', () => {
       assert.isFunction(datetime.formatBirthdate);
     });
-    it('returns child name when isOtherPerson', () => {
-      expect(datetime.formatBirthdate(fakeChildAcct)).to.equal('Jan 31, 1983');
+
+    it('should format birthdate extracted from normal patient object', () => {
+      expect(datetime.formatBirthdate(patient)).to.equal('Jan 31, 1983');
     });
-    it('returns child name when isOtherPerson', () => {
+
+    it('should format birthdate extracted from fake child account patient object', () => {
       expect(datetime.formatBirthdate(fakeChildAcct)).to.equal('Jan 31, 1983');
     });
   });
@@ -167,11 +169,13 @@ describe('datetime', () => {
     it('should be a function', () => {
       assert.isFunction(datetime.formatDiagnosisDate);
     });
-    it('returns child name when isOtherPerson', () => {
+
+    it('should format diagnosisDate extracted from patient object', () => {
       expect(datetime.formatDiagnosisDate(patient)).to.equal('Jan 31, 1990');
     });
-    it('returns child name when isOtherPerson', () => {
-      expect(datetime.formatDiagnosisDate(patient)).to.equal('Jan 31, 1990');
+
+    it('should format diagnosisDate extracted from fake child account patient object', () => {
+      expect(datetime.formatDiagnosisDate(fakeChildAcct)).to.equal('Jan 31, 1990');
     });
   });
 

--- a/test/utils/datetime.test.js
+++ b/test/utils/datetime.test.js
@@ -179,6 +179,72 @@ describe('datetime', () => {
     });
   });
 
+  describe('formatDuration', () => {
+    it('should be a function', () => {
+      assert.isFunction(datetime.formatDuration);
+    });
+
+    it('should properly format a 30 minute duration', () => {
+      expect(datetime.formatDuration(36e5 / 2)).to.equal('30 min');
+    });
+
+    it('should properly format a 1 hr duration', () => {
+      expect(datetime.formatDuration(36e5)).to.equal('1 hr');
+    });
+
+    it('should properly format a 1.25 hr duration', () => {
+      expect(datetime.formatDuration(36e5 + 36e5 / 4)).to.equal('1¼ hr');
+    });
+
+    it('should properly format a 1.33333 hr duration', () => {
+      expect(datetime.formatDuration(36e5 + 36e5 / 3)).to.equal('1⅓ hr');
+    });
+
+    it('should properly format a 1.5 hr duration', () => {
+      expect(datetime.formatDuration(36e5 + 36e5 / 2)).to.equal('1½ hr');
+    });
+
+    it('should properly format a 1.66667 hr duration', () => {
+      expect(datetime.formatDuration(36e5 + 36e5 * (2 / 3))).to.equal('1⅔ hr');
+    });
+
+    it('should properly format a 1.75 hr duration', () => {
+      expect(datetime.formatDuration(36e5 + 36e5 * (3 / 4))).to.equal('1¾ hr');
+    });
+
+    it('should properly format a 1.1 hr duration', () => {
+      expect(datetime.formatDuration(36e5 + 36e5 / 10)).to.equal('1 hr 6 min');
+    });
+
+    it('should properly format a 2 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5)).to.equal('2 hrs');
+    });
+
+    it('should properly format a 2.25 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5 + 36e5 / 4)).to.equal('2¼ hrs');
+    });
+
+    it('should properly format a 2.33333 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5 + 36e5 / 3)).to.equal('2⅓ hrs');
+    });
+
+    it('should properly format a 2.5 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5 + 36e5 / 2)).to.equal('2½ hrs');
+    });
+
+    it('should properly format a 2.66667 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5 + 36e5 * (2 / 3))).to.equal('2⅔ hrs');
+    });
+
+    it('should properly format a 2.75 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5 + 36e5 * (3 / 4))).to.equal('2¾ hrs');
+    });
+
+    it('should properly format a 2.1 hr duration', () => {
+      expect(datetime.formatDuration(2 * 36e5 + 36e5 / 10)).to.equal('2 hrs 6 min');
+    });
+  });
+
   describe('formatLocalizedFromUTC', () => {
     const tzAwareLA = {
       timezoneAware: true,

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -113,4 +113,33 @@ describe('format', () => {
       expect(format.formatDecimalNumber(9.3328, 1)).to.equal('9.3');
     });
   });
+
+  describe('formatPercentage', () => {
+    it('should be a function', () => {
+      assert.isFunction(format.formatPercentage);
+    });
+
+    it('should return a String percentage including `%` suffix', () => {
+      expect(format.formatPercentage(0.5)).to.equal('50%');
+    });
+
+    it('should round to zero decimal places', () => {
+      expect(format.formatPercentage(0.732)).to.equal('73%');
+      expect(format.formatPercentage(0.736)).to.equal('74%');
+    });
+  });
+
+  describe('removeTrailingZeroes', () => {
+    it('should be a function', () => {
+      assert.isFunction(format.removeTrailingZeroes);
+    });
+
+    it('should return a String integer if only zeroes follow the decimal point', () => {
+      expect(format.removeTrailingZeroes('2.000')).to.equal('2');
+    });
+
+    it('should preserve everything non-zero right of the decimal point', () => {
+      expect(format.removeTrailingZeroes('2.100')).to.equal('2.100');
+    });
+  });
 });


### PR DESCRIPTION
There are two things here: some small tweaks to the bolus rendering for greater render-target-agnostic behavior (after trying things out in print view)... The key here is to define all paths explicitly as shapes even if just drawing a line because of the variability across render targets for how stroke is positioned on a path. (Yes, it varies, sadly.)

Then I pulled over more of the utilities I've had to add in the print view work, including a backwards-compatible change to the existing `classifyBgValue`.

Would recommend going through this PR commit by commit @krystophv 