### PR TITLE
Add Basal:Bolus ratio to basics view for Automated Basal devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.11.0",
+  "version": "0.11.1-automated-basal-add-basal-bolus.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -506,10 +506,6 @@ export function defineBasicsSections(bgPrefs, manufacturer, deviceModel) {
 
   const deviceLabels = getPumpVocabulary(manufacturer);
 
-  const activeBasalRatio = isAutomatedBasalDevice(manufacturer, deviceModel)
-    ? 'timeInAutoRatio'
-    : 'basalBolusRatio';
-
   const sectionNames = [
     'averageDailyCarbs',
     'basalBolusRatio',
@@ -594,7 +590,6 @@ export function defineBasicsSections(bgPrefs, manufacturer, deviceModel) {
 
       case 'basalBolusRatio':
         title = 'Insulin ratio';
-        active = activeBasalRatio === 'basalBolusRatio';
         dimensions = [
           { key: 'basal', label: 'Basal' },
           { key: 'bolus', label: 'Bolus' },
@@ -603,7 +598,7 @@ export function defineBasicsSections(bgPrefs, manufacturer, deviceModel) {
 
       case 'timeInAutoRatio':
         title = `Time in ${deviceLabels[AUTOMATED_DELIVERY]} ratio`;
-        active = activeBasalRatio === 'timeInAutoRatio';
+        active = isAutomatedBasalDevice(manufacturer, deviceModel);
         dimensions = [
           { key: 'manual', label: `${deviceLabels[SCHEDULED_DELIVERY]}` },
           { key: 'automated', label: `${deviceLabels[AUTOMATED_DELIVERY]}` },

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -1105,9 +1105,9 @@ describe('basics data utils', () => {
       expect(result.timeInAutoRatio.active).to.be.false;
     });
 
-    it('should set the active basal ratio to `timeInAutoRatio` for automated-basal devices', () => {
+    it('should activate both `basalBolusRatio` and `timeInAutoRatio` for automated-basal devices', () => {
       const result = dataUtils.defineBasicsSections(bgPrefs[MGDL_UNITS], MEDTRONIC, '1780');
-      expect(result.basalBolusRatio.active).to.be.false;
+      expect(result.basalBolusRatio.active).to.be.true;
       expect(result.timeInAutoRatio.active).to.be.true;
     });
 
@@ -1149,14 +1149,14 @@ describe('basics data utils', () => {
     };
 
     it('should disable sections for which there is no data available', () => {
-      // all sections (except basalBolusRatio since it's an automated-basal device) active by default
+      // all sections (including timeInAutoRatio since it's an automated-basal device) active by default
       expect(basicsData.sections.basals.active).to.be.true;
       expect(basicsData.sections.boluses.active).to.be.true;
       expect(basicsData.sections.siteChanges.active).to.be.true;
       expect(basicsData.sections.fingersticks.active).to.be.true;
       expect(basicsData.sections.bgDistribution.active).to.be.true;
       expect(basicsData.sections.totalDailyDose.active).to.be.true;
-      expect(basicsData.sections.basalBolusRatio.active).to.be.false;
+      expect(basicsData.sections.basalBolusRatio.active).to.be.true;
       expect(basicsData.sections.timeInAutoRatio.active).to.be.true;
       expect(basicsData.sections.averageDailyCarbs.active).to.be.true;
       expect(_.find(basicsData.sections.fingersticks.filters, { path: 'calibration' })).to.be.defined;


### PR DESCRIPTION
See https://trello.com/c/NFKNjxyT for details.

Related PRs:
https://github.com/tidepool-org/blip/pull/494
https://github.com/tidepool-org/tideline/pull/347