### PR TITLE
Tidepool web crashes when rendering SD stat widget when SD > mean

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.1.0",
+  "version": "1.2.0-negative-sd-range-fix.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/stat/BgBar.js
+++ b/src/components/common/stat/BgBar.js
@@ -38,11 +38,15 @@ export const BgBar = props => {
   const datumY = yPos + (barWidth / 2);
   const datumX = scale.y(datum.y) * widthCorrection;
 
+  console.log('datumX', datumX);
+
   const dev1Value = datum.y - deviation;
   const dev1X = scale.y(datum.y - deviation) * widthCorrection;
+  console.log('dev1X', dev1X);
 
   const dev2Value = datum.y + deviation;
   const dev2X = scale.y(datum.y + deviation) * widthCorrection;
+  console.log('dev2X', dev2X);
 
   const isEnabled = renderMean ? datum.y >= 0 : deviation >= 0;
 
@@ -130,20 +134,20 @@ export const BgBar = props => {
         <g className="bgDeviation">
           <Rect
             {...props}
-            x={dev1X - 3}
+            x={_.max([dev1X - 3, 0])}
             y={datumY - barWidth * 2 - 1}
             width={4}
             height={barWidth * 4 + 2}
             style={{
               stroke: 'white',
               strokeWidth: 2,
-              fill: colors[classifyBgValue(bgBounds, dev1Value)],
+              fill: colors[classifyBgValue(bgBounds, _.max([dev1Value, 0.1]))],
             }}
           />
 
           <Rect
             {...props}
-            x={dev2X - 3}
+            x={_.min([dev2X - 3, width - chartLabelWidth - 3])}
             y={datumY - barWidth * 2 - 1}
             width={4}
             height={barWidth * 4 + 2}

--- a/src/components/common/stat/BgBar.js
+++ b/src/components/common/stat/BgBar.js
@@ -38,15 +38,11 @@ export const BgBar = props => {
   const datumY = yPos + (barWidth / 2);
   const datumX = scale.y(datum.y) * widthCorrection;
 
-  console.log('datumX', datumX);
-
   const dev1Value = datum.y - deviation;
   const dev1X = scale.y(datum.y - deviation) * widthCorrection;
-  console.log('dev1X', dev1X);
 
   const dev2Value = datum.y + deviation;
   const dev2X = scale.y(datum.y + deviation) * widthCorrection;
-  console.log('dev2X', dev2X);
 
   const isEnabled = renderMean ? datum.y >= 0 : deviation >= 0;
 

--- a/test/components/common/stat/BgBar.test.js
+++ b/test/components/common/stat/BgBar.test.js
@@ -262,5 +262,30 @@ describe('BgBar', () => {
       expect(bgDeviation().childAt(0).props().style.fill).to.equal(colors.high);
       expect(bgDeviation().childAt(1).props().style.fill).to.equal(colors.high);
     });
+
+    it('should set the color to `low` when the deviation is > the mean, resulting in a negative low bar value', () => {
+      // -1 low value
+      wrapper.setProps(props({ datum: {
+        y: 50,
+        deviation: { value: 51 },
+      } }));
+
+      expect(bgDeviation().childAt(0).props().style.fill).to.equal(colors.low);
+    });
+
+    it('should constrain the bars to render within the scale when the deviation would cause them to render outside of it', () => {
+      // -50 to 450 -- scale only shows 0 to 400
+      wrapper.setProps(props({ datum: {
+        y: 200,
+        deviation: { value: 250 },
+      } }));
+
+      const scaleWidth = defaultProps.width - defaultProps.chartLabelWidth;
+
+      expect(bgDeviation().childAt(0).props().x).to.equal(0);
+
+      expect(scaleWidth).to.equal(220);
+      expect(bgDeviation().childAt(1).props().x).to.equal(217); // scaleWidth - 3 for bar thickness
+    });
   });
 });


### PR DESCRIPTION
See https://trello.com/c/YcHZj4dI for details

Goes with:
tidepool-org/blip#549

Fix is twofold:

1. The actual error was resulting from the `classifyBgValue` utility function being called with a negative value during the BgBar component render. This PR ensures that only a positive, numeric value is passed in, which avoids the thrown error.
2. In cases where there are extremely wide deviation, it was possible that the high and low "bars" on the bg scale would actually render beyond the scale limits.  The rendered bar x positions are now constrained to the scale limits.