### PR TITLE
Add thousandths precision to insulin formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "0.11.2",
+  "version": "0.11.3-bolus-rounding.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -100,12 +100,11 @@ export function formatDecimalNumber(val, places) {
  * @returns {String} numeric value formatted for the precision of insulin dosing
  */
 export function formatInsulin(val) {
-  let decimalLength;
+  let decimalLength = 1;
   const qtyString = val.toString();
-  if (qtyString.indexOf('.') !== -1 && qtyString.split('.')[1].length === 2) {
-    decimalLength = 2;
-  } else {
-    decimalLength = 1;
+  if (qtyString.indexOf('.') !== -1) {
+    const length = qtyString.split('.')[1].length;
+    decimalLength = _.min([length, 3]);
   }
   return formatDecimalNumber(val, decimalLength);
 }

--- a/stories/components/daily/BolusTooltip.js
+++ b/stories/components/daily/BolusTooltip.js
@@ -15,6 +15,11 @@ const normalPrecise = {
   normalTime: '2017-11-11T05:45:52.000Z',
 };
 
+const normalVeryPrecise = {
+  normal: 5.025,
+  normalTime: '2017-11-11T05:45:52.000Z',
+};
+
 const cancelled = {
   normal: 2,
   expectedNormal: 5,
@@ -436,6 +441,12 @@ storiesOf('BolusTooltip', module)
     <div>
       {refDiv}
       <BolusTooltip {...props} bolus={normalPrecise} />
+    </div>
+  ))
+  .add('normalVeryPrecise', () => (
+    <div>
+      {refDiv}
+      <BolusTooltip {...props} bolus={normalVeryPrecise} />
     </div>
   ))
   .add('cancelled', () => (

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -126,6 +126,11 @@ describe('format', () => {
     it('should include hundredths for insulin with hundredths precision', () => {
       expect(format.formatInsulin(5.05)).to.equal('5.05');
     });
+
+    it('should include thousandths for insulin with thousandths precision', () => {
+      expect(format.formatInsulin(0.375)).to.equal('0.375');
+      expect(format.formatInsulin(3.825)).to.equal('3.825');
+    });
   });
 
   describe('formatPercentage', () => {


### PR DESCRIPTION
Some pumps allow for boluses at 0.025 unit intervals and we shouldn't be rounding them if they're provided in that level of precision.

blip PR: https://github.com/tidepool-org/blip/pull/502

Trello: https://trello.com/c/9ET8Bmh5/146-setting-6-series-bolus-increment-to-025-causes-loss-of-precision-due-to-rounding