### PR TITLE
Fix for displaying inaccurate 'High' and 'Low' smbg values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -21,6 +21,7 @@ import Tooltip from '../../common/tooltips/Tooltip';
 
 import { MGDL_UNITS, MMOLL_UNITS } from '../../../utils/constants';
 import { formatBgValue } from '../../../utils/format';
+import { getOutOfRangeThreshold } from '../../../utils/bloodglucose';
 import {
   formatClocktimeFromMsPer24,
   formatLocalizedFromUTC,
@@ -40,14 +41,6 @@ const FocusedSMBGPointLabel = (props) => {
   const { focusedPoint } = props;
   if (!focusedPoint) {
     return null;
-  }
-
-  function getOutOfRangeThreshold(smbg) {
-    const outOfRangeAnnotation = _.find(
-      smbg.annotations || [], (annotation) => (annotation.code === 'bg/out-of-range')
-    );
-    return outOfRangeAnnotation ?
-      { [outOfRangeAnnotation.value]: outOfRangeAnnotation.threshold } : null;
   }
 
   const {

--- a/src/modules/print/DailyPrintView.js
+++ b/src/modules/print/DailyPrintView.js
@@ -25,7 +25,11 @@ import moment from 'moment-timezone';
 import { calculateBasalPath, getBasalSequencePaths } from '../render/basal';
 import getBolusPaths from '../render/bolus';
 import { getTotalBasal } from '../../utils/basal';
-import { calcBgPercentInCategories, classifyBgValue } from '../../utils/bloodglucose';
+import {
+  calcBgPercentInCategories,
+  classifyBgValue,
+  getOutOfRangeThreshold,
+} from '../../utils/bloodglucose';
 import {
   getBolusFromInsulinEvent,
   getCarbs,
@@ -767,7 +771,7 @@ class DailyPrintView {
     _.each(smbgs, (smbg) => {
       const xPos = xScale(smbg.utc);
       const yPos = bgScale(smbg.value);
-      const smbgLabel = formatBgValue(smbg.value, this.bgPrefs);
+      const smbgLabel = formatBgValue(smbg.value, this.bgPrefs, getOutOfRangeThreshold(smbg));
       const labelWidth = this.doc.widthOfString(smbgLabel);
       const labelOffsetX = labelWidth / 2;
       let labelStartX = xPos - labelOffsetX;

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -102,3 +102,16 @@ export function reshapeBgClassesToBgBounds(bgPrefs) {
 
   return bgBounds;
 }
+
+/**
+ * getOutOfRangeThreshold
+ * @param {Object} bgDatum
+ * @return Object containing out of range threshold or null
+ */
+export function getOutOfRangeThreshold(bgDatum) {
+  const outOfRangeAnnotation = _.find(
+    bgDatum.annotations || [], (annotation) => (annotation.code === 'bg/out-of-range')
+  );
+  return outOfRangeAnnotation ?
+    { [outOfRangeAnnotation.value]: outOfRangeAnnotation.threshold } : null;
+}

--- a/src/utils/print/data.js
+++ b/src/utils/print/data.js
@@ -32,7 +32,6 @@ export function stripDatum(d) {
   return _.assign({}, _.omit(
     d,
     [
-      'annotations',
       'clockDriftOffset',
       'conversionOffset',
       'createdUserId',

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -230,4 +230,51 @@ describe('blood glucose utilities', () => {
       });
     });
   });
+
+  describe('getOutOfRangeThreshold', () => {
+    it('should return a high out-of-range threshold for a high datum', () => {
+      const datum = {
+        type: 'smbg',
+        value: 601,
+        annotations: [
+          {
+            code: 'bg/out-of-range',
+            threshold: 600,
+            value: 'high',
+          },
+        ],
+      };
+
+      expect(bgUtils.getOutOfRangeThreshold(datum)).to.deep.equal({
+        high: 600,
+      });
+    });
+
+    it('should return a low out-of-range threshold for a low datum', () => {
+      const datum = {
+        type: 'smbg',
+        value: 32,
+        annotations: [
+          {
+            code: 'bg/out-of-range',
+            threshold: 40,
+            value: 'low',
+          },
+        ],
+      };
+
+      expect(bgUtils.getOutOfRangeThreshold(datum)).to.deep.equal({
+        low: 40,
+      });
+    });
+
+    it('should return null for an in-range datum', () => {
+      const datum = {
+        type: 'smbg',
+        value: 100,
+      };
+
+      expect(bgUtils.getOutOfRangeThreshold(datum)).to.equal(null);
+    });
+  });
 });

--- a/test/utils/print/data.test.js
+++ b/test/utils/print/data.test.js
@@ -194,6 +194,7 @@ describe('print data utils', () => {
 
       const stripped = dataUtils.stripDatum(originalDatum);
       expect(stripped).to.eql({
+        annotations: '',
         type: 'cbg',
         value: 75,
       });


### PR DESCRIPTION
For CBG values, we show a HI/LO tooltip when the value is out of range. For SMBG values, we show value +1/-1 the threshold, e.g. when the threshold is 600 the value would be 601, and an annotation to indicate that the actual value can be higher or lower. 

We want CBG and SMBG values to have the same behaviour, ie., both should show 'High/Low' text (CBG text to be truncated to 'Hi/Lo' to fit into small tooltip circle.

Full details on trello: https://trello.com/c/p7L3RoNn

Goes hand-in-hand with https://github.com/tidepool-org/tideline/pull/321