### PR TITLE
Fix Y-Axis bg tick overlaps on Trends view

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gsap": "2.0.2",
     "i18next": "11.9.0",
     "intl": "1.2.5",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "memorystream": "0.3.1",
     "moment": "2.22.2",
     "moment-timezone": "0.5.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.2.0-negative-sd-range-fix.1",
+  "version": "1.2.0-trends-y-axis-fix.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/trends/common/TrendsContainer.js
+++ b/src/components/trends/common/TrendsContainer.js
@@ -324,8 +324,8 @@ export class TrendsContainer extends PureComponent {
     const { bgPrefs: { bgBounds, bgUnits }, yScaleClampTop } = props;
     const upperBound = yScaleClampTop[bgUnits];
     const yScaleDomain = [bgDomain[0], upperBound];
-    if (bgDomain[0] > bgBounds.targetLowerBound) {
-      yScaleDomain[0] = bgBounds.targetLowerBound;
+    if (bgDomain[0] > bgBounds.veryLowThreshold) {
+      yScaleDomain[0] = bgBounds.veryLowThreshold;
     }
     const yScale = scaleLinear().domain(yScaleDomain).clamp(true);
 

--- a/test/components/trends/common/TrendsContainer.test.js
+++ b/test/components/trends/common/TrendsContainer.test.js
@@ -610,11 +610,11 @@ describe('TrendsContainer', () => {
           expect(yScale.clamp()).to.be.true;
         });
 
-        it('should have a minimum yScale domain: [targetLowerBound, yScaleClampTop]', () => {
+        it('should have a minimum yScale domain: [veryLowThreshold, yScaleClampTop]', () => {
           const { yScale } = minimalData.state();
           expect(yScale.domain())
             .to.deep.equal(
-              [mgdl.bgPrefs.bgBounds.targetLowerBound, props.yScaleClampTop[MGDL_UNITS]]
+              [mgdl.bgPrefs.bgBounds.veryLowThreshold, props.yScaleClampTop[MGDL_UNITS]]
             );
         });
 
@@ -640,11 +640,11 @@ describe('TrendsContainer', () => {
           expect(yScale.clamp()).to.be.true;
         });
 
-        it('should have a minimum yScale domain: [targetLowerBound, yScaleClampTop]', () => {
+        it('should have a minimum yScale domain: [veryLowThreshold, yScaleClampTop]', () => {
           const { yScale } = minimalDataMmol.state();
           expect(yScale.domain())
             .to.deep.equal(
-              [mmoll.bgPrefs.bgBounds.targetLowerBound, props.yScaleClampTop[MMOLL_UNITS]]
+              [mmoll.bgPrefs.bgBounds.veryLowThreshold, props.yScaleClampTop[MMOLL_UNITS]]
             );
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,17 +6342,18 @@ lodash.without@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
 
-lodash@4.*, lodash@4.17.10, lodash@^4.0.1, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.0:
+lodash@4.*, lodash@^4.0.1, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lodash@4.17.11, lodash@^4.15.0:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@4.17.4:
   version "4.17.4"
   resolved "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.15.0:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 log-symbols@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
See https://trello.com/c/EnbpV4VY for details.

Also, includes a minor patch version upgrade to `lodash`, which included a fix for a security vulnerability (though not one that was critical or exploitable in our app).

See also tidepool-org/blip#552