### PR TITLE
Only volume-mount the bare minimum of files docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ COPY . /app
 RUN yarn install
 
 VOLUME /app
-VOLUME /app/node_modules
-VOLUME /app/dist
 
 EXPOSE 8081 8082
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,19 @@ RUN apk add --no-cache fontconfig \
  && apk add --no-cache --virtual .build-deps curl git \
  && echo "Fixing PhantomJS to run on alpine" \
  && curl -Ls "https://github.com/tidepool-org/tools/raw/master/alpine_phantomjs_dependencies/dockerized-phantomjs.tar.xz" | tar xJ -C / \
- && mkdir /app/dist && chown node:node -R /app/dist && chmod -R 755 /app/dist \
- && yarn install \
+ && mkdir /app/dist && mkdir /app/node_modules && chown node:node -R /app \
  && apk del .build-deps \
  && rm -rf /usr/share/man /tmp/* /var/tmp/* /root/.npm /root/.node-gyp
 
-COPY . /app
-
 USER node
 
-EXPOSE 8081
+COPY . /app
+
+RUN yarn install
+
+VOLUME /app
+VOLUME /app/node_modules
+
+EXPOSE 8081 8082
 
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yarn install
 
 VOLUME /app
 VOLUME /app/node_modules
+VOLUME /app/dist
 
 EXPOSE 8081 8082
 


### PR DESCRIPTION
Goes hand-in-hand with:
https://github.com/tidepool-org/tools/pull/64
https://github.com/tidepool-org/blip/pull/451

Changes to Dockerfile to allow us to not volume-mount the `node_modules` and `dist` directories to improve local performance. 