### PR TITLE
bugfix for Redux state mutation violation (crashes app in dev mode)

### DIFF
--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -57,9 +57,9 @@ const FocusedSMBGPointLabel = (props) => {
   let smbgsOnDate = allSmbgsOnDate.slice();
   let positions = allPositions.slice();
   if (!lines) {
-    const focusedPointIndex = _.indexOf(allSmbgsOnDate, datum);
-    smbgsOnDate = _.pullAt(smbgsOnDate, focusedPointIndex);
-    positions = _.pullAt(positions, focusedPointIndex);
+    const focusedPointIndex = _.findIndex(allSmbgsOnDate, (d) => (d.value === datum.value));
+    _.pullAt(smbgsOnDate, focusedPointIndex);
+    _.pullAt(positions, focusedPointIndex);
   }
   const pointTooltips = _.map(smbgsOnDate, (smbg, i) => (
     <Tooltip

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -54,8 +54,8 @@ const FocusedSMBGPointLabel = (props) => {
   const lineDate = formatLocalizedFromUTC(hammertime, timePrefs);
   const shortDate = formatLocalizedFromUTC(hammertime, timePrefs, 'MMM D');
   const side = position.tooltipLeft ? 'left' : 'right';
-  let smbgsOnDate = allSmbgsOnDate.slice();
-  let positions = allPositions.slice();
+  const smbgsOnDate = allSmbgsOnDate.slice();
+  const positions = allPositions.slice();
   if (!lines) {
     const focusedPointIndex = _.findIndex(allSmbgsOnDate, (d) => (d.value === datum.value));
     _.pullAt(smbgsOnDate, focusedPointIndex);

--- a/src/components/trends/smbg/FocusedSMBGPointLabel.js
+++ b/src/components/trends/smbg/FocusedSMBGPointLabel.js
@@ -54,12 +54,14 @@ const FocusedSMBGPointLabel = (props) => {
   const lineDate = formatLocalizedFromUTC(hammertime, timePrefs);
   const shortDate = formatLocalizedFromUTC(hammertime, timePrefs, 'MMM D');
   const side = position.tooltipLeft ? 'left' : 'right';
+  let smbgsOnDate = allSmbgsOnDate.slice();
+  let positions = allPositions.slice();
   if (!lines) {
     const focusedPointIndex = _.indexOf(allSmbgsOnDate, datum);
-    _.pullAt(allSmbgsOnDate, focusedPointIndex);
-    _.pullAt(allPositions, focusedPointIndex);
+    smbgsOnDate = _.pullAt(smbgsOnDate, focusedPointIndex);
+    positions = _.pullAt(positions, focusedPointIndex);
   }
-  const pointTooltips = _.map(allSmbgsOnDate, (smbg, i) => (
+  const pointTooltips = _.map(smbgsOnDate, (smbg, i) => (
     <Tooltip
       key={i}
       content={
@@ -67,7 +69,7 @@ const FocusedSMBGPointLabel = (props) => {
           {formatBgValue(smbg.value, bgPrefs, getOutOfRangeThreshold(smbg))}
         </span>
       }
-      position={allPositions[i]}
+      position={positions[i]}
       side={'bottom'}
       tail={false}
       offset={{ top: SIMPLE_VALUE_TOP_OFFSET, left: 0 }}

--- a/test/components/trends/smbg/FocusedSMBGPointLabel.test.js
+++ b/test/components/trends/smbg/FocusedSMBGPointLabel.test.js
@@ -90,7 +90,7 @@ describe('FocusedSMBGPointLabel', () => {
     });
 
     it('should render individual point tooltips', () => {
-      expect(wrapper.find(formatClassesAsSelector(styles.number))).to.have.length(4);
+      expect(wrapper.find(formatClassesAsSelector(styles.number))).to.have.length(3);
     });
     it('should render a detailed individual point tooltip', () => {
       expect(wrapper.find(formatClassesAsSelector(styles.shortDate))).to.have.length(1);
@@ -113,7 +113,7 @@ describe('FocusedSMBGPointLabel', () => {
     });
 
     it('should render individual point tooltips', () => {
-      expect(wrapper.find(formatClassesAsSelector(styles.number))).to.have.length(4);
+      expect(wrapper.find(formatClassesAsSelector(styles.number))).to.have.length(3);
     });
     it('should render a detailed individual point tooltip', () => {
       expect(wrapper.find(formatClassesAsSelector(styles.shortDate))).to.have.length(1);


### PR DESCRIPTION
Prior to this fix, hovering on a BGM in default dev tools on mode (with the Redux state mutation tracker) would crash the app when hovering on a BGM in the BGM version of Trends view:
![screenshot 2017-10-25 09 24 37](https://user-images.githubusercontent.com/1588547/32001088-b24277ee-b966-11e7-8c34-34815968becf.png)
![screenshot 2017-10-25 09 24 42](https://user-images.githubusercontent.com/1588547/32001089-b2668742-b966-11e7-8802-1f9f1d8dcc14.png)
![screenshot 2017-10-25 09 24 47](https://user-images.githubusercontent.com/1588547/32001090-b2813a6a-b966-11e7-863b-014aed2d412b.png)

The change I've made here is to make sure to clone the `allSmbgsOnDate` and `allPositions` arrays (via `.slice()`) in `<FocusedSMBGPointLabel/>` prior to mutating them.

Just a small little fix 🙂 