### PR TITLE
Remove calibration related annotation messages for 600 series

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.11.3-calib-message.1",
+  "version": "0.11.3-calib-message.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.11.2",
+  "version": "0.11.3-calib-message.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/smbgtooltip/SMBGTooltip.css
+++ b/src/components/daily/smbgtooltip/SMBGTooltip.css
@@ -65,10 +65,6 @@
   composes: subType;
 }
 
-.sentForCalibration {
-  composes: subType;
-}
-
 .source {
   composes: subType;
 }

--- a/src/components/daily/smbgtooltip/SMBGTooltip.css
+++ b/src/components/daily/smbgtooltip/SMBGTooltip.css
@@ -65,7 +65,7 @@
   composes: subType;
 }
 
-.calibration {
+.sentForCalibration {
   composes: subType;
 }
 

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -41,10 +41,6 @@ const medtronic600BGMessages = {
   'medtronic600/smbg/remote-bg-acceptance-screen-timeout': 'Timed Out',
 };
 
-const medtronic600CalibrationMessages = {
-  'medtronic600/smbg/bg-sent-for-calib': 'Yes',
-};
-
 const simpleAnnotationMessages = {
   'animas/bolus/extended-equal-split':
     "* Animas pumps don't capture the details of how combo boluses are split between the normal and extended amounts.",
@@ -90,19 +86,6 @@ export function getMedtronic600AnnotationMessages(datum) {
         message: {
           label: 'Confirm BG',
           value: medtronic600BGMessages[medtronic600BGMessage[0]],
-        },
-      })
-    );
-  }
-  const medtronic600CalibrationMessage = _.intersection(
-    _.keys(medtronic600CalibrationMessages),
-    annotationCodes
-  );
-  if (medtronic600CalibrationMessage.length > 0) {
-    messages.push(
-      _.assign(_.find(annotations, { code: medtronic600CalibrationMessage[0] }), {
-        message: {
-          label: 'Sent for Calibration',
         },
       })
     );

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -43,7 +43,6 @@ const medtronic600BGMessages = {
 
 const medtronic600CalibrationMessages = {
   'medtronic600/smbg/bg-sent-for-calib': 'Yes',
-  'medtronic600/smbg/user-rejected-sensor-calib': 'No',
 };
 
 const simpleAnnotationMessages = {
@@ -103,8 +102,7 @@ export function getMedtronic600AnnotationMessages(datum) {
     messages.push(
       _.assign(_.find(annotations, { code: medtronic600CalibrationMessage[0] }), {
         message: {
-          label: 'Calibration',
-          value: medtronic600CalibrationMessages[medtronic600CalibrationMessage[0]],
+          label: 'Sent for Calibration',
         },
       })
     );

--- a/test/components/daily/SMBGTooltip.test.js
+++ b/test/components/daily/SMBGTooltip.test.js
@@ -274,14 +274,14 @@ describe('SMBGTooltip', () => {
 
   it('should render "Manual" for a manual medtronic 600 series smbg', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600calibManual} />);
-    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(0);
+    expect(wrapper.find(formatClassesAsSelector(styles.calibration))).to.have.length(0);
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });
 
   it('should render "Manual" for a non-calibration manual medtronic 600 series smbg', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600noncalibManual} />);
-    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(0);
+    expect(wrapper.find(formatClassesAsSelector(styles.calibration))).to.have.length(0);
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });
@@ -290,7 +290,7 @@ describe('SMBGTooltip', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600acceptedNoncalibManual} />);
     expect(wrapper.find(formatClassesAsSelector(styles.confirmBg))).to.have.length(1);
     expect(wrapper.find(bgValueSelector).text()).to.equal('Yes');
-    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(0);
+    expect(wrapper.find(formatClassesAsSelector(styles.calibration))).to.have.length(0);
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });

--- a/test/components/daily/SMBGTooltip.test.js
+++ b/test/components/daily/SMBGTooltip.test.js
@@ -192,7 +192,7 @@ const props = {
 
 const bgValueSelector = `${formatClassesAsSelector(styles.confirmBg)} ${formatClassesAsSelector(styles.value)}`;
 const sourceValueSelector = `${formatClassesAsSelector(styles.source)} ${formatClassesAsSelector(styles.value)}`;
-const calibrationValueSelector = `${formatClassesAsSelector(styles.calibration)} ${formatClassesAsSelector(styles.value)}`;
+const calibrationValueSelector = `${formatClassesAsSelector(styles.sentForCalibration)}`;
 const glucoseValueSelector = `${formatClassesAsSelector(styles.bg)} ${formatClassesAsSelector(styles.value)}`;
 
 describe('SMBGTooltip', () => {
@@ -273,28 +273,26 @@ describe('SMBGTooltip', () => {
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });
 
-  it('should render "Yes" and "Manual" for a calibration manual medtronic 600 series smbg', () => {
+  it('should render "Sent for Calibration" and "Manual" for a calibration manual medtronic 600 series smbg', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600calibManual} />);
-    expect(wrapper.find(formatClassesAsSelector(styles.calibration))).to.have.length(1);
-    expect(wrapper.find(calibrationValueSelector).text()).to.equal('Yes');
+    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(1);
+    expect(wrapper.find(calibrationValueSelector).text()).to.equal('Sent for Calibration');
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });
 
-  it('should render "No" and "Manual" for a non-calibration manual medtronic 600 series smbg', () => {
+  it('should render "Manual" for a non-calibration manual medtronic 600 series smbg', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600noncalibManual} />);
-    expect(wrapper.find(formatClassesAsSelector(styles.calibration))).to.have.length(1);
-    expect(wrapper.find(calibrationValueSelector).text()).to.equal('No');
+    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(0);
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });
 
-  it('should render "Yes", "No" and "Manual" for an accepted non-calibration manual medtronic 600 series smbg', () => {
+  it('should render "Yes" and "Manual" for an accepted non-calibration manual medtronic 600 series smbg', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600acceptedNoncalibManual} />);
     expect(wrapper.find(formatClassesAsSelector(styles.confirmBg))).to.have.length(1);
     expect(wrapper.find(bgValueSelector).text()).to.equal('Yes');
-    expect(wrapper.find(formatClassesAsSelector(styles.calibration))).to.have.length(1);
-    expect(wrapper.find(calibrationValueSelector).text()).to.equal('No');
+    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(0);
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });

--- a/test/components/daily/SMBGTooltip.test.js
+++ b/test/components/daily/SMBGTooltip.test.js
@@ -192,7 +192,6 @@ const props = {
 
 const bgValueSelector = `${formatClassesAsSelector(styles.confirmBg)} ${formatClassesAsSelector(styles.value)}`;
 const sourceValueSelector = `${formatClassesAsSelector(styles.source)} ${formatClassesAsSelector(styles.value)}`;
-const calibrationValueSelector = `${formatClassesAsSelector(styles.sentForCalibration)}`;
 const glucoseValueSelector = `${formatClassesAsSelector(styles.bg)} ${formatClassesAsSelector(styles.value)}`;
 
 describe('SMBGTooltip', () => {
@@ -273,10 +272,9 @@ describe('SMBGTooltip', () => {
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });
 
-  it('should render "Sent for Calibration" and "Manual" for a calibration manual medtronic 600 series smbg', () => {
+  it('should render "Manual" for a manual medtronic 600 series smbg', () => {
     const wrapper = mount(<SMBGTooltip {...props} smbg={medT600calibManual} />);
-    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(1);
-    expect(wrapper.find(calibrationValueSelector).text()).to.equal('Sent for Calibration');
+    expect(wrapper.find(formatClassesAsSelector(styles.sentForCalibration))).to.have.length(0);
     expect(wrapper.find(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(wrapper.find(sourceValueSelector).text()).to.equal('Manual');
   });

--- a/test/utils/annotations.test.js
+++ b/test/utils/annotations.test.js
@@ -32,7 +32,6 @@ const medT600acceptedNoncalibManual = {
   subType: 'manual',
   annotations: [
     { code: 'medtronic600/smbg/user-accepted-remote-bg' },
-    { code: 'medtronic600/smbg/user-rejected-sensor-calib' },
   ],
 };
 

--- a/test/utils/annotations.test.js
+++ b/test/utils/annotations.test.js
@@ -141,13 +141,6 @@ describe('annotation utilities', () => {
             value: 'Yes',
           },
         },
-        {
-          code: 'medtronic600/smbg/user-rejected-sensor-calib',
-          message: {
-            label: 'Calibration',
-            value: 'No',
-          },
-        },
       ]);
       expect(annotations.getAnnotationMessages(animasBolus)[0].message.value).to.equal(
         "* Animas pumps don't capture the details of how combo boluses are split between the normal and extended amounts."
@@ -174,13 +167,6 @@ describe('annotation utilities', () => {
           message: {
             label: 'Confirm BG',
             value: 'Yes',
-          },
-        },
-        {
-          code: 'medtronic600/smbg/user-rejected-sensor-calib',
-          message: {
-            label: 'Calibration',
-            value: 'No',
           },
         },
       ]);

--- a/test/utils/annotations.test.js
+++ b/test/utils/annotations.test.js
@@ -32,6 +32,7 @@ const medT600acceptedNoncalibManual = {
   subType: 'manual',
   annotations: [
     { code: 'medtronic600/smbg/user-accepted-remote-bg' },
+    { code: 'medtronic600/smbg/user-rejected-sensor-calib' },
   ],
 };
 


### PR DESCRIPTION
See: https://trello.com/c/u8Fid7Hi/439-600-series-bug-remove-calibration-yes-annotation

blip PR: https://github.com/tidepool-org/blip/pull/501