### PR TITLE
Reduce idle cpu usage on data views

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.5.0",
+  "version": "1.6.0-idle-cpu-usage.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.6.0-idle-cpu-usage.1",
+  "version": "1.6.0-idle-cpu-usage.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/loader/Loader.css
+++ b/src/components/common/loader/Loader.css
@@ -45,6 +45,9 @@
   border-radius: 50%;
   background: var(--brand-purple-dark);
   transform: scale(0.5);
+}
+
+.loaderDot.animating {
   animation: scale-dot 1.2s ease-out infinite;
 }
 

--- a/src/components/common/loader/Loader.js
+++ b/src/components/common/loader/Loader.js
@@ -34,14 +34,19 @@ const Loader = (props) => {
     [styles.overlay]: overlay,
   });
 
+  const loaderDotClasses = cx({
+    [styles.loaderDot]: true,
+    [styles.animating]: show,
+  });
+
   return (
     <div className={loaderOuterClasses}>
       <div className={loaderInnerClasses}>
-        <div className={styles.loaderDot} />
-        <div className={styles.loaderDot} />
-        <div className={styles.loaderDot} />
-        <div className={styles.loaderDot} />
-        <div className={styles.loaderDot} />
+        <div className={loaderDotClasses} />
+        <div className={loaderDotClasses} />
+        <div className={loaderDotClasses} />
+        <div className={loaderDotClasses} />
+        <div className={loaderDotClasses} />
 
         <div className={styles.loaderText}>{text}</div>
       </div>

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -80,6 +80,7 @@ class Stat extends PureComponent {
   static defaultProps = {
     alwaysShowSummary: false,
     alwaysShowTooltips: true,
+    animate: true,
     bgPrefs: {},
     categories: {},
     chartHeight: 0,
@@ -403,10 +404,10 @@ class Stat extends PureComponent {
   };
 
   getDefaultChartProps = props => {
-    const { chartHeight } = props;
+    const { chartHeight, animate } = props;
 
     return {
-      animate: { duration: 300, onLoad: { duration: 0 } },
+      animate: animate ? { duration: 300, onLoad: { duration: 0 } } : false,
       height: chartHeight,
       labels: d => formatPercentage(d.y),
       renderer: null,

--- a/test/components/common/stat/Stat.test.js
+++ b/test/components/common/stat/Stat.test.js
@@ -63,6 +63,7 @@ describe('Stat', () => {
     expect(Stat.defaultProps).to.eql({
       alwaysShowSummary: false,
       alwaysShowTooltips: true,
+      animate: true,
       bgPrefs: {},
       categories: {},
       chartHeight: 0,


### PR DESCRIPTION
https://trello.com/c/kiGrj7Oo

The main fix was to ensure that the CSS loading dot animations are only happening while visible.

The other fix is a workaround for the time being, allowing the the stat animations to be disabled via a `animateStats=false` query param.

Related PR: tidepool-org/blip#586