### PR TITLE
Libre data not being calculated due to insufficient data points

### DIFF
--- a/data/types.js
+++ b/data/types.js
@@ -79,13 +79,12 @@ class Basal extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       deliveryType: 'scheduled',
       deviceTime: this.makeDeviceTime(),
       duration: MS_IN_DAY / 12,
       rate: 0.5,
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'basal';
 
@@ -105,12 +104,11 @@ class Bolus extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       deviceTime: this.makeDeviceTime(),
       subType: 'normal',
       value: 5.0,
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'bolus';
     this.deviceTime = opts.deviceTime;
@@ -130,16 +128,17 @@ class CBG extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
+      deviceId: 'DexG4Rec_XXXXXXXXX',
       deviceTime: this.makeDeviceTime(),
       units: MGDL_UNITS,
       value: 100,
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'cbg';
 
     this.deviceTime = opts.deviceTime;
+    this.deviceId = opts.deviceId;
     this.units = opts.units;
     this.value = opts.value;
 
@@ -153,12 +152,11 @@ class Message extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       messageText: 'This is a note.',
       parentMessage: null,
       time: new Date().toISOString(),
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'message';
 
@@ -177,7 +175,7 @@ class Settings extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       activeBasalSchedule: 'standard',
       basalSchedules: [{
         name: 'standard',
@@ -204,8 +202,7 @@ class Settings extends Common {
         carb: 'grams',
         bg: MGDL_UNITS,
       },
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'settings';
 
@@ -227,15 +224,13 @@ class SMBG extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       deviceTime: this.makeDeviceTime(),
       normalTime: this.makeNormalTime(),
       displayOffset: 0,
       units: MGDL_UNITS,
       value: 100,
-    };
-
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'smbg';
 
@@ -254,13 +249,12 @@ class DeviceEvent extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       deviceTime: this.makeDeviceTime(),
       units: 'mg/dL',
       value: 100,
       primeTarget: 'cannula',
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'deviceEvent';
     this.subType = opts.subType;
@@ -282,11 +276,10 @@ class Upload extends Common {
   constructor(opts = {}) {
     super(opts);
 
-    const defaults = {
+    _.defaults(opts, {
       deviceTime: this.makeDeviceTime(),
       timezone: 'US/Eastern',
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'upload';
     this.deviceTags = opts.deviceTags;
@@ -308,7 +301,7 @@ class Wizard extends Common {
       // eslint-disable-next-line no-param-reassign
       opts.deviceTime = opts.bolus.deviceTime;
     }
-    const defaults = {
+    _.defaults(opts, {
       bgTarget: {
         high: 120,
         target: 100,
@@ -318,8 +311,7 @@ class Wizard extends Common {
       insulinSensitivity: 50,
       recommended: {},
       value: 5.0,
-    };
-    _.defaults(opts, defaults);
+    });
 
     this.type = 'wizard';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.9.6",
+  "version": "0.9.7-basics-libre-avg-cbg-fix.alpha.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/trends/common/TrendsContainer.js
+++ b/src/components/trends/common/TrendsContainer.js
@@ -15,8 +15,6 @@
  * == BSD2 LICENSE ==
  */
 
-const CBG_READINGS_ONE_DAY = 86400000 / (1000 * 60 * 5);
-
 import _ from 'lodash';
 import bows from 'bows';
 import { extent } from 'd3-array';
@@ -29,11 +27,20 @@ import { bindActionCreators } from 'redux';
 
 import * as actions from '../../../redux/actions/';
 import TrendsSVGContainer from './TrendsSVGContainer';
+
 import {
-  MGDL_CLAMP_TOP, MMOLL_CLAMP_TOP, MGDL_UNITS, MMOLL_UNITS, trends,
+  CGM_READINGS_ONE_DAY,
+  MGDL_CLAMP_TOP,
+  MMOLL_CLAMP_TOP,
+  MGDL_UNITS,
+  MMOLL_UNITS,
+  trends,
 } from '../../../utils/constants';
-const { extentSizes: { ONE_WEEK, TWO_WEEKS, FOUR_WEEKS } } = trends;
+
 import * as datetime from '../../../utils/datetime';
+import { weightedCGMCount } from '../../../utils/bloodglucose';
+
+const { extentSizes: { ONE_WEEK, TWO_WEEKS, FOUR_WEEKS } } = trends;
 
 /**
  * getAllDatesInRange
@@ -425,8 +432,8 @@ export class TrendsContainer extends PureComponent {
     }
     const { currentCbgData } = this.state;
     const { extentSize, showingCbg } = this.props;
-    const minimumCbgs = (extentSize * CBG_READINGS_ONE_DAY) / 2;
-    if (showingCbg && currentCbgData.length < minimumCbgs) {
+    const minimumCbgs = (extentSize * CGM_READINGS_ONE_DAY) / 2;
+    if (showingCbg && weightedCGMCount(currentCbgData) < minimumCbgs) {
       this.props.onSwitchBgDataSource();
     }
     this.props.markTrendsViewed(currentPatientInViewId);

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -21,14 +21,17 @@ import sundial from 'sundial';
 import crossfilter from 'crossfilter';
 
 import generateClassifiers from '../classifiers';
-import { generateBgRangeLabels } from '../bloodglucose';
+import {
+  generateBgRangeLabels,
+  weightedCGMCount,
+} from '../bloodglucose';
 
 import {
   BGM_DATA_KEY,
   CGM_DATA_KEY,
   MS_IN_DAY,
   MS_IN_HOUR,
-  CGM_IN_DAY,
+  CGM_READINGS_ONE_DAY,
   NOT_ENOUGH_CGM,
   CGM_CALCULATED,
   NO_CGM,
@@ -44,18 +47,6 @@ import {
   MEDTRONIC,
   pumpVocabulary,
 } from '../constants';
-
-/**
- * Get the latest CGM upload
- *
- * @export
- * @param {*} basicsData - the preprocessed basics data object
- * @returns {Object} the latest cgm upload data record if found, otherwise `undefined`
- */
-export function getLatestCGMUpload(basicsData) {
-  const uploadData = _.get(basicsData, 'data.upload.data', []);
-  return _.findLast(uploadData, upload => _.includes(_.get(upload, 'deviceTags', []), 'cgm'));
-}
 
 /**
  * Get the BG distribution source and status
@@ -75,18 +66,11 @@ export function determineBgDistributionSource(basicsData) {
   };
 
   if (cgmAvailable) {
-    const latestCGMUpload = getLatestCGMUpload(basicsData) || {};
-    const count = basicsData.data[CGM_DATA_KEY].data.length;
+    const cbgCount = weightedCGMCount(basicsData.data[CGM_DATA_KEY].data);
     const spanInDays = (Date.parse(basicsData.dateRange[1]) -
       Date.parse(basicsData.dateRange[0])) / MS_IN_DAY;
 
-    // We need to adjust the CGM_IN_DAY value for the Freestyle Libre, as it only
-    // collects BG samples every 15 minutes as opposed the 5 minute dexcom intervals.
-    const maxCGMInDay = latestCGMUpload.deviceModel === 'FreeStyle Libre'
-      ? CGM_IN_DAY / 3
-      : CGM_IN_DAY;
-
-    if (count < maxCGMInDay / 2 * spanInDays) {
+    if (cbgCount < CGM_READINGS_ONE_DAY / 2 * spanInDays) {
       bgSource.cgmStatus = NOT_ENOUGH_CGM;
     } else {
       bgSource.cgmStatus = CGM_CALCULATED;

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -82,11 +82,11 @@ export function determineBgDistributionSource(basicsData) {
 
     // We need to adjust the CGM_IN_DAY value for the Freestyle Libre, as it only
     // collects BG samples every 15 minutes as opposed the 5 minute dexcom intervals.
-    const expectedCGMInDay = latestCGMUpload.deviceModel === 'FreeStyle Libre'
+    const maxCGMInDay = latestCGMUpload.deviceModel === 'FreeStyle Libre'
       ? CGM_IN_DAY / 3
       : CGM_IN_DAY;
 
-    if (count < expectedCGMInDay / 2 * spanInDays) {
+    if (count < maxCGMInDay / 2 * spanInDays) {
       bgSource.cgmStatus = NOT_ENOUGH_CGM;
     } else {
       bgSource.cgmStatus = CGM_CALCULATED;

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -74,9 +74,8 @@ export function determineBgDistributionSource(basicsData) {
     source: bgmAvailable ? BGM_DATA_KEY : null,
   };
 
-  const latestCGMUpload = getLatestCGMUpload(basicsData) || {};
-
   if (cgmAvailable) {
+    const latestCGMUpload = getLatestCGMUpload(basicsData) || {};
     const count = basicsData.data[CGM_DATA_KEY].data.length;
     const spanInDays = (Date.parse(basicsData.dateRange[1]) -
       Date.parse(basicsData.dateRange[0])) / MS_IN_DAY;

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -138,3 +138,26 @@ export function getOutOfRangeThreshold(bgDatum) {
   return outOfRangeAnnotation ?
     { [outOfRangeAnnotation.value]: outOfRangeAnnotation.threshold } : null;
 }
+
+/**
+ * Get the adjusted count of expected CGM data points for devices that do not sample at the default
+ * 5 minute interval, such as the Abbot FreeStyle Libre, which samples every 15 mins
+ *
+ * @param {Array} data - cgm data
+ * @return {Integer} count - the weighted count
+ */
+export function weightedCGMCount(data) {
+  return _.reduce(data, (total, datum) => {
+    let datumWeight = 1;
+
+    // Because our decision as to whether or not there's enough cgm data to warrant using
+    // it to calculate average BGs is based on the expected number of readings in a day,
+    // we need to adjust the weight of a for the Freestyle Libre datum, as it only
+    // collects BG samples every 15 minutes as opposed the default 5 minutes from dexcom.
+    if (datum.deviceId.indexOf('AbbottFreeStyleLibre') === 0) {
+      datumWeight = 3;
+    }
+
+    return total + datumWeight;
+  }, 0);
+}

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -154,7 +154,7 @@ export function weightedCGMCount(data) {
     // it to calculate average BGs is based on the expected number of readings in a day,
     // we need to adjust the weight of a for the Freestyle Libre datum, as it only
     // collects BG samples every 15 minutes as opposed the default 5 minutes from dexcom.
-    if (datum.deviceId.indexOf('AbbottFreeStyleLibre') === 0) {
+    if (datum.type === 'cbg' && datum.deviceId.indexOf('AbbottFreeStyleLibre') === 0) {
       datumWeight = 3;
     }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,11 +37,11 @@ const FOUR_WEEKS = 28;
 
 export const trends = { extentSizes: { ONE_WEEK, TWO_WEEKS, FOUR_WEEKS } };
 
-export const CGM_IN_DAY = 288;
 export const MS_IN_DAY = 864e5;
 export const MS_IN_HOUR = 864e5 / 24;
 export const MS_IN_MIN = MS_IN_HOUR / 60;
 
+export const CGM_READINGS_ONE_DAY = 288;
 export const CGM_DATA_KEY = 'cbg';
 export const BGM_DATA_KEY = 'smbg';
 export const NO_CGM = 'noCGM';

--- a/test/components/trends/common/TrendsContainer.test.js
+++ b/test/components/trends/common/TrendsContainer.test.js
@@ -143,48 +143,54 @@ describe('TrendsContainer', () => {
       },
     };
 
-    const justOneDatum = (device = devices.dexcom) => sinon.stub().returns([{
+    const justOneDatum = (device = devices.dexcom, type = 'cbg') => sinon.stub().returns([{
       id: chance.hash({ length: 6 }),
       deviceId: device.id,
       msPer24: chance.integer({ min: 0, max: 864e5 }),
+      type,
       value: 100,
     }]);
     const lowestBg = 25;
-    const sevenDaysData = (device = devices.dexcom) => sinon.stub().returns(
+    const sevenDaysData = (device = devices.dexcom, type = 'cbg') => sinon.stub().returns(
       _.map(range(0, device.cgmInDay * extentSize), () => ({
         id: chance.hash({ length: 6 }),
         deviceId: device.id,
         msPer24: chance.integer({ min: 0, max: 864e5 }),
+        type,
         value: chance.pickone([lowestBg, 525]),
       }))
     );
 
-    const sevenDaysDataMixedMinimum = () => sinon.stub().returns(
+    const sevenDaysDataMixedMinimum = (type = 'cbg') => sinon.stub().returns(
       _.map(range(0, (devices.dexcom.cgmInDay / 4) * extentSize), () => ({
         id: chance.hash({ length: 6 }),
         deviceId: devices.dexcom.id,
         msPer24: chance.integer({ min: 0, max: 864e5 }),
+        type,
         value: chance.pickone([lowestBg, 525]),
       })).concat(_.map(range(0, (devices.libre.cgmInDay / 4) * extentSize), () => ({
         id: chance.hash({ length: 6 }),
         deviceId: devices.libre.id,
         msPer24: chance.integer({ min: 0, max: 864e5 }),
+        type,
         value: chance.pickone([lowestBg, 525]),
       })))
     );
 
-    const justOneDatumMmol = (device = devices.dexcom) => sinon.stub().returns([{
+    const justOneDatumMmol = (device = devices.dexcom, type = 'cbg') => sinon.stub().returns([{
       id: chance.hash({ length: 6 }),
       deviceId: device.id,
       msPer24: chance.integer({ min: 0, max: 864e5 }),
+      type,
       value: 5.2,
     }]);
     const lowestBgMmol = 3.1;
-    const sevenDaysDataMmol = (device = devices.dexcom) => sinon.stub().returns(
+    const sevenDaysDataMmol = (device = devices.dexcom, type = 'cbg') => sinon.stub().returns(
       _.map(range(0, device.cgmInDay * extentSize), () => ({
         id: chance.hash({ length: 6 }),
         deviceId: device.id,
         msPer24: chance.integer({ min: 0, max: 864e5 }),
+        type,
         value: chance.pickone([lowestBgMmol, 28.4]),
       }))
     );

--- a/test/components/trends/common/TrendsContainer.test.js
+++ b/test/components/trends/common/TrendsContainer.test.js
@@ -132,29 +132,58 @@ describe('TrendsContainer', () => {
     const extentSize = 7;
     const timezone = 'US/Pacific';
 
-    const justOneDatum = sinon.stub().returns([{
+    const devices = {
+      dexcom: {
+        id: 'DexG4Rec_XXXXXXXXX',
+        cgmInDay: 288,
+      },
+      libre: {
+        id: 'AbbottFreeStyleLibre_XXXXXXXXX',
+        cgmInDay: 96,
+      },
+    };
+
+    const justOneDatum = (device = devices.dexcom) => sinon.stub().returns([{
       id: chance.hash({ length: 6 }),
+      deviceId: device.id,
       msPer24: chance.integer({ min: 0, max: 864e5 }),
       value: 100,
     }]);
     const lowestBg = 25;
-    const sevenDaysData = sinon.stub().returns(
-      _.map(range(0, 288 * extentSize), () => ({
+    const sevenDaysData = (device = devices.dexcom) => sinon.stub().returns(
+      _.map(range(0, device.cgmInDay * extentSize), () => ({
         id: chance.hash({ length: 6 }),
+        deviceId: device.id,
         msPer24: chance.integer({ min: 0, max: 864e5 }),
         value: chance.pickone([lowestBg, 525]),
       }))
     );
 
-    const justOneDatumMmol = sinon.stub().returns([{
+    const sevenDaysDataMixedMinimum = () => sinon.stub().returns(
+      _.map(range(0, (devices.dexcom.cgmInDay / 4) * extentSize), () => ({
+        id: chance.hash({ length: 6 }),
+        deviceId: devices.dexcom.id,
+        msPer24: chance.integer({ min: 0, max: 864e5 }),
+        value: chance.pickone([lowestBg, 525]),
+      })).concat(_.map(range(0, (devices.libre.cgmInDay / 4) * extentSize), () => ({
+        id: chance.hash({ length: 6 }),
+        deviceId: devices.libre.id,
+        msPer24: chance.integer({ min: 0, max: 864e5 }),
+        value: chance.pickone([lowestBg, 525]),
+      })))
+    );
+
+    const justOneDatumMmol = (device = devices.dexcom) => sinon.stub().returns([{
       id: chance.hash({ length: 6 }),
+      deviceId: device.id,
       msPer24: chance.integer({ min: 0, max: 864e5 }),
       value: 5.2,
     }]);
     const lowestBgMmol = 3.1;
-    const sevenDaysDataMmol = sinon.stub().returns(
-      _.map(range(0, 288 * extentSize), () => ({
+    const sevenDaysDataMmol = (device = devices.dexcom) => sinon.stub().returns(
+      _.map(range(0, device.cgmInDay * extentSize), () => ({
         id: chance.hash({ length: 6 }),
+        deviceId: device.id,
         msPer24: chance.integer({ min: 0, max: 864e5 }),
         value: chance.pickone([lowestBgMmol, 28.4]),
       }))
@@ -255,7 +284,7 @@ describe('TrendsContainer', () => {
 
     before(() => {
       minimalData = mount(
-        <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum)} />
+        <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum())} />
       );
     });
 
@@ -273,7 +302,7 @@ describe('TrendsContainer', () => {
           <TrendsContainer
             {...props}
             {...mgdl}
-            {...makeDataStubs(justOneDatum)}
+            {...makeDataStubs(justOneDatum())}
             initialDatetimeLocation="2016-03-15T19:00:00.000Z"
           />
         );
@@ -301,7 +330,7 @@ describe('TrendsContainer', () => {
           <TrendsContainer
             {...props}
             {...mgdl}
-            {...makeDataStubs(justOneDatum)}
+            {...makeDataStubs(justOneDatum())}
           />
         );
         expect(markTrendsViewed.callCount).to.equal(1);
@@ -313,7 +342,7 @@ describe('TrendsContainer', () => {
           <TrendsContainer
             {..._.merge({}, props, { trendsState: { touched: true } })}
             {...mgdl}
-            {...makeDataStubs(justOneDatum)}
+            {...makeDataStubs(justOneDatum())}
           />
         );
         expect(markTrendsViewed.callCount).to.equal(0);
@@ -325,19 +354,43 @@ describe('TrendsContainer', () => {
           <TrendsContainer
             {...props}
             {...mgdl}
-            {...makeDataStubs(justOneDatum)}
+            {...makeDataStubs(justOneDatum())}
           />
         );
         expect(onSwitchBgDataSource.callCount).to.equal(1);
       });
 
-      it('should not toggle BG data source if enough cbg data', () => {
+      it('should not toggle BG data source if enough cbg data (dexcom)', () => {
         expect(onSwitchBgDataSource.callCount).to.equal(0);
         mount(
           <TrendsContainer
             {...props}
             {...mgdl}
-            {...makeDataStubs(sevenDaysData)}
+            {...makeDataStubs(sevenDaysData())}
+          />
+        );
+        expect(onSwitchBgDataSource.callCount).to.equal(0);
+      });
+
+      it('should not toggle BG data source if enough cbg data (libre)', () => {
+        expect(onSwitchBgDataSource.callCount).to.equal(0);
+        mount(
+          <TrendsContainer
+            {...props}
+            {...mgdl}
+            {...makeDataStubs(sevenDaysData(devices.libre))}
+          />
+        );
+        expect(onSwitchBgDataSource.callCount).to.equal(0);
+      });
+
+      it('should not toggle BG data source if enough cbg data (dexcom + libre mix)', () => {
+        expect(onSwitchBgDataSource.callCount).to.equal(0);
+        mount(
+          <TrendsContainer
+            {...props}
+            {...mgdl}
+            {...makeDataStubs(sevenDaysDataMixedMinimum())}
           />
         );
         expect(onSwitchBgDataSource.callCount).to.equal(0);
@@ -349,7 +402,7 @@ describe('TrendsContainer', () => {
           <TrendsContainer
             {..._.merge({}, props, { trendsState: { touched: true } })}
             {...mgdl}
-            {...makeDataStubs(justOneDatum)}
+            {...makeDataStubs(justOneDatum())}
           />
         );
         expect(onSwitchBgDataSource.callCount).to.equal(0);
@@ -403,7 +456,7 @@ describe('TrendsContainer', () => {
 
       beforeEach(() => {
         toBeUnmounted = mount(
-          <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum)} />
+          <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum())} />
         );
       });
 
@@ -454,7 +507,7 @@ describe('TrendsContainer', () => {
       describe('mg/dL blood glucose units', () => {
         before(() => {
           enoughCbgData = mount(
-            <TrendsContainer {...props} {...mgdl} {...makeDataStubs(sevenDaysData)} />
+            <TrendsContainer {...props} {...mgdl} {...makeDataStubs(sevenDaysData())} />
           );
         });
 
@@ -481,10 +534,10 @@ describe('TrendsContainer', () => {
       describe('mmol/L blood glucose units', () => {
         before(() => {
           enoughCbgDataMmol = mount(
-            <TrendsContainer {...props} {...mmoll} {...makeDataStubs(sevenDaysDataMmol)} />
+            <TrendsContainer {...props} {...mmoll} {...makeDataStubs(sevenDaysDataMmol())} />
           );
           minimalDataMmol = mount(
-            <TrendsContainer {...props} {...mmoll} {...makeDataStubs(justOneDatumMmol)} />
+            <TrendsContainer {...props} {...mmoll} {...makeDataStubs(justOneDatumMmol())} />
           );
         });
 
@@ -521,7 +574,7 @@ describe('TrendsContainer', () => {
             <TrendsContainer
               {...props}
               {...mgdl}
-              {...makeDataStubs(justOneDatum)}
+              {...makeDataStubs(justOneDatum())}
               initialDatetimeLocation="2016-03-15T19:00:00.000Z"
             />
           );
@@ -721,7 +774,7 @@ describe('TrendsContainer', () => {
     describe('render', () => {
       it('should render `TrendsSVGContainer`', () => {
         const wrapper = mount(
-          <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum)} />
+          <TrendsContainer {...props} {...mgdl} {...makeDataStubs(justOneDatum())} />
         );
         expect(wrapper.find(TrendsSVGContainer)).to.have.length(1);
       });

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -118,53 +118,7 @@ const siteChangeSections = {
 };
 
 describe('basics data utils', () => {
-  describe('getLatestCGMUpload', () => {
-    const uploadData = [
-      {
-        source: 'cgm',
-        deviceTags: ['cgm'],
-      },
-      {
-        source: 'bgm',
-        deviceTags: ['bgm'],
-      },
-      {
-        source: 'cgm2',
-        deviceTags: ['cgm'],
-      },
-      {
-        source: 'insulin-pump',
-        deviceTags: ['insulin-pump'],
-      },
-    ];
-
-    const noCGMUploadData = [
-      {
-        source: 'bgm',
-        deviceTags: ['bgm'],
-      },
-      {
-        source: 'other',
-      },
-    ];
-
-    it('should return the latest cgm upload data', () => {
-      expect(dataUtils.getLatestCGMUpload({
-        data: { upload: { data: uploadData } },
-      })).to.deep.equal({
-        source: 'cgm2',
-        deviceTags: ['cgm'],
-      });
-    });
-
-    it('should return `undefined` when there is no latest cgm upload data', () => {
-      expect(dataUtils.getLatestCGMUpload({
-        data: { upload: { data: noCGMUploadData } },
-      })).to.be.undefined;
-    });
-  });
-
-  describe('determineBgDistributionSource', () => {
+  describe.only('determineBgDistributionSource', () => {
     context('has enough cbg data (Dexcom)', () => {
       it('should yield cgmStatus `calculatedCGM` and source `cbg`', () => {
         const now = new Date();
@@ -173,9 +127,9 @@ describe('basics data utils', () => {
         ];
         const cbg = [];
 
-        const minimumCBGRequired = 144;
+        const minimumCBGRequiredPerDay = 144;
 
-        for (let i = 0; i < minimumCBGRequired; ++i) {
+        for (let i = 0; i < minimumCBGRequiredPerDay; ++i) {
           cbg.push(new Types.CBG({
             deviceTime: new Date(now.valueOf() + i * 2000).toISOString().slice(0, -5),
             value: 50,
@@ -189,6 +143,17 @@ describe('basics data utils', () => {
           cgmStatus: 'calculatedCGM',
           source: 'cbg',
         });
+
+        // remove one cbg point, and it should set status to `notEnoughCGM`
+        cbg.pop();
+
+        expect(dataUtils.determineBgDistributionSource({
+          data: { smbg: { data: smbg }, cbg: { data: cbg } },
+          dateRange: [utcDay.floor(now), utcDay.ceil(now)],
+        })).to.deep.equal({
+          cgmStatus: 'notEnoughCGM',
+          source: 'smbg',
+        });
       });
     });
 
@@ -200,29 +165,33 @@ describe('basics data utils', () => {
         ];
         const cbg = [];
 
-        const minimumCBGRequired = 144 / 3;
+        const minimumCBGRequiredPerDay = 48;
 
-        for (let i = 0; i < minimumCBGRequired; ++i) {
+        for (let i = 0; i < minimumCBGRequiredPerDay; ++i) {
           cbg.push(new Types.CBG({
+            deviceId: 'AbbottFreeStyleLibre-XXX-XXXX',
             deviceTime: new Date(now.valueOf() + i * 2000).toISOString().slice(0, -5),
             value: 50,
           }));
         }
 
-        const upload = [
-          {
-            source: 'Abbot',
-            deviceModel: 'FreeStyle Libre',
-            deviceTags: ['cgm', 'bgm'],
-          },
-        ];
-
         expect(dataUtils.determineBgDistributionSource({
-          data: { smbg: { data: smbg }, cbg: { data: cbg }, upload: { data: upload } },
+          data: { smbg: { data: smbg }, cbg: { data: cbg } },
           dateRange: [utcDay.floor(now), utcDay.ceil(now)],
         })).to.deep.equal({
           cgmStatus: 'calculatedCGM',
           source: 'cbg',
+        });
+
+        // remove one cbg point, and it should set status to `notEnoughCGM`
+        cbg.pop();
+
+        expect(dataUtils.determineBgDistributionSource({
+          data: { smbg: { data: smbg }, cbg: { data: cbg } },
+          dateRange: [utcDay.floor(now), utcDay.ceil(now)],
+        })).to.deep.equal({
+          cgmStatus: 'notEnoughCGM',
+          source: 'smbg',
         });
       });
     });

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -164,7 +164,7 @@ describe('basics data utils', () => {
     });
   });
 
-  describe.only('determineBgDistributionSource', () => {
+  describe('determineBgDistributionSource', () => {
     context('has enough cbg data (Dexcom)', () => {
       it('should yield cgmStatus `calculatedCGM` and source `cbg`', () => {
         const now = new Date();

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -15,6 +15,7 @@
  * == BSD2 LICENSE ==
  */
 
+import _ from 'lodash';
 import * as bgUtils from '../../src/utils/bloodglucose';
 
 describe('blood glucose utilities', () => {
@@ -326,6 +327,34 @@ describe('blood glucose utilities', () => {
       };
 
       expect(bgUtils.getOutOfRangeThreshold(datum)).to.equal(null);
+    });
+  });
+
+  describe('weightedCGMCount', () => {
+    it('should return a count of 1 for every cgm datum by default', () => {
+      const data = _.map(_.range(0, 10), () => ({
+        deviceId: 'Dexcom_XXXXXXX',
+      }));
+
+      expect(bgUtils.weightedCGMCount(data)).to.equal(data.length);
+    });
+
+    it('should return a count of 3 for every FreeStyle Libre cgm datum by default', () => {
+      const data = _.map(_.range(0, 10), () => ({
+        deviceId: 'AbbottFreeStyleLibre_XXXXXXX',
+      }));
+
+      expect(bgUtils.weightedCGMCount(data)).to.equal(data.length * 3);
+    });
+
+    it('should properly handle a mix of FreeStyle Libre and Dexcom data', () => {
+      const data = _.map(_.range(0, 10), () => ({
+        deviceId: 'Dexcom_XXXXXXX',
+      })).concat(_.map(_.range(0, 10), () => ({
+        deviceId: 'AbbottFreeStyleLibre_XXXXXXX',
+      })));
+
+      expect(bgUtils.weightedCGMCount(data)).to.equal(40);
     });
   });
 });

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -334,6 +334,7 @@ describe('blood glucose utilities', () => {
     it('should return a count of 1 for every cgm datum by default', () => {
       const data = _.map(_.range(0, 10), () => ({
         deviceId: 'Dexcom_XXXXXXX',
+        type: 'cbg',
       }));
 
       expect(bgUtils.weightedCGMCount(data)).to.equal(data.length);
@@ -342,6 +343,7 @@ describe('blood glucose utilities', () => {
     it('should return a count of 3 for every FreeStyle Libre cgm datum by default', () => {
       const data = _.map(_.range(0, 10), () => ({
         deviceId: 'AbbottFreeStyleLibre_XXXXXXX',
+        type: 'cbg',
       }));
 
       expect(bgUtils.weightedCGMCount(data)).to.equal(data.length * 3);
@@ -352,6 +354,7 @@ describe('blood glucose utilities', () => {
         deviceId: 'Dexcom_XXXXXXX',
       })).concat(_.map(_.range(0, 10), () => ({
         deviceId: 'AbbottFreeStyleLibre_XXXXXXX',
+        type: 'cbg',
       })));
 
       expect(bgUtils.weightedCGMCount(data)).to.equal(40);

--- a/test/utils/constants.test.js
+++ b/test/utils/constants.test.js
@@ -60,9 +60,9 @@ describe('constants', () => {
     });
   });
 
-  describe('CGM_IN_DAY', () => {
+  describe('CGM_READINGS_ONE_DAY', () => {
     it('should be `288`', () => {
-      expect(constants.CGM_IN_DAY).to.equal(288);
+      expect(constants.CGM_READINGS_ONE_DAY).to.equal(288);
     });
   });
 


### PR DESCRIPTION
Libre CBG data is not being calculated in a number of locations due to having an insufficient number of data points collected in a day.

This is because the minimum data thresholds are all based on getting a certain percentage of the day covered, based on getting a new reading every 5 minutes.  The Libre, however, only gets readings every 15 minutes, so we have to reduce the minimum amount of readings expected for Libre data threefold.

This PR includes fixes for the BG distribution widget in the Basics print view, and properly defaulting to cbg data in the trends view when data is sufficient.

See https://trello.com/c/FNlDqd1A for details.

Goes hand-in-hand with:
https://github.com/tidepool-org/blip/pull/458
https://github.com/tidepool-org/tideline/pull/326