### PR TITLE
Update glucose defaults to reflect standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.10.1",
+  "version": "0.10.2-standardbgdefaultsfix.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.10.2-standardbgdefaultsfix.2",
+  "version": "0.10.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.10.2-standardbgdefaultsfix.1",
+  "version": "0.10.2-standardbgdefaultsfix.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -19,7 +19,7 @@ import React, { PropTypes, PureComponent } from 'react';
 import _ from 'lodash';
 import * as bolusUtils from '../../../utils/bolus';
 import { formatLocalizedFromUTC, formatDuration } from '../../../utils/datetime';
-import { formatDecimalNumber } from '../../../utils/format';
+import { formatDecimalNumber, formatBgValue } from '../../../utils/format';
 import Tooltip from '../../common/tooltips/Tooltip';
 import colors from '../../../styles/colors.css';
 import styles from './BolusTooltip.css';
@@ -57,6 +57,7 @@ class BolusTooltip extends PureComponent {
   }
 
   getTarget() {
+    const bgPrefs = this.props.bgPrefs;
     const wizardTarget = _.get(this.props.bolus, 'bgTarget');
     const target = _.get(wizardTarget, 'target', null);
     const targetLow = _.get(wizardTarget, 'low', null);
@@ -83,12 +84,12 @@ class BolusTooltip extends PureComponent {
       return [
         <div className={styles.target} key={'target'}>
           <div className={styles.label}>Target</div>
-          <div className={styles.value}>{`${target}`}</div>
+          <div className={styles.value}>{`${formatBgValue(target, bgPrefs)}`}</div>
           <div className={styles.units} />
         </div>,
         <div className={styles.target} key={'range'}>
           <div className={styles.label}>Range</div>
-          <div className={styles.value}>{`${targetRange}`}</div>
+          <div className={styles.value}>{`${formatBgValue(targetRange, bgPrefs)}`}</div>
           <div className={styles.units} />
         </div>,
       ];
@@ -162,6 +163,7 @@ class BolusTooltip extends PureComponent {
 
   renderWizard() {
     const wizard = this.props.bolus;
+    const bgPrefs = this.props.bgPrefs;
     const recommended = bolusUtils.getRecommended(wizard);
     const suggested = _.isFinite(recommended) ? `${recommended}` : null;
     const bg = _.get(wizard, 'bgInput', null);
@@ -250,7 +252,7 @@ class BolusTooltip extends PureComponent {
       !!bg && (
       <div className={styles.isf}>
         <div className={styles.label}>ISF</div>
-        <div className={styles.value}>{`${isf}`}</div>
+        <div className={styles.value}>{`${formatBgValue(isf, bgPrefs)}`}</div>
         <div className={styles.units} />
       </div>
       );
@@ -360,6 +362,7 @@ BolusTooltip.propTypes = {
   bolus: PropTypes.shape({
     type: PropTypes.string.isRequired,
   }).isRequired,
+  bgPrefs: PropTypes.object.isRequired,
   timePrefs: PropTypes.object.isRequired,
 };
 

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -36,6 +36,10 @@ class BolusTooltip extends PureComponent {
     return formatDecimalNumber(qty, decimalLength);
   }
 
+  formatBgValue(val) {
+    return formatBgValue(val, this.props.bgPrefs);
+  }
+
   isAnimasExtended() {
     const annotations = bolusUtils.getAnnotations(this.props.bolus);
     const isAnimasExtended =
@@ -57,7 +61,6 @@ class BolusTooltip extends PureComponent {
   }
 
   getTarget() {
-    const bgPrefs = this.props.bgPrefs;
     const wizardTarget = _.get(this.props.bolus, 'bgTarget');
     const target = _.get(wizardTarget, 'target', null);
     const targetLow = _.get(wizardTarget, 'low', null);
@@ -67,9 +70,9 @@ class BolusTooltip extends PureComponent {
       // medtronic
       let value;
       if (targetLow === targetHigh) {
-        value = `${targetLow}`;
+        value = `${this.formatBgValue(targetLow)}`;
       } else {
-        value = `${targetLow}-${targetHigh}`;
+        value = `${this.formatBgValue(targetLow)}-${this.formatBgValue(targetHigh)}`;
       }
       return (
         <div className={styles.target}>
@@ -84,12 +87,12 @@ class BolusTooltip extends PureComponent {
       return [
         <div className={styles.target} key={'target'}>
           <div className={styles.label}>Target</div>
-          <div className={styles.value}>{`${formatBgValue(target, bgPrefs)}`}</div>
+          <div className={styles.value}>{`${this.formatBgValue(target)}`}</div>
           <div className={styles.units} />
         </div>,
         <div className={styles.target} key={'range'}>
           <div className={styles.label}>Range</div>
-          <div className={styles.value}>{`${formatBgValue(targetRange, bgPrefs)}`}</div>
+          <div className={styles.value}>{`${this.formatBgValue(targetRange)}`}</div>
           <div className={styles.units} />
         </div>,
       ];
@@ -99,12 +102,12 @@ class BolusTooltip extends PureComponent {
       return [
         <div className={styles.target} key={'target'}>
           <div className={styles.label}>Target</div>
-          <div className={styles.value}>{`${target}`}</div>
+          <div className={styles.value}>{`${this.formatBgValue(target)}`}</div>
           <div className={styles.units} />
         </div>,
         <div className={styles.target} key={'high'}>
           <div className={styles.label}>High</div>
-          <div className={styles.value}>{`${targetHigh}`}</div>
+          <div className={styles.value}>{`${this.formatBgValue(targetHigh)}`}</div>
           <div className={styles.units} />
         </div>,
       ];
@@ -113,7 +116,7 @@ class BolusTooltip extends PureComponent {
     return (
       <div className={styles.target}>
         <div className={styles.label}>Target</div>
-        <div className={styles.value}>{`${target}`}</div>
+        <div className={styles.value}>{`${this.formatBgValue(target)}`}</div>
         <div className={styles.units} />
       </div>
     );
@@ -163,7 +166,6 @@ class BolusTooltip extends PureComponent {
 
   renderWizard() {
     const wizard = this.props.bolus;
-    const bgPrefs = this.props.bgPrefs;
     const recommended = bolusUtils.getRecommended(wizard);
     const suggested = _.isFinite(recommended) ? `${recommended}` : null;
     const bg = _.get(wizard, 'bgInput', null);
@@ -215,7 +217,7 @@ class BolusTooltip extends PureComponent {
     const bgLine = !!bg && (
       <div className={styles.bg}>
         <div className={styles.label}>BG</div>
-        <div className={styles.value}>{bg}</div>
+        <div className={styles.value}>{this.formatBgValue(bg)}</div>
         <div className={styles.units} />
       </div>
     );
@@ -252,7 +254,7 @@ class BolusTooltip extends PureComponent {
       !!bg && (
       <div className={styles.isf}>
         <div className={styles.label}>ISF</div>
-        <div className={styles.value}>{`${formatBgValue(isf, bgPrefs)}`}</div>
+        <div className={styles.value}>{`${this.formatBgValue(isf)}`}</div>
         <div className={styles.units} />
       </div>
       );


### PR DESCRIPTION
See https://trello.com/c/OKj6Qyji for details.

Related PRs:
tidepool-org/tideline#338
tidepool-org/blip#480

This PR is required due to a side effect of a rounding fix applied to the tideline PR in the nurseshark plugin that was rounding the BG values when converting from the stored `mmol/L` values to `mg/dL` prior to categorization.  

This caused the `mg/dL` values in the bolus tooltips to show numerous decimal places.  This PR performs the missing formatting in the component render methods.