### PR TITLE
Bolus tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.8-bolus-tooltip.3",
+  "version": "0.9.8-bolus-tooltip.4",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.8-bolus-tooltip.6",
+  "version": "0.9.8-bolus-tooltip.7",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.7-bolus-tooltip",
+  "version": "0.9.7-bolus-tooltip.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.8-bolus-tooltip.7",
+  "version": "0.9.8",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.6",
+  "version": "0.9.7-bolus-tooltip",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.8-bolus-tooltip.5",
+  "version": "0.9.8-bolus-tooltip.6",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.7-bolus-tooltip.2",
+  "version": "0.9.8-bolus-tooltip.3",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.8-bolus-tooltip.4",
+  "version": "0.9.8-bolus-tooltip.5",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.7-bolus-tooltip.1",
+  "version": "0.9.7-bolus-tooltip.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/tooltips/Tooltip.css
+++ b/src/components/common/tooltips/Tooltip.css
@@ -23,7 +23,6 @@
   pointer-events: none;
   position: absolute;
   border-radius: 4px;
-  opacity: 0.75;
 }
 
 .content {

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -93,6 +93,7 @@ class Tooltip extends PureComponent {
       marginInnerValue = `${padding - 1}px`;
     }
     const borderSide = (tailSide === 'left') ? 'right' : 'left';
+    const tailInnerColor = this.props.tailColor || this.props.backgroundColor || backgroundColor;
     // The two child divs form the solid color tail and the border around it by layering
     // on one another offset by the border width adjusted slightly for the angle
     return (
@@ -107,16 +108,18 @@ class Tooltip extends PureComponent {
             [`border${_.capitalize(borderSide)}Color`]: borderColor,
           }}
         ></div>
-        <div
-          className={styles.tail}
-          style={{
-            marginTop: `-${tailHeight}px`,
-            marginLeft: marginInnerValue,
-            borderWidth: `${tailHeight}px ${2 * tailWidth}px`,
-            [`border${_.capitalize(borderSide)}Color`]:
-              this.props.backgroundColor || backgroundColor,
-          }}
-        ></div>
+        {tailInnerColor !== borderColor && (
+          <div
+            className={styles.tail}
+            style={{
+              marginTop: `-${tailHeight}px`,
+              marginLeft: marginInnerValue,
+              borderWidth: `${tailHeight}px ${2 * tailWidth}px`,
+              [`border${_.capitalize(borderSide)}Color`]:
+                this.props.tailColor || this.props.backgroundColor || backgroundColor,
+            }}
+          ></div>
+        )}
       </div>
     );
   }
@@ -184,6 +187,7 @@ Tooltip.propTypes = {
   side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']).isRequired,
   tailWidth: PropTypes.number.isRequired,
   tailHeight: PropTypes.number.isRequired,
+  tailColor: PropTypes.string,
   backgroundColor: PropTypes.string,
   borderColor: PropTypes.string.isRequired,
   borderWidth: PropTypes.number.isRequired,

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -86,8 +86,8 @@ class Tooltip extends PureComponent {
     let marginOuterValue;
     let marginInnerValue;
     if (tailSide === 'left') {
-      marginOuterValue = `calc(-100% - 2 * ${padding}px)`;
-      marginInnerValue = `calc(-100% - (2 * ${padding}px - ${borderWidth + 1}px))`;
+      marginOuterValue = `calc(-100% - (4 * ${tailWidth}px - ${padding}px)`;
+      marginInnerValue = `calc(-100% - (4 * ${tailWidth}px - ${padding}px - ${borderWidth + 1}px))`;
     } else {
       marginOuterValue = `calc(${padding}px + ${borderWidth}px)`;
       marginInnerValue = `${padding - 1}px`;

--- a/src/components/daily/bolustooltip/BolusTooltip.css
+++ b/src/components/daily/bolustooltip/BolusTooltip.css
@@ -22,6 +22,7 @@
   flex-direction: column;
   min-width: 160px;
   margin: 2px 0;
+  max-width: 180px;
 }
 
 .row {
@@ -107,6 +108,10 @@
 }
 
 .carbRatio {
+  composes: row;
+}
+
+.annotation {
   composes: row;
 }
 

--- a/src/components/daily/bolustooltip/BolusTooltip.css
+++ b/src/components/daily/bolustooltip/BolusTooltip.css
@@ -25,6 +25,7 @@
 }
 
 .row {
+  composes: smallSize from '../../../styles/typography.css';
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -45,6 +46,7 @@
 }
 
 .title {
+  composes: smallSize from '../../../styles/typography.css';
   text-align: right;
 }
 
@@ -71,6 +73,7 @@
 }
 
 .normal {
+  color: var(--gray-dark);
   composes: row;
 }
 
@@ -80,6 +83,10 @@
 }
 
 .programmed {
+  composes: row;
+}
+
+.carbs {
   composes: row;
 }
 

--- a/src/components/daily/bolustooltip/BolusTooltip.css
+++ b/src/components/daily/bolustooltip/BolusTooltip.css
@@ -1,0 +1,116 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+@import '../../../styles/colors.css';
+
+.container {
+  opacity: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+  margin: 2px 0;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  line-height: 20px;
+}
+
+.label {
+  flex-grow: 1;
+}
+
+.value {
+  margin-left: 20px;
+}
+
+.units {
+  min-width: 0.7em;
+  margin-left: 10px;
+}
+
+.title {
+  text-align: right;
+}
+
+.suggested {
+  composes: row;
+  font-weight: bold;
+}
+
+.delivered {
+  composes: row;
+  font-weight: bold;
+}
+
+.override {
+  composes: row;
+  color: var(--bolus--ride);
+  font-weight: bold;
+}
+
+.interrupted {
+  composes: row;
+  color: var(--bolus--interrupted);
+  font-weight: bold;
+}
+
+.normal {
+  composes: row;
+}
+
+.extended {
+  color: var(--gray-dark);
+  composes: row;
+}
+
+.programmed {
+  composes: row;
+}
+
+.bg {
+  composes: row;
+}
+
+.iob {
+  composes: row;
+}
+
+.target {
+  composes: row;
+}
+
+.isf {
+  composes: row;
+}
+
+.carbRatio {
+  composes: row;
+}
+
+.dividerSmall {
+  background-color: var(--bolus);
+  height: 2px;
+  margin: 5px -10px;
+}
+
+.dividerLarge {
+  background-color: var(--bolus);
+  height: 4px;
+  margin: 5px -10px;
+}

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -25,6 +25,17 @@ import colors from '../../../styles/colors.css';
 import styles from './BolusTooltip.css';
 
 class BolusTooltip extends PureComponent {
+  formatInsulin(qty) {
+    let decimalLength;
+    const qtyString = qty.toString();
+    if (qtyString.indexOf('.') !== -1 && qtyString.split('.')[1].length === 2) {
+      decimalLength = 2;
+    } else {
+      decimalLength = 1;
+    }
+    return formatDecimalNumber(qty, decimalLength);
+  }
+
   getTarget() {
     const wizardTarget = _.get(this.props.bolus, 'bgTarget');
     const target = _.get(wizardTarget, 'target', null);
@@ -33,10 +44,16 @@ class BolusTooltip extends PureComponent {
     const targetRange = _.get(wizardTarget, 'range', null);
     if (targetLow) {
       // medtronic
+      let value;
+      if (targetLow === targetHigh) {
+        value = `${targetLow}`;
+      } else {
+        value = `${targetLow}-${targetHigh}`;
+      }
       return (
         <div className={styles.target}>
           <div className={styles.label}>Target</div>
-          <div className={styles.value}>{`${targetLow}-${targetHigh}`}</div>
+          <div className={styles.value}>{value}</div>
           <div className={styles.units} />
         </div>
       );
@@ -106,7 +123,7 @@ class BolusTooltip extends PureComponent {
         <div className={styles.override}>
           <div className={styles.label}>Override</div>
           <div className={styles.value}>
-            {`+${formatDecimalNumber(programmed - recommended, 1)}`}
+            {`+${this.formatInsulin(programmed - recommended)}`}
           </div>
           <div className={styles.units}>U</div>
         </div>
@@ -117,7 +134,7 @@ class BolusTooltip extends PureComponent {
         <div className={styles.override}>
           <div className={styles.label}>Underride</div>
           <div className={styles.value}>
-            {`-${formatDecimalNumber(recommended - programmed, 1)}`}
+            {`-${this.formatInsulin(recommended - programmed)}`}
           </div>
           <div className={styles.units}>U</div>
         </div>
@@ -127,14 +144,14 @@ class BolusTooltip extends PureComponent {
     const deliveredLine = !!delivered && (
       <div className={styles.delivered}>
         <div className={styles.label}>Delivered</div>
-        <div className={styles.value}>{`${formatDecimalNumber(delivered, 1)}`}</div>
+        <div className={styles.value}>{`${this.formatInsulin(delivered)}`}</div>
         <div className={styles.units}>U</div>
       </div>
     );
     const suggestedLine = (isInterrupted || overrideLine) && !!suggested && (
       <div className={styles.suggested}>
         <div className={styles.label}>Suggested</div>
-        <div className={styles.value}>{formatDecimalNumber(suggested, 1)}</div>
+        <div className={styles.value}>{this.formatInsulin(suggested)}</div>
         <div className={styles.units}>U</div>
       </div>
     );
@@ -148,14 +165,14 @@ class BolusTooltip extends PureComponent {
     const iobLine = !!iob && (
       <div className={styles.iob}>
         <div className={styles.label}>IOB</div>
-        <div className={styles.value}>{`${formatDecimalNumber(iob, 1)}`}</div>
+        <div className={styles.value}>{`${this.formatInsulin(iob)}`}</div>
         <div className={styles.units}>U</div>
       </div>
     );
     const interruptedLine = isInterrupted && (
       <div className={styles.interrupted}>
         <div className={styles.label}>Interrupted</div>
-        <div className={styles.value}>{`-${formatDecimalNumber(programmed - delivered, 1)}`}</div>
+        <div className={styles.value}>{`-${this.formatInsulin(programmed - delivered)}`}</div>
         <div className={styles.units}>U</div>
       </div>
     );
@@ -177,7 +194,7 @@ class BolusTooltip extends PureComponent {
       !!normal && (
         <div className={styles.normal} key={'normal'}>
           <div className={styles.label}>{`Up Front (${normalPercentage})`}</div>
-          <div className={styles.value}>{`${formatDecimalNumber(normal, 1)}`}</div>
+          <div className={styles.value}>{`${this.formatInsulin(normal)}`}</div>
           <div className={styles.units}>U</div>
         </div>
       ),
@@ -186,7 +203,7 @@ class BolusTooltip extends PureComponent {
           {`Over ${formatDuration(bolusUtils.getDuration(wizard))} ${extendedPercentage}`}
         </div>
         <div className={styles.value}>
-          {`${formatDecimalNumber(bolusUtils.getExtended(wizard), 1)}`}
+          {`${this.formatInsulin(bolusUtils.getExtended(wizard))}`}
         </div>
         <div className={styles.units}>U</div>
       </div>,
@@ -225,14 +242,14 @@ class BolusTooltip extends PureComponent {
     const deliveredLine = !!delivered && (
       <div className={styles.delivered}>
         <div className={styles.label}>Delivered</div>
-        <div className={styles.value}>{`${formatDecimalNumber(delivered, 1)}`}</div>
+        <div className={styles.value}>{`${this.formatInsulin(delivered)}`}</div>
         <div className={styles.units}>U</div>
       </div>
     );
     const interruptedLine = isInterrupted && (
       <div className={styles.interrupted}>
         <div className={styles.label}>Interrupted</div>
-        <div className={styles.value}>{`-${formatDecimalNumber(programmed - delivered, 1)}`}</div>
+        <div className={styles.value}>{`-${this.formatInsulin(programmed - delivered)}`}</div>
         <div className={styles.units}>U</div>
       </div>
     );
@@ -240,7 +257,7 @@ class BolusTooltip extends PureComponent {
       !!programmed && (
       <div className={styles.programmed}>
         <div className={styles.label}>Programmed</div>
-        <div className={styles.value}>{`${formatDecimalNumber(programmed, 1)}`}</div>
+        <div className={styles.value}>{`${this.formatInsulin(programmed)}`}</div>
         <div className={styles.units}>U</div>
       </div>
     );
@@ -248,7 +265,7 @@ class BolusTooltip extends PureComponent {
       !!normal && (
         <div className={styles.normal} key={'normal'}>
           <div className={styles.label}>{`Up Front (${normalPercentage})`}</div>
-          <div className={styles.value}>{`${formatDecimalNumber(normal, 1)}`}</div>
+          <div className={styles.value}>{`${this.formatInsulin(normal)}`}</div>
           <div className={styles.units}>U</div>
         </div>
       ),
@@ -257,7 +274,7 @@ class BolusTooltip extends PureComponent {
           {`Over ${formatDuration(bolusUtils.getDuration(bolus))} ${extendedPercentage}`}
         </div>
         <div className={styles.value}>
-          {`${formatDecimalNumber(bolusUtils.getExtended(bolus), 1)}`}
+          {`${this.formatInsulin(bolusUtils.getExtended(bolus))}`}
         </div>
         <div className={styles.units}>U</div>
       </div>,

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -101,11 +101,11 @@ class BolusTooltip extends PureComponent {
   renderWizard() {
     const wizard = this.props.bolus;
     const recommended = bolusUtils.getRecommended(wizard);
-    const suggested = !_.isNaN(recommended) ? `${recommended}` : null;
+    const suggested = _.isFinite(recommended) ? `${recommended}` : null;
     const bg = _.get(wizard, 'bgInput', null);
     const iob = _.get(wizard, 'insulinOnBoard', null);
     const carbs = bolusUtils.getCarbs(wizard);
-    const carbsInput = !_.isNaN(carbs) && carbs > 0;
+    const carbsInput = _.isFinite(carbs) && carbs > 0;
     const carbRatio = _.get(wizard, 'insulinCarbRatio', null);
     const isf = _.get(wizard, 'insulinSensitivity', null);
     const delivered = bolusUtils.getDelivered(wizard);
@@ -141,7 +141,7 @@ class BolusTooltip extends PureComponent {
         </div>
       );
     }
-    const deliveredLine = !!delivered && (
+    const deliveredLine = _.isFinite(delivered) && (
       <div className={styles.delivered}>
         <div className={styles.label}>Delivered</div>
         <div className={styles.value}>{`${this.formatInsulin(delivered)}`}</div>
@@ -246,7 +246,7 @@ class BolusTooltip extends PureComponent {
     const extendedPercentage = _.isNaN(bolusUtils.getExtendedPercentage(bolus))
       ? ''
       : `(${bolusUtils.getExtendedPercentage(bolus)})`;
-    const deliveredLine = !!delivered && (
+    const deliveredLine = _.isFinite(delivered) && (
       <div className={styles.delivered}>
         <div className={styles.label}>Delivered</div>
         <div className={styles.value}>{`${this.formatInsulin(delivered)}`}</div>

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -1,0 +1,331 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React, { PropTypes, PureComponent } from 'react';
+import _ from 'lodash';
+import * as bolusUtils from '../../../utils/bolus';
+import { formatLocalizedFromUTC, formatDuration } from '../../../utils/datetime';
+import { formatDecimalNumber } from '../../../utils/format';
+import Tooltip from '../../common/tooltips/Tooltip';
+import colors from '../../../styles/colors.css';
+import styles from './BolusTooltip.css';
+
+class BolusTooltip extends PureComponent {
+  getTarget() {
+    const wizardTarget = _.get(this.props.bolus, 'bgTarget');
+    const target = _.get(wizardTarget, 'target', null);
+    const targetLow = _.get(wizardTarget, 'low', null);
+    const targetHigh = _.get(wizardTarget, 'high', null);
+    const targetRange = _.get(wizardTarget, 'range', null);
+    if (targetLow) {
+      // medtronic
+      return (
+        <div className={styles.target}>
+          <div className={styles.label}>Target</div>
+          <div className={styles.value}>{`${targetLow}-${targetHigh}`}</div>
+          <div className={styles.units} />
+        </div>
+      );
+    }
+    if (targetRange) {
+      // animas
+      return [
+        <div className={styles.target} key={'target'}>
+          <div className={styles.label}>Target</div>
+          <div className={styles.value}>{`${target}`}</div>
+          <div className={styles.units} />
+        </div>,
+        <div className={styles.target} key={'range'}>
+          <div className={styles.label}>Range</div>
+          <div className={styles.value}>{`${targetRange}`}</div>
+          <div className={styles.units} />
+        </div>,
+      ];
+    }
+    if (targetHigh) {
+      // insulet
+      return [
+        <div className={styles.target} key={'target'}>
+          <div className={styles.label}>Target</div>
+          <div className={styles.value}>{`${target}`}</div>
+          <div className={styles.units} />
+        </div>,
+        <div className={styles.target} key={'high'}>
+          <div className={styles.label}>High</div>
+          <div className={styles.value}>{`${targetHigh}`}</div>
+          <div className={styles.units} />
+        </div>,
+      ];
+    }
+    // tandem
+    return (
+      <div className={styles.target}>
+        <div className={styles.label}>Target</div>
+        <div className={styles.value}>{`${target}`}</div>
+        <div className={styles.units} />
+      </div>
+    );
+  }
+
+  renderWizard() {
+    const wizard = this.props.bolus;
+    const recommended = bolusUtils.getRecommended(wizard);
+    const suggested = !_.isNaN(recommended) ? `${recommended}` : null;
+    const bg = _.get(wizard, 'bgInput', null);
+    const iob = _.get(wizard, 'insulinOnBoard', null);
+    const carbsInput = !_.isNaN(bolusUtils.getCarbs(wizard)) && bolusUtils.getCarbs(wizard) > 0;
+    const carbRatio = _.get(wizard, 'insulinCarbRatio', null);
+    const isf = _.get(wizard, 'insulinSensitivity', null);
+    const delivered = bolusUtils.getDelivered(wizard);
+    const isInterrupted = bolusUtils.isInterruptedBolus(wizard);
+    const programmed = bolusUtils.getProgrammed(wizard);
+    const hasExtended = bolusUtils.hasExtended(wizard);
+    const normal = _.get(wizard, 'bolus.normal', NaN);
+    const normalPercentage = bolusUtils.getNormalPercentage(wizard);
+    const extendedPercentage = _.isNaN(bolusUtils.getExtendedPercentage(wizard))
+      ? ''
+      : `(${bolusUtils.getExtendedPercentage(wizard)})`;
+
+    let overrideLine = null;
+    if (bolusUtils.isOverride(wizard)) {
+      overrideLine = (
+        <div className={styles.override}>
+          <div className={styles.label}>Override</div>
+          <div className={styles.value}>
+            {`+${formatDecimalNumber(programmed - recommended, 1)}`}
+          </div>
+          <div className={styles.units}>U</div>
+        </div>
+      );
+    }
+    if (bolusUtils.isUnderride(wizard)) {
+      overrideLine = (
+        <div className={styles.override}>
+          <div className={styles.label}>Underride</div>
+          <div className={styles.value}>
+            {`-${formatDecimalNumber(recommended - programmed, 1)}`}
+          </div>
+          <div className={styles.units}>U</div>
+        </div>
+      );
+    }
+    const deliveredAtTop = !isInterrupted && !overrideLine;
+    const deliveredLine = !!delivered && (
+      <div className={styles.delivered}>
+        <div className={styles.label}>Delivered</div>
+        <div className={styles.value}>{`${formatDecimalNumber(delivered, 1)}`}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const suggestedLine = (isInterrupted || overrideLine) && !!suggested && (
+      <div className={styles.suggested}>
+        <div className={styles.label}>Suggested</div>
+        <div className={styles.value}>{formatDecimalNumber(suggested, 1)}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const bgLine = !!bg && (
+      <div className={styles.bg}>
+        <div className={styles.label}>BG</div>
+        <div className={styles.value}>{bg}</div>
+        <div className={styles.units} />
+      </div>
+    );
+    const iobLine = !!iob && (
+      <div className={styles.iob}>
+        <div className={styles.label}>IOB</div>
+        <div className={styles.value}>{`${formatDecimalNumber(iob, 1)}`}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const interruptedLine = isInterrupted && (
+      <div className={styles.interrupted}>
+        <div className={styles.label}>Interrupted</div>
+        <div className={styles.value}>{`-${formatDecimalNumber(programmed - delivered, 1)}`}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const icRatioLine = !!carbsInput && !!carbRatio && (
+      <div className={styles.carbRatio}>
+        <div className={styles.label}>I:C Ratio</div>
+        <div className={styles.value}>{`1:${carbRatio}`}</div>
+        <div className={styles.units} />
+      </div>
+    );
+    const isfLine = !!isf && !!bg && (
+      <div className={styles.isf}>
+        <div className={styles.label}>ISF</div>
+        <div className={styles.value}>{`${isf}`}</div>
+        <div className={styles.units} />
+      </div>
+    );
+    const extendedLine = hasExtended && [
+      !!normal && (
+        <div className={styles.normal}>
+          <div className={styles.label}>{`Up Front (${normalPercentage})`}</div>
+          <div className={styles.value}>{`${formatDecimalNumber(normal, 1)}`}</div>
+          <div className={styles.units}>U</div>
+        </div>
+      ),
+      <div className={styles.extended}>
+        <div className={styles.label}>
+          {`Over ${formatDuration(bolusUtils.getDuration(wizard))} ${extendedPercentage}`}
+        </div>
+        <div className={styles.value}>
+          {`${formatDecimalNumber(bolusUtils.getExtended(wizard), 1)}`}
+        </div>
+        <div className={styles.units}>U</div>
+      </div>,
+    ];
+
+    return (
+      <div className={styles.container}>
+        {suggestedLine}
+        {deliveredAtTop && deliveredLine}
+        {bgLine}
+        {iobLine}
+        {(isInterrupted || overrideLine || hasExtended) && <div className={styles.dividerSmall} />}
+        {interruptedLine}
+        {overrideLine}
+        {!deliveredAtTop && deliveredLine}
+        {(icRatioLine || isfLine || bg || hasExtended) && <div className={styles.dividerLarge} />}
+        {extendedLine}
+        {icRatioLine}
+        {isfLine}
+        {!!bg && this.getTarget()}
+      </div>
+    );
+  }
+
+  renderNormal() {
+    const bolus = this.props.bolus;
+    const delivered = bolusUtils.getDelivered(bolus);
+    const isInterrupted = bolusUtils.isInterruptedBolus(bolus);
+    const programmed = bolusUtils.getProgrammed(bolus);
+    const hasExtended = bolusUtils.hasExtended(bolus);
+    const normal = _.get(bolus, 'normal', NaN);
+    const normalPercentage = bolusUtils.getNormalPercentage(bolus);
+    const extendedPercentage = _.isNaN(bolusUtils.getExtendedPercentage(bolus))
+      ? ''
+      : `(${bolusUtils.getExtendedPercentage(bolus)})`;
+    const deliveredLine = !!delivered && (
+      <div className={styles.delivered}>
+        <div className={styles.label}>Delivered</div>
+        <div className={styles.value}>{`${formatDecimalNumber(delivered, 1)}`}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const interruptedLine = isInterrupted && (
+      <div className={styles.interrupted}>
+        <div className={styles.label}>Interrupted</div>
+        <div className={styles.value}>{`-${formatDecimalNumber(programmed - delivered, 1)}`}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const programmedLine = isInterrupted &&
+      !!programmed && (
+      <div className={styles.programmed}>
+        <div className={styles.label}>Programmed</div>
+        <div className={styles.value}>{`${formatDecimalNumber(programmed, 1)}`}</div>
+        <div className={styles.units}>U</div>
+      </div>
+    );
+    const extendedLine = hasExtended && [
+      !!normal && (
+        <div className={styles.normal}>
+          <div className={styles.label}>{`Up Front (${normalPercentage})`}</div>
+          <div className={styles.value}>{`${formatDecimalNumber(normal, 1)}`}</div>
+          <div className={styles.units}>U</div>
+        </div>
+      ),
+      <div className={styles.extended}>
+        <div className={styles.label}>
+          {`Over ${formatDuration(bolusUtils.getDuration(bolus))} ${extendedPercentage}`}
+        </div>
+        <div className={styles.value}>
+          {`${formatDecimalNumber(bolusUtils.getExtended(bolus), 1)}`}
+        </div>
+        <div className={styles.units}>U</div>
+      </div>,
+    ];
+
+    return (
+      <div className={styles.container}>
+        {programmedLine}
+        {!isInterrupted && deliveredLine}
+        {(isInterrupted || hasExtended) && <div className={styles.dividerSmall} />}
+        {interruptedLine}
+        {extendedLine}
+        {isInterrupted && deliveredLine}
+      </div>
+    );
+  }
+
+  renderBolus() {
+    let content;
+    if (this.props.bolus.type === 'wizard') {
+      content = this.renderWizard();
+    } else {
+      content = this.renderNormal();
+    }
+    return content;
+  }
+
+  render() {
+    const title = (
+      <div className={styles.title}>
+        {formatLocalizedFromUTC(this.props.bolus.normalTime, this.props.timePrefs, 'h:mm a')}
+      </div>
+    );
+    return <Tooltip {...this.props} title={title} content={this.renderBolus()} />;
+  }
+}
+
+BolusTooltip.propTypes = {
+  position: PropTypes.shape({
+    top: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+  }).isRequired,
+  offset: PropTypes.shape({
+    top: PropTypes.number.isRequired,
+    left: PropTypes.number,
+    horizontal: PropTypes.number,
+  }),
+  tail: PropTypes.bool.isRequired,
+  side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']).isRequired,
+  tailWidth: PropTypes.number.isRequired,
+  tailHeight: PropTypes.number.isRequired,
+  backgroundColor: PropTypes.string,
+  borderColor: PropTypes.string.isRequired,
+  borderWidth: PropTypes.number.isRequired,
+  bolus: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+  }).isRequired,
+  timePrefs: PropTypes.object.isRequired,
+};
+
+BolusTooltip.defaultProps = {
+  tail: true,
+  side: 'right',
+  tailWidth: 9,
+  tailHeight: 17,
+  tailColor: colors.bolus,
+  borderColor: colors.bolus,
+  borderWidth: 2,
+};
+
+export default BolusTooltip;

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -104,7 +104,8 @@ class BolusTooltip extends PureComponent {
     const suggested = !_.isNaN(recommended) ? `${recommended}` : null;
     const bg = _.get(wizard, 'bgInput', null);
     const iob = _.get(wizard, 'insulinOnBoard', null);
-    const carbsInput = !_.isNaN(bolusUtils.getCarbs(wizard)) && bolusUtils.getCarbs(wizard) > 0;
+    const carbs = bolusUtils.getCarbs(wizard);
+    const carbsInput = !_.isNaN(carbs) && carbs > 0;
     const carbRatio = _.get(wizard, 'insulinCarbRatio', null);
     const isf = _.get(wizard, 'insulinSensitivity', null);
     const delivered = bolusUtils.getDelivered(wizard);
@@ -140,7 +141,6 @@ class BolusTooltip extends PureComponent {
         </div>
       );
     }
-    const deliveredAtTop = !isInterrupted && !overrideLine;
     const deliveredLine = !!delivered && (
       <div className={styles.delivered}>
         <div className={styles.label}>Delivered</div>
@@ -160,6 +160,13 @@ class BolusTooltip extends PureComponent {
         <div className={styles.label}>BG</div>
         <div className={styles.value}>{bg}</div>
         <div className={styles.units} />
+      </div>
+    );
+    const carbsLine = !!carbs && (
+      <div className={styles.carbs}>
+        <div className={styles.label}>Carbs</div>
+        <div className={styles.value}>{carbs}</div>
+        <div className={styles.units}>g</div>
       </div>
     );
     const iobLine = !!iob && (
@@ -211,16 +218,16 @@ class BolusTooltip extends PureComponent {
 
     return (
       <div className={styles.container}>
-        {suggestedLine}
-        {deliveredAtTop && deliveredLine}
         {bgLine}
+        {carbsLine}
         {iobLine}
-        {(isInterrupted || overrideLine || hasExtended) && <div className={styles.dividerSmall} />}
-        {interruptedLine}
-        {overrideLine}
-        {!deliveredAtTop && deliveredLine}
-        {(icRatioLine || isfLine || bg || hasExtended) && <div className={styles.dividerLarge} />}
+        {suggestedLine}
         {extendedLine}
+        {(isInterrupted || overrideLine || hasExtended) && <div className={styles.dividerSmall} />}
+        {overrideLine}
+        {interruptedLine}
+        {deliveredLine}
+        {(icRatioLine || isfLine || bg) && <div className={styles.dividerLarge} />}
         {icRatioLine}
         {isfLine}
         {!!bg && this.getTarget()}
@@ -283,11 +290,9 @@ class BolusTooltip extends PureComponent {
     return (
       <div className={styles.container}>
         {programmedLine}
-        {!isInterrupted && deliveredLine}
-        {(isInterrupted || hasExtended) && <div className={styles.dividerSmall} />}
         {interruptedLine}
+        {deliveredLine}
         {extendedLine}
-        {isInterrupted && deliveredLine}
       </div>
     );
   }

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -307,6 +307,7 @@ BolusTooltip.propTypes = {
   }),
   tail: PropTypes.bool.isRequired,
   side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']).isRequired,
+  tailColor: PropTypes.string.isRequired,
   tailWidth: PropTypes.number.isRequired,
   tailHeight: PropTypes.number.isRequired,
   backgroundColor: PropTypes.string,

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -175,13 +175,13 @@ class BolusTooltip extends PureComponent {
     );
     const extendedLine = hasExtended && [
       !!normal && (
-        <div className={styles.normal}>
+        <div className={styles.normal} key={'normal'}>
           <div className={styles.label}>{`Up Front (${normalPercentage})`}</div>
           <div className={styles.value}>{`${formatDecimalNumber(normal, 1)}`}</div>
           <div className={styles.units}>U</div>
         </div>
       ),
-      <div className={styles.extended}>
+      <div className={styles.extended} key={'extended'}>
         <div className={styles.label}>
           {`Over ${formatDuration(bolusUtils.getDuration(wizard))} ${extendedPercentage}`}
         </div>
@@ -246,13 +246,13 @@ class BolusTooltip extends PureComponent {
     );
     const extendedLine = hasExtended && [
       !!normal && (
-        <div className={styles.normal}>
+        <div className={styles.normal} key={'normal'}>
           <div className={styles.label}>{`Up Front (${normalPercentage})`}</div>
           <div className={styles.value}>{`${formatDecimalNumber(normal, 1)}`}</div>
           <div className={styles.units}>U</div>
         </div>
       ),
-      <div className={styles.extended}>
+      <div className={styles.extended} key={'extended'}>
         <div className={styles.label}>
           {`Over ${formatDuration(bolusUtils.getDuration(bolus))} ${extendedPercentage}`}
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ import RangeSelect from './components/trends/cbg/RangeSelect';
 import TwoOptionToggle from './components/common/controls/TwoOptionToggle';
 import PumpSettingsContainer from './components/settings/common/PumpSettingsContainer';
 import TrendsContainer from './components/trends/common/TrendsContainer';
+import Tooltip from './components/common/tooltips/Tooltip';
+import BolusTooltip from './components/daily/bolustooltip/BolusTooltip';
 
 import vizReducer from './redux/reducers/';
 import * as actions from './redux/actions/worker';
@@ -42,6 +44,8 @@ const components = {
   FocusedSMBGPointLabel,
   RangeSelect,
   TwoOptionToggle,
+  Tooltip,
+  BolusTooltip,
 };
 
 const containers = {

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -58,6 +58,7 @@
 }
 
 :export {
+  bolus: #7CD0F0;
   basal: #19A0D7;
   low: #FF8B7C;
   target: #76D3A6;

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -343,3 +343,15 @@ export function isOverride(insulinEvent) {
 export function isUnderride(insulinEvent) {
   return getRecommended(insulinEvent) > getProgrammed(insulinEvent);
 }
+
+/**
+ * getAnnoations
+ * @param {Object} insulinEvent - a Tidebool bolus or wizard object
+ *
+ * @returns {Array} array of annotations for the bolus or an empty array
+ */
+export function getAnnotations(insulinEvent) {
+  const bolus = getBolusFromInsulinEvent(insulinEvent);
+  const annotations = _.get(bolus, 'annotations', []);
+  return annotations;
+}

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -70,7 +70,7 @@ export function getProgrammed(insulinEvent) {
   let bolus = insulinEvent;
   if (_.get(insulinEvent, 'type') === 'wizard') {
     bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus.normal && !bolus.extended) {
+    if (!_.inRange(bolus.normal, Infinity) && !_.inRange(bolus.extended, Infinity)) {
       return NaN;
     }
   }
@@ -129,7 +129,7 @@ export function getDelivered(insulinEvent) {
   let bolus = insulinEvent;
   if (_.get(insulinEvent, 'type') === 'wizard') {
     bolus = getBolusFromInsulinEvent(insulinEvent);
-    if (!bolus.normal && !bolus.extended) {
+    if (!_.inRange(bolus.normal, Infinity) && !_.inRange(bolus.extended, Infinity)) {
       return NaN;
     }
   }
@@ -315,7 +315,7 @@ export function isInterruptedBolus(insulinEvent) {
     bolus.extended !== bolus.expectedExtended
   );
 
-  if (_.isFinite(bolus.normal)) {
+  if (_.inRange(bolus.normal, Infinity)) {
     if (!bolus.extended) {
       return cancelledDuringNormal;
     }

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -315,7 +315,7 @@ export function isInterruptedBolus(insulinEvent) {
     bolus.extended !== bolus.expectedExtended
   );
 
-  if (bolus.normal) {
+  if (_.isFinite(bolus.normal)) {
     if (!bolus.extended) {
       return cancelledDuringNormal;
     }

--- a/stories/components/common/tooltips/Tooltip.js
+++ b/stories/components/common/tooltips/Tooltip.js
@@ -89,7 +89,7 @@ storiesOf('Tooltip', module)
   .add('tailWidth', () => (
     <div>
       {refDiv}
-      <Tooltip {...props} tailWidth={10} />
+      <Tooltip {...props} tailWidth={20} />
     </div>
   ))
   .add('tailHeight', () => (
@@ -144,6 +144,12 @@ storiesOf('Tooltip', module)
     <div>
       {refDiv}
       <Tooltip {...props} side={'right'} />
+    </div>
+  ))
+  .add('tail, on right, tailWidth', () => (
+    <div>
+      {refDiv}
+      <Tooltip {...props} side={'right'} tailWidth={20} />
     </div>
   ))
   .add('tail, on right, offset 5,5', () => (

--- a/stories/components/daily/BolusTooltip.js
+++ b/stories/components/daily/BolusTooltip.js
@@ -153,6 +153,30 @@ const immediatelyCancelledExtended = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const extendedAnimas = {
+  extended: 1.2,
+  duration: 18000000,
+  normalTime: '2017-11-11T05:45:52.000Z',
+  annotations: [
+    { code: 'animas/bolus/extended-equal-split' },
+  ],
+};
+
+const extendedAnimasUnderride = {
+  type: 'wizard',
+  bolus: {
+    extended: 1.2,
+    duration: 18000000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+    annotations: [
+      { code: 'animas/bolus/extended-equal-split' },
+    ],
+  },
+  recommended: {
+    correction: 3.5,
+  },
+};
+
 const extendedUnderride = {
   type: 'wizard',
   bolus: {
@@ -440,6 +464,18 @@ storiesOf('BolusTooltip', module)
     <div>
       {refDiv}
       <BolusTooltip {...props} bolus={immediatelyCancelledExtended} />
+    </div>
+  ))
+  .add('extendedAnimas', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={extendedAnimas} />
+    </div>
+  ))
+  .add('extendedAnimasUnderride', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={extendedAnimasUnderride} />
     </div>
   ))
   .add('extendedUnderride', () => (

--- a/stories/components/daily/BolusTooltip.js
+++ b/stories/components/daily/BolusTooltip.js
@@ -153,6 +153,33 @@ const immediatelyCancelledExtended = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const immediatelyCancelledExtendedWizard = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 0,
+    extended: 0,
+    expectedNormal: 2,
+    expectedExtended: 3,
+    duration: 0,
+    expectedDuration: 3600000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    net: 5,
+    carb: 5,
+    correction: 2,
+  },
+  carbInput: 75,
+  bgInput: 280,
+  insulinSensitivity: 70,
+  insulinOnBoard: 10,
+  insulinCarbRatio: 15,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
 const extendedAnimas = {
   extended: 1.2,
   duration: 18000000,
@@ -464,6 +491,12 @@ storiesOf('BolusTooltip', module)
     <div>
       {refDiv}
       <BolusTooltip {...props} bolus={immediatelyCancelledExtended} />
+    </div>
+  ))
+  .add('immediatelyCancelledExtendedWizard', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={immediatelyCancelledExtendedWizard} />
     </div>
   ))
   .add('extendedAnimas', () => (

--- a/stories/components/daily/BolusTooltip.js
+++ b/stories/components/daily/BolusTooltip.js
@@ -10,6 +10,11 @@ const normal = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const normalPrecise = {
+  normal: 5.05,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
 const cancelled = {
   normal: 2,
   expectedNormal: 5,
@@ -343,6 +348,12 @@ storiesOf('BolusTooltip', module)
     <div>
       {refDiv}
       <BolusTooltip {...props} bolus={normal} />
+    </div>
+  ))
+  .add('normalPrecise', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={normalPrecise} />
     </div>
   ))
   .add('cancelled', () => (

--- a/stories/components/daily/BolusTooltip.js
+++ b/stories/components/daily/BolusTooltip.js
@@ -21,6 +21,14 @@ const cancelled = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const immediatelyCancelled = {
+  normal: 0,
+  expectedNormal: 5.3,
+  normalTime: '2017-11-11T05:45:52.000Z',
+  type: 'bolus',
+  subType: 'normal',
+};
+
 const override = {
   type: 'wizard',
   bolus: {
@@ -360,6 +368,12 @@ storiesOf('BolusTooltip', module)
     <div>
       {refDiv}
       <BolusTooltip {...props} bolus={cancelled} />
+    </div>
+  ))
+  .add('immediatelyCancelled', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={immediatelyCancelled} />
     </div>
   ))
   .add('override', () => (

--- a/stories/components/daily/BolusTooltip.js
+++ b/stories/components/daily/BolusTooltip.js
@@ -1,0 +1,479 @@
+import React from 'react';
+
+import { storiesOf } from '@kadira/storybook';
+
+import BolusTooltip from '../../../src/components/daily/bolustooltip/BolusTooltip';
+
+// bolus' lifted from bolus utils tests
+const normal = {
+  normal: 5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelled = {
+  normal: 2,
+  expectedNormal: 5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const override = {
+  type: 'wizard',
+  bolus: {
+    normal: 2,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 0,
+    correction: 0,
+  },
+};
+
+const underride = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 1,
+    correction: 0.5,
+  },
+};
+
+const combo = {
+  normal: 1,
+  extended: 2,
+  duration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelledInNormalCombo = {
+  normal: 0.2,
+  expectedNormal: 1,
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelledInExtendedCombo = {
+  normal: 1,
+  extended: 0.5,
+  expectedExtended: 2,
+  duration: 9e5,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const comboOverride = {
+  type: 'wizard',
+  bolus: {
+    normal: 1.5,
+    extended: 2.5,
+    duration: 36e5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 3,
+  },
+};
+
+const comboUnderrideCancelled = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+    extended: 1,
+    expectedExtended: 3,
+    duration: 1200000,
+    expectedDuration: 3600000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+  },
+};
+
+const comboUnderrideCancelledWithBG = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 1,
+    extended: 1,
+    expectedExtended: 3,
+    duration: 1200000,
+    expectedDuration: 3600000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    net: 5,
+    carb: 5,
+    correction: 2,
+  },
+  carbInput: 75,
+  bgInput: 280,
+  insulinSensitivity: 70,
+  insulinCarbRatio: 15,
+};
+
+const extended = {
+  extended: 2,
+  duration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelledExtended = {
+  extended: 0.2,
+  expectedExtended: 2,
+  duration: 36e4,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const immediatelyCancelledExtended = {
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const extendedUnderride = {
+  type: 'wizard',
+  bolus: {
+    extended: 3,
+    duration: 36e5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    correction: 3.5,
+  },
+};
+
+const withNetRec = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    net: 2,
+  },
+};
+
+const withCarbInput = {
+  type: 'wizard',
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withBGInput = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  bgInput: 280,
+  insulinSensitivity: 70,
+};
+
+const withBGInputAndIOB = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  bgInput: 280,
+  insulinSensitivity: 70,
+  insulinOnBoard: 0.5,
+};
+
+const withBGAndCarbInput = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+  bgInput: 180,
+};
+
+const withMedtronicTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    low: 60,
+    high: 180,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withAnimasTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    target: 100,
+    range: 40,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withInsuletTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    target: 100,
+    high: 180,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withTandemTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const props = {
+  position: { top: 200, left: 200 },
+  timePrefs: { timezoneAware: false },
+};
+
+const BackgroundDecorator = story => (
+  <div style={{ backgroundColor: 'FloralWhite', width: '100%', height: '96vh' }}>{story()}</div>
+);
+
+const refDiv = (
+  <div
+    style={{
+      position: 'absolute',
+      width: '10px',
+      height: '10px',
+      top: '199px',
+      left: '199px',
+      backgroundColor: 'FireBrick',
+      opacity: 0.5,
+      zIndex: '1',
+    }}
+  />
+);
+
+storiesOf('BolusTooltip', module)
+  .addDecorator(BackgroundDecorator)
+  .add('normal', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={normal} />
+    </div>
+  ))
+  .add('cancelled', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={cancelled} />
+    </div>
+  ))
+  .add('override', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={override} />
+    </div>
+  ))
+  .add('underride', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={underride} />
+    </div>
+  ))
+  .add('combo', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={combo} />
+    </div>
+  ))
+  .add('cancelledInNormalCombo', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={cancelledInNormalCombo} />
+    </div>
+  ))
+  .add('cancelledInExtendedCombo', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={cancelledInExtendedCombo} />
+    </div>
+  ))
+  .add('comboOverride', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={comboOverride} />
+    </div>
+  ))
+  .add('comboUnderrideCancelled', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={comboUnderrideCancelled} />
+    </div>
+  ))
+  .add('comboUnderrideCancelledWithBG', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={comboUnderrideCancelledWithBG} />
+    </div>
+  ))
+  .add('extended', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={extended} />
+    </div>
+  ))
+  .add('cancelledExtended', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={cancelledExtended} />
+    </div>
+  ))
+  .add('immediatelyCancelledExtended', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={immediatelyCancelledExtended} />
+    </div>
+  ))
+  .add('extendedUnderride', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={extendedUnderride} />
+    </div>
+  ))
+  .add('withNetRec', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withNetRec} />
+    </div>
+  ))
+  .add('withCarbInput', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withCarbInput} />
+    </div>
+  ))
+  .add('withBGInput', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withBGInput} />
+    </div>
+  ))
+  .add('withBGInputAndIOB', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withBGInputAndIOB} />
+    </div>
+  ))
+  .add('withBGAndCarbInput', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withBGAndCarbInput} />
+    </div>
+  ))
+  .add('withMedtronicTarget', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withMedtronicTarget} />
+    </div>
+  ))
+  .add('withAnimasTarget', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withAnimasTarget} />
+    </div>
+  ))
+  .add('withInsuletTarget', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withInsuletTarget} />
+    </div>
+  ))
+  .add('withTandemTarget', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={withTandemTarget} />
+    </div>
+  ));

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -1,0 +1,457 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React from 'react';
+import _ from 'lodash';
+
+import { mount, shallow } from 'enzyme';
+
+import { formatClassesAsSelector } from '../../helpers/cssmodules';
+
+import BolusTooltip from '../../../src/components/daily/bolustooltip/BolusTooltip';
+import styles from '../../../src/components/daily/bolustooltip/BolusTooltip.css';
+
+const normal = {
+  normal: 5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelled = {
+  normal: 2,
+  expectedNormal: 5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const override = {
+  type: 'wizard',
+  bolus: {
+    normal: 2,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 0,
+    correction: 0,
+  },
+};
+
+const underride = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 1,
+    correction: 0.5,
+  },
+};
+
+const combo = {
+  normal: 1,
+  extended: 2,
+  duration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelledInNormalCombo = {
+  normal: 0.2,
+  expectedNormal: 1,
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelledInExtendedCombo = {
+  normal: 1,
+  extended: 0.5,
+  expectedExtended: 2,
+  duration: 9e5,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const comboOverride = {
+  type: 'wizard',
+  bolus: {
+    normal: 1.5,
+    extended: 2.5,
+    duration: 36e5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 3,
+  },
+};
+
+const comboUnderrideCancelled = {
+  type: 'wizard',
+  bolus: {
+    normal: 1,
+    extended: 1,
+    expectedExtended: 3,
+    duration: 1200000,
+    expectedDuration: 3600000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+  },
+};
+
+const comboUnderrideCancelledWithBG = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 1,
+    extended: 1,
+    expectedExtended: 3,
+    duration: 1200000,
+    expectedDuration: 3600000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    net: 5,
+    carb: 5,
+    correction: 2,
+  },
+  carbInput: 75,
+  bgInput: 280,
+  insulinSensitivity: 70,
+  insulinCarbRatio: 15,
+};
+
+const extended = {
+  extended: 2,
+  duration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const cancelledExtended = {
+  extended: 0.2,
+  expectedExtended: 2,
+  duration: 36e4,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const immediatelyCancelledExtended = {
+  extended: 0,
+  expectedExtended: 2,
+  duration: 0,
+  expectedDuration: 36e5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
+const extendedUnderride = {
+  type: 'wizard',
+  bolus: {
+    extended: 3,
+    duration: 36e5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    correction: 3.5,
+  },
+};
+
+const withCarbInput = {
+  type: 'wizard',
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withBGInputAndIOB = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  bgInput: 280,
+  insulinSensitivity: 70,
+  insulinOnBoard: 0.5,
+};
+
+const withMedtronicTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    low: 60,
+    high: 180,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withAnimasTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    target: 100,
+    range: 40,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withInsuletTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    target: 100,
+    high: 180,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const withTandemTarget = {
+  type: 'wizard',
+  bgInput: 180,
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    carb: 5,
+    correction: 0,
+    net: 5,
+  },
+  carbInput: 75,
+  insulinCarbRatio: 15,
+};
+
+const props = {
+  position: { top: 200, left: 200 },
+  timePrefs: { timezoneAware: false },
+};
+
+describe('BolusTooltip', () => {
+  it('should render without issue when all properties provided', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={normal} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+  });
+
+  it('should render programmed, interrupted and delivered for cancelled bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={cancelled} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+  });
+
+  it('should render suggested, override and delivered for override bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={override} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.suggested))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.override))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+  });
+
+  it('should render suggested, underride and delivered for underride bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={underride} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.suggested))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.override))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+  });
+
+  it('should render delivered, normal and extended for combo bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={combo} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.normal))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render programmed, interrupted, normal, extended and delivered for cancelled in normal combo bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={cancelledInNormalCombo} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.normal))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render programmed, interrupted, normal, extended and delivered for cancelled in extended combo bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={cancelledInExtendedCombo} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.normal))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render suggested, normal, extended, override and delivered for override combo bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={comboOverride} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.suggested))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.override))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.normal))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render suggested, interrupted, override, delivered, normal and extended for underride interrupted combo bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={comboUnderrideCancelled} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.suggested))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.override))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.normal))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render suggested, bg, interrupted, override, delivered, normal, extended, carbRatio, isf and target for underride interrupted combo with BG bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={comboUnderrideCancelledWithBG} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.suggested))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.bg))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.override))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.normal))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.carbRatio))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.isf))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.target))).to.have.length(1);
+  });
+
+  it('should render delivered and extended for extended bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={extended} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render programmed, interrupted, delivered and extendedDuraation for interrupted extended bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={cancelledExtended} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render programmed, interrupted and extended for immediately cancelled extended bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={immediatelyCancelledExtended} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should render suggested, override, delivered and extended for extended underide bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={extendedUnderride} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.suggested))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.override))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.extended))).to.have.length(1);
+  });
+
+  it('should render carbRatio for bolus with carb input', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={withCarbInput} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.carbRatio))).to.have.length(1);
+  });
+
+  it('should render delivered, bg, iob, isf and target for bg and iob bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={withBGInputAndIOB} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.bg))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.iob))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.isf))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.target))).to.have.length(1);
+  });
+
+  describe('getTarget', () => {
+    // eslint-disable-next-line max-len
+    const targetValue = `${formatClassesAsSelector(styles.target)} ${formatClassesAsSelector(styles.value)}`;
+    it('should return a single div for Medtronic style target', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={withMedtronicTarget} />);
+      expect(shallow(wrapper.instance().getTarget()).type()).to.equal('div');
+      expect(wrapper.find(targetValue).text()).to.equal('60-180');
+    });
+    it('should return an array for Animas style target', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={withAnimasTarget} />);
+      expect(_.isArray(wrapper.instance().getTarget())).to.be.true;
+      expect(wrapper.instance().getTarget().length).to.equal(2);
+      expect(wrapper.find(targetValue).first().text()).to.equal('100');
+      expect(wrapper.find(targetValue).last().text()).to.equal('40');
+    });
+    it('should return an array for Insulet style target', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={withInsuletTarget} />);
+      expect(_.isArray(wrapper.instance().getTarget())).to.be.true;
+      expect(wrapper.instance().getTarget().length).to.equal(2);
+      expect(wrapper.find(targetValue).first().text()).to.equal('100');
+      expect(wrapper.find(targetValue).last().text()).to.equal('180');
+    });
+    it('should return a single div for Tandem style target', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={withTandemTarget} />);
+      expect(shallow(wrapper.instance().getTarget()).type()).to.equal('div');
+      expect(wrapper.find(targetValue).text()).to.equal('100');
+    });
+  });
+});

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -41,6 +41,12 @@ const cancelled = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const immediatelyCancelled = {
+  normal: 0,
+  expectedNormal: 5,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
 const override = {
   type: 'wizard',
   bolus: {
@@ -303,6 +309,13 @@ describe('BolusTooltip', () => {
 
   it('should render programmed, interrupted and delivered for cancelled bolus', () => {
     const wrapper = mount(<BolusTooltip {...props} bolus={cancelled} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
+    expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
+  });
+
+  it('should render programmed, interrupted and delivered for immediately cancelled bolus', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={immediatelyCancelled} />);
     expect(wrapper.find(formatClassesAsSelector(styles.programmed))).to.have.length(1);
     expect(wrapper.find(formatClassesAsSelector(styles.interrupted))).to.have.length(1);
     expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -30,6 +30,11 @@ const normal = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const normalPrecise = {
+  normal: 5.05,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
 const cancelled = {
   normal: 2,
   expectedNormal: 5,
@@ -452,6 +457,21 @@ describe('BolusTooltip', () => {
       const wrapper = mount(<BolusTooltip {...props} bolus={withTandemTarget} />);
       expect(shallow(wrapper.instance().getTarget()).type()).to.equal('div');
       expect(wrapper.find(targetValue).text()).to.equal('100');
+    });
+  });
+
+  describe('formatInsulin', () => {
+    // eslint-disable-next-line max-len
+    const insulinValue = `${formatClassesAsSelector(styles.delivered)} ${formatClassesAsSelector(styles.value)}`;
+    it('should return a single digit fixed point float for integers', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={normal} />);
+      expect(wrapper.instance().formatInsulin(normal.normal)).to.equal('5.0');
+      expect(wrapper.find(insulinValue).text()).to.equal('5.0');
+    });
+    it('should include hundredths for insulin with hundredths precision', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={normalPrecise} />);
+      expect(wrapper.instance().formatInsulin(normalPrecise.normal)).to.equal('5.05');
+      expect(wrapper.find(insulinValue).text()).to.equal('5.05');
     });
   });
 });

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -130,6 +130,33 @@ const immediatelyCancelledExtended = {
   expectedDuration: 36e5,
 };
 
+const immediatelyCancelledExtendedWizard = {
+  type: 'wizard',
+  bgTarget: {
+    target: 100,
+  },
+  bolus: {
+    normal: 0,
+    extended: 0,
+    expectedNormal: 2,
+    expectedExtended: 3,
+    duration: 0,
+    expectedDuration: 3600000,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  recommended: {
+    net: 5,
+    carb: 5,
+    correction: 2,
+  },
+  carbInput: 75,
+  bgInput: 280,
+  insulinSensitivity: 70,
+  insulinOnBoard: 10,
+  insulinCarbRatio: 15,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
 const extendedUnderride = {
   type: 'wizard',
   bolus: {
@@ -287,6 +314,20 @@ describe('bolus utilities', () => {
         comboUnderrideCancelled.bolus.normal + comboUnderrideCancelled.bolus.expectedExtended
       );
     });
+
+    it('should return the `expectedExtended` for an immediately cancelled extended', () => {
+      expect(bolusUtils.getProgrammed(immediatelyCancelledExtended)).to.equal(
+        immediatelyCancelledExtended.expectedExtended
+      );
+    });
+
+    it(`should return the \`expectedNormal\` and \`expectedExtended\` for an immediately 
+        cancelled extended wizard`, () => {
+      expect(bolusUtils.getProgrammed(immediatelyCancelledExtendedWizard)).to.equal(
+        immediatelyCancelledExtendedWizard.bolus.expectedExtended +
+        immediatelyCancelledExtendedWizard.bolus.expectedNormal
+      );
+    });
   });
 
   describe('getRecommended', () => {
@@ -384,6 +425,20 @@ describe('bolus utilities', () => {
     it('should return the `normal` & `extended` of a cancelled `combo` underride', () => {
       expect(bolusUtils.getDelivered(comboUnderrideCancelled)).to.equal(
         comboUnderrideCancelled.bolus.normal + comboUnderrideCancelled.bolus.extended
+      );
+    });
+
+    it('should return the `extended` for an immediately cancelled extended', () => {
+      expect(bolusUtils.getDelivered(immediatelyCancelledExtended)).to.equal(
+        immediatelyCancelledExtended.extended
+      );
+    });
+
+    it(`should return the \`normal\` and \`extended\` for an immediately 
+        cancelled extended wizard`, () => {
+      expect(bolusUtils.getDelivered(immediatelyCancelledExtendedWizard)).to.equal(
+        immediatelyCancelledExtendedWizard.bolus.extended +
+        immediatelyCancelledExtendedWizard.bolus.normal
       );
     });
   });

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -29,6 +29,11 @@ const cancelled = {
   expectedNormal: 5,
 };
 
+const immediatelyCancelled = {
+  normal: 0,
+  expectedNormal: 5,
+};
+
 const override = {
   type: 'wizard',
   bolus: {
@@ -707,6 +712,10 @@ describe('bolus utilities', () => {
 
     it('should return `false` on a no-frills `combo` bolus', () => {
       expect(bolusUtils.isInterruptedBolus(combo)).to.be.false;
+    });
+
+    it('should return `true` on an immediately cancelled `normal` bolus', () => {
+      expect(bolusUtils.isInterruptedBolus(immediatelyCancelled)).to.be.true;
     });
 
     it('should return `true` on a cancelled `normal` bolus', () => {


### PR DESCRIPTION
Adds a new bolus tooltip which will display all relevant information concerning a bolus.

See also:
blip: https://github.com/tidepool-org/blip/pull/457
tideline: https://github.com/tidepool-org/tideline/pull/325