### PR TITLE
render carb circles & labels for wizards

### DIFF
--- a/data/bolus/fixtures.js
+++ b/data/bolus/fixtures.js
@@ -44,6 +44,7 @@ export const interruptedNormal = {
 
 export const underrideNormal = {
   type: 'wizard',
+  carbInput: 80,
   recommended: {
     net: 10,
     carb: 8,
@@ -60,6 +61,7 @@ export const underrideNormal = {
 
 export const zeroUnderride = {
   type: 'wizard',
+  carbInput: 20,
   recommended: {
     net: 2,
     carb: 2,
@@ -76,6 +78,7 @@ export const zeroUnderride = {
 
 export const overrideNormal = {
   type: 'wizard',
+  carbInput: 20,
   recommended: {
     net: 0.5,
     carb: 2,
@@ -92,6 +95,7 @@ export const overrideNormal = {
 
 export const zeroOverride = {
   type: 'wizard',
+  carbInput: 20,
   recommended: {
     net: 0,
     carb: 2,
@@ -108,6 +112,7 @@ export const zeroOverride = {
 
 export const underrideAndInterruptedNormal = {
   type: 'wizard',
+  carbInput: 80,
   recommended: {
     net: 10,
     carb: 8,
@@ -125,6 +130,7 @@ export const underrideAndInterruptedNormal = {
 
 export const overrideAndInterruptedNormal = {
   type: 'wizard',
+  carbInput: 60,
   recommended: {
     net: 5,
     carb: 6,
@@ -174,6 +180,7 @@ export const interruptedExtended = {
 
 export const overrideExtended = {
   type: 'wizard',
+  carbInput: 40,
   recommended: {
     carb: 4,
     correction: 0,
@@ -191,6 +198,7 @@ export const overrideExtended = {
 
 export const underrideExtended = {
   type: 'wizard',
+  carbInput: 40,
   recommended: {
     carb: 4,
     correction: 0,
@@ -208,6 +216,7 @@ export const underrideExtended = {
 
 export const interruptedUnderrideExtended = {
   type: 'wizard',
+  carbInput: 40,
   recommended: {
     carb: 4,
     correction: 0,
@@ -259,6 +268,7 @@ export const interruptedDuringExtendedCombo = {
 
 export const underrideCombo = {
   type: 'wizard',
+  carbInput: 80,
   recommended: {
     carb: 8,
     correction: 1.25,
@@ -277,6 +287,7 @@ export const underrideCombo = {
 
 export const overrideCombo = {
   type: 'wizard',
+  carbInput: 80,
   recommended: {
     carb: 8,
     correction: 1.25,
@@ -295,6 +306,7 @@ export const overrideCombo = {
 
 export const interruptedOverrideCombo = {
   type: 'wizard',
+  carbInput: 80,
   recommended: {
     carb: 8,
     correction: 1.25,

--- a/src/components/common/data/Bolus.css
+++ b/src/components/common/data/Bolus.css
@@ -20,6 +20,15 @@
   stroke-width: 0;
 }
 
+.carbCircle {
+  composes: noStroke;
+  composes: carbs from '../../../styles/diabetes.css';
+}
+
+.carbText {
+  composes: mediumContrastText smallSize svgMiddleAnchored svgVerticalCentered from '../../../styles/typography.css';
+}
+
 .delivered {
   composes: noStroke;
   composes: bolusDelivered from '../../../styles/diabetes.css';

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -21,6 +21,7 @@
   --bolus--interrupted: #FF8B7C;
   --bolus--ride: #107EA8;
   --bolus--undelivered: #BCECFA;
+  --carbs: #FFD382;
   --collapsible--border: #EDEDED;
   --table-stripe--light: #F7F7F7;
   --table-stripe--dark: #ECECEC;

--- a/src/styles/diabetes.css
+++ b/src/styles/diabetes.css
@@ -83,3 +83,8 @@
   color: var(--bolus--undelivered);
   fill: var(--bolus--undelivered);
 }
+
+.carbs {
+  color: var(--carbs);
+  fill: var(--carbs);
+}

--- a/test/components/common/data/Bolus.test.js
+++ b/test/components/common/data/Bolus.test.js
@@ -24,7 +24,7 @@ const { detailXScale, detailBolusScale } = detail;
 import Bolus from '../../../../src/components/common/data/Bolus';
 import getBolusPaths from '../../../../src/modules/render/bolus';
 
-import { normal, zeroUnderride } from '../../../../data/bolus/fixtures';
+import { normal, underrideNormal, zeroUnderride } from '../../../../data/bolus/fixtures';
 
 const BOLUS_OPTS = {
   bolusWidth: 12,
@@ -48,5 +48,15 @@ describe('Bolus', () => {
     );
     expect(wrapper.find(`#bolus-${normal.id}`).length).to.equal(1);
     expect(wrapper.find('path').length).to.equal(paths.length);
+    expect(wrapper.find('circle').length).to.equal(0);
+    expect(wrapper.find('text').length).to.equal(0);
+  });
+
+  it('should include a <circle> and <text> for carbs if insulinEvent has `carbInput`', () => {
+    const wrapper = shallow(
+      <Bolus insulinEvent={underrideNormal} xScale={detailXScale} yScale={detailBolusScale} />
+    );
+    expect(wrapper.find('circle').length).to.equal(1);
+    expect(wrapper.find('text').length).to.equal(1);
   });
 });


### PR DESCRIPTION
Another small addition building on the last PR (#78).

Note that I've chosen to add the rendering for the web SVG target independently of the print view here. While it would be possible to do the circles with a path generator, it's not possible to do the text label that way, so some code would have to be reimplemented across print view and web SVG rendering anyway, and circles are easy, so might as well just reimplement both rather than have a confusing (IMO) mix of circle rendered via the path generator and label rendered in the native code.