### PR TITLE
Carb rendering

### DIFF
--- a/data/types.js
+++ b/data/types.js
@@ -334,11 +334,31 @@ export class Wizard extends Common {
   }
 }
 
+export class Food extends Common {
+  constructor(opts = {}) {
+    super(opts);
+
+    _.defaults(opts, {
+      deviceTime: this.makeDeviceTime(),
+    });
+
+    this.type = 'food';
+    this.deviceTime = opts.deviceTime;
+    this.nutrition = opts.nutrition;
+
+    this.time = this.makeTime();
+    this.normalTime = this.makeNormalTime();
+    this.createdTime = this.makeTime();
+    this.timezoneOffset = this.makeTimezoneOffset();
+  }
+}
+
 export const types = {
   Basal,
   Bolus,
   CBG,
   DeviceEvent,
+  Food,
   Message,
   Settings,
   SMBG,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.0.0-release.1",
+  "version": "1.1.0-carb-rendering.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/foodtooltip/FoodTooltip.css
+++ b/src/components/daily/foodtooltip/FoodTooltip.css
@@ -1,0 +1,57 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+@import '../../../styles/colors.css';
+
+.container {
+  opacity: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 80px;
+  margin: 2px 0;
+  max-width: 180px;
+}
+
+.row {
+  composes: smallSize from '../../../styles/typography.css';
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  line-height: 20px;
+}
+
+.label {
+  flex-grow: 1;
+}
+
+.value {
+  margin-left: 20px;
+}
+
+.units {
+  min-width: 0.7em;
+  margin-left: 10px;
+}
+
+.title {
+  composes: smallSize from '../../../styles/typography.css';
+  text-align: right;
+}
+
+.carb {
+  composes: row;
+  font-weight: bold;
+}

--- a/src/components/daily/foodtooltip/FoodTooltip.js
+++ b/src/components/daily/foodtooltip/FoodTooltip.js
@@ -1,0 +1,110 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React, { PropTypes, PureComponent } from 'react';
+import _ from 'lodash';
+
+import { formatLocalizedFromUTC } from '../../../utils/datetime';
+
+import Tooltip from '../../common/tooltips/Tooltip';
+import colors from '../../../styles/colors.css';
+import styles from './FoodTooltip.css';
+import i18next from 'i18next';
+
+const t = i18next.t.bind(i18next);
+
+class FoodTooltip extends PureComponent {
+  getCarbs(food) {
+    return _.get(food, 'nutrition.carbohydrate.net', 0);
+  }
+
+  renderFood() {
+    const food = this.props.food;
+    const rows = [
+      <div key={'carb'} className={styles.carb}>
+        <div className={styles.label}>{t('Carbs')}</div>
+        <div className={styles.value}>
+          {`${this.getCarbs(food)}`}
+        </div>
+        <div className={styles.units}>g</div>
+      </div>,
+    ];
+
+    return <div className={styles.container}>{rows}</div>;
+  }
+
+  render() {
+    const title = this.props.title ? this.props.title : (
+      <div className={styles.title}>
+        {formatLocalizedFromUTC(this.props.food.normalTime, this.props.timePrefs, 'h:mm a')}
+      </div>
+    );
+    return (
+      <Tooltip
+        {...this.props}
+        title={title}
+        content={this.renderFood()}
+      />
+    );
+  }
+}
+
+FoodTooltip.propTypes = {
+  position: PropTypes.shape({
+    top: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+  }).isRequired,
+  offset: PropTypes.shape({
+    top: PropTypes.number.isRequired,
+    left: PropTypes.number,
+    horizontal: PropTypes.number,
+  }),
+  titls: PropTypes.node,
+  tail: PropTypes.bool.isRequired,
+  side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']).isRequired,
+  tailColor: PropTypes.string.isRequired,
+  tailWidth: PropTypes.number.isRequired,
+  tailHeight: PropTypes.number.isRequired,
+  backgroundColor: PropTypes.string,
+  borderColor: PropTypes.string.isRequired,
+  borderWidth: PropTypes.number.isRequired,
+  food: PropTypes.shape({
+    nutrition: PropTypes.shape({
+      carbohydrate: PropTypes.shape({
+        net: PropTypes.number.isRequired,
+        units: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }).isRequired,
+  timePrefs: PropTypes.object.isRequired,
+  bgPrefs: PropTypes.shape({
+    bgClasses: PropTypes.object.isRequired,
+    bgUnits: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+FoodTooltip.defaultProps = {
+  tail: true,
+  side: 'right',
+  tailWidth: 9,
+  tailHeight: 17,
+  tailColor: colors.bolus,
+  borderColor: colors.bolus,
+  borderWidth: 2,
+};
+
+export default FoodTooltip;

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import BolusTooltip from './components/daily/bolustooltip/BolusTooltip';
 import SMBGTooltip from './components/daily/smbgtooltip/SMBGTooltip';
 import Stat from './components/common/stat/Stat';
 import CBGTooltip from './components/daily/cbgtooltip/CBGTooltip';
+import FoodTooltip from './components/daily/foodtooltip/FoodTooltip';
 
 import reducers from './redux/reducers/';
 
@@ -68,6 +69,7 @@ const components = {
   SMBGTooltip,
   Stat,
   CBGTooltip,
+  FoodTooltip,
 };
 
 const containers = {

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -194,12 +194,21 @@ export class DataUtil {
     this.applyDateFilters();
 
     const wizardData = this.filter.byType('wizard').top(Infinity);
+    const foodData = this.filter.byType('food').top(Infinity);
 
-    let carbs = _.reduce(
+    const wizardCarbs = _.reduce(
       wizardData,
       (result, datum) => result + _.get(datum, 'carbInput', 0),
       0
     );
+
+    const foodCarbs = _.reduce(
+      foodData,
+      (result, datum) => result + _.get(datum, 'nutrition.carbohydrate.net', 0),
+      0
+    );
+
+    let carbs = wizardCarbs + foodCarbs;
 
     if (this.days > 1) {
       carbs = carbs / this.days;
@@ -207,7 +216,7 @@ export class DataUtil {
 
     return {
       carbs,
-      total: wizardData.length,
+      total: wizardData.length + foodData.length,
     };
   };
 

--- a/test/components/daily/FoodTooltip.test.js
+++ b/test/components/daily/FoodTooltip.test.js
@@ -1,0 +1,87 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2016, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import { formatClassesAsSelector } from '../../helpers/cssmodules';
+
+import FoodTooltip from '../../../src/components/daily/foodtooltip/FoodTooltip';
+import styles from '../../../src/components/daily/foodtooltip/FoodTooltip.css';
+
+const normal = {
+  type: 'food',
+  nutrition: {
+    carbohydrate: {
+      net: 5,
+      units: 'grams',
+    },
+  },
+};
+
+const large = {
+  type: 'food',
+  nutrition: {
+    carbohydrate: {
+      net: 200,
+      units: 'grams',
+    },
+  },
+};
+
+const nonCarb = {
+  type: 'food',
+  nutrition: {
+    fat: {
+      total: 10,
+      units: 'grams',
+    },
+  },
+};
+
+const props = {
+  position: { top: 200, left: 200 },
+  timePrefs: { timezoneAware: false },
+};
+
+describe('FoodTooltip', () => {
+  it('should render without issue when all properties provided', () => {
+    const wrapper = mount(<FoodTooltip {...props} food={normal} />);
+    expect(wrapper.find(formatClassesAsSelector(styles.carb))).to.have.length(1);
+  });
+
+  describe('getCarbs', () => {
+    // eslint-disable-next-line max-len
+    const carbValue = `${formatClassesAsSelector(styles.carb)} ${formatClassesAsSelector(styles.value)}`;
+    it('should return 5 for a 5 gram net food value', () => {
+      const wrapper = mount(<FoodTooltip {...props} food={normal} />);
+      expect(wrapper.instance().getCarbs(normal)).to.equal(5);
+      expect(wrapper.find(carbValue).text()).to.equal('5');
+    });
+    it('should return 200 for a 200 gram net food value', () => {
+      const wrapper = mount(<FoodTooltip {...props} food={large} />);
+      expect(wrapper.instance().getCarbs(large)).to.equal(200);
+      expect(wrapper.find(carbValue).text()).to.equal('200');
+    });
+    it('should return 0 for a non-carbohydrate food value', () => {
+      const wrapper = mount(<FoodTooltip {...props} food={nonCarb} />);
+      expect(wrapper.instance().getCarbs(nonCarb)).to.equal(0);
+      expect(wrapper.find(carbValue).text()).to.equal('0');
+    });
+  });
+});

--- a/test/utils/data.test.js
+++ b/test/utils/data.test.js
@@ -97,6 +97,33 @@ describe('DataUtil', () => {
     }),
   ];
 
+  const foodData = [
+    new Types.Food({
+      deviceTime: '2018-02-01T02:00:00',
+      nutrition: {
+        carbohydrate: {
+          net: 7,
+        },
+      },
+    }),
+    new Types.Food({
+      deviceTime: '2018-02-01T04:00:00',
+      nutrition: {
+        carbohydrate: {
+          net: 9,
+        },
+      },
+    }),
+    new Types.Food({
+      deviceTime: '2018-02-02T04:00:00',
+      nutrition: {
+        carbohydrate: {
+          net: 13,
+        },
+      },
+    }),
+  ];
+
   const smbgData = [
     new Types.SMBG({
       value: 60,
@@ -157,6 +184,7 @@ describe('DataUtil', () => {
     ...basalData,
     ...bolusData,
     ...cbgData,
+    ...foodData,
     ...smbgData,
     ...uploadData,
     ...wizardData,
@@ -590,19 +618,19 @@ describe('DataUtil', () => {
   });
 
   describe('getCarbsData', () => {
-    it('should return the total carbs from wizard data when viewing 1 day', () => {
+    it('should return the total carbs from wizard and food data when viewing 1 day', () => {
       dataUtil.endpoints = dayEndpoints;
       expect(dataUtil.getCarbsData()).to.eql({
-        carbs: 6,
-        total: 3,
+        carbs: 22,
+        total: 5,
       });
     });
 
-    it('should return the avg daily carbs from wizard data when viewing more than 1 day', () => {
+    it('should return the avg daily carbs from wizard and food data when viewing more than 1 day', () => {
       dataUtil.endpoints = twoDayEndpoints;
       expect(dataUtil.getCarbsData()).to.eql({
-        carbs: 8,
-        total: 4,
+        carbs: 22.5,
+        total: 7,
       });
     });
   });


### PR DESCRIPTION
Adds a FoodTooltip which largely mimics the existing tooltip components, if just a little simplified for now as we _only_ have/are concerned with displaying carbohydrate data from an otherwise potentially very complex datatype (`food`). Also modifies `getCarbsData` to take the new `food` datatype into account.

Pairs well with:
tideline: https://github.com/tidepool-org/tideline/pull/365
blip: https://github.com/tidepool-org/blip/pull/537

Trello: https://trello.com/c/0WUNaQS6