### PR TITLE
Tooltip hover fix [WEB-165]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.6.0-idle-cpu-usage.2",
+  "version": "1.7.0-tooltip-fix.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.7.0-tooltip-fix.1",
+  "version": "1.7.0-tooltip-fix.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -15,6 +15,8 @@
  * == BSD2 LICENSE ==
  */
 
+/* global requestAnimationFrame */
+
 import React, { PropTypes, PureComponent } from 'react';
 import _ from 'lodash';
 
@@ -28,12 +30,14 @@ class Tooltip extends PureComponent {
 
   componentDidMount() {
     this.calculateOffset(this.props);
-  }
 
-  componentDidUpdate() {
-    // In cases where the tooltip width is not statically set, we may need to re-caculate
-    // the offset after updates to get the proper positioning after browser reflow is complete.
-    this.calculateOffset(this.props);
+    // In cases where the tooltip CSS width is not statically set, we may need to re-caculate
+    // the offset after updates to get the proper positioning after browser reflow is complete,
+    // but before repaint happens. The second call within requestAnimationFrame ensures the tooltip
+    // is properly positioned on the first render.
+    requestAnimationFrame(() => {
+      this.calculateOffset(this.props);
+    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -82,11 +86,7 @@ class Tooltip extends PureComponent {
       offset.left = leftOffset + horizontalOffset;
     }
 
-    // We only update the offset state when a change is required.  Otherwise, we'd end up in an
-    // infinite render loop since this method is invoked from componentDidUpdate
-    if (!_.isEqual(offset, this.state.offset)) {
-      this.setState({ offset });
-    }
+    this.setState({ offset });
   }
 
   renderTail(backgroundColor = 'white') {

--- a/src/components/common/tooltips/Tooltip.js
+++ b/src/components/common/tooltips/Tooltip.js
@@ -26,6 +26,14 @@ class Tooltip extends PureComponent {
   constructor(props) {
     super(props);
     this.state = { offset: { top: 0, left: 0 } };
+
+    this.setElementRef = ref => {
+      this.element = ref;
+    };
+
+    this.setTailElemRef = ref => {
+      this.tailElem = ref;
+    };
   }
 
   componentDidMount() {
@@ -45,48 +53,54 @@ class Tooltip extends PureComponent {
   }
 
   calculateOffset(currentProps) {
-    const { offset: propOffset, side, tail } = currentProps;
-    const offset = {};
-    const tooltipRect = this.element.getBoundingClientRect();
-    let horizontalOffset = (propOffset.left != null) ?
-      propOffset.left : (propOffset.horizontal || 0);
-    if (side === 'left') {
-      horizontalOffset = -horizontalOffset;
-    }
-    if (tail) {
-      const tailRect = this.tailElem.getBoundingClientRect();
-      const tailCenter = {
-        top: tailRect.top + (tailRect.height / 2),
-        left: tailRect.left + (tailRect.width / 2),
-      };
-      offset.top = -tailCenter.top + tooltipRect.top + propOffset.top;
-      offset.left = -tailCenter.left + tooltipRect.left + horizontalOffset;
-    } else {
-      let leftOffset;
-      let topOffset;
-      switch (side) {
-        case 'top':
-          leftOffset = -tooltipRect.width / 2;
-          topOffset = -tooltipRect.height;
-          break;
-        case 'bottom':
-          leftOffset = -tooltipRect.width / 2;
-          topOffset = 0;
-          break;
-        case 'right':
-          leftOffset = 0;
-          topOffset = -tooltipRect.height / 2;
-          break;
-        case 'left':
-        default:
-          leftOffset = -tooltipRect.width;
-          topOffset = -tooltipRect.height / 2;
-      }
-      offset.top = topOffset + propOffset.top;
-      offset.left = leftOffset + horizontalOffset;
-    }
+    if (this.element) {
+      const { offset: propOffset, side, tail } = currentProps;
+      const offset = {};
+      const tooltipRect = this.element.getBoundingClientRect();
 
-    this.setState({ offset });
+      let horizontalOffset = (propOffset.left != null)
+        ? propOffset.left
+        : (propOffset.horizontal || 0);
+
+      if (side === 'left') {
+        horizontalOffset = -horizontalOffset;
+      }
+
+      if (tail) {
+        const tailRect = this.tailElem.getBoundingClientRect();
+        const tailCenter = {
+          top: tailRect.top + (tailRect.height / 2),
+          left: tailRect.left + (tailRect.width / 2),
+        };
+        offset.top = -tailCenter.top + tooltipRect.top + propOffset.top;
+        offset.left = -tailCenter.left + tooltipRect.left + horizontalOffset;
+      } else {
+        let leftOffset;
+        let topOffset;
+        switch (side) {
+          case 'top':
+            leftOffset = -tooltipRect.width / 2;
+            topOffset = -tooltipRect.height;
+            break;
+          case 'bottom':
+            leftOffset = -tooltipRect.width / 2;
+            topOffset = 0;
+            break;
+          case 'right':
+            leftOffset = 0;
+            topOffset = -tooltipRect.height / 2;
+            break;
+          case 'left':
+          default:
+            leftOffset = -tooltipRect.width;
+            topOffset = -tooltipRect.height / 2;
+        }
+        offset.top = topOffset + propOffset.top;
+        offset.left = leftOffset + horizontalOffset;
+      }
+
+      this.setState({ offset });
+    }
   }
 
   renderTail(backgroundColor = 'white') {
@@ -109,7 +123,7 @@ class Tooltip extends PureComponent {
     return (
       <div>
         <div
-          ref={(ref) => { this.tailElem = ref; }}
+          ref={this.setTailElemRef}
           className={styles.tail}
           style={{
             marginTop: `-${tailHeight}px`,
@@ -172,7 +186,7 @@ class Tooltip extends PureComponent {
       <div
         className={styles.tooltip}
         style={{ top, left, backgroundColor, borderColor, borderWidth: `${borderWidth}px` }}
-        ref={(ref) => { this.element = ref; }}
+        ref={this.setElementRef}
       >
         {title && this.renderTitle(title)}
         {content && this.renderContent(content)}

--- a/test/components/common/tooltip/Tooltip.test.js
+++ b/test/components/common/tooltip/Tooltip.test.js
@@ -262,8 +262,6 @@ describe('Tooltip', () => {
         />
       );
       const instance = wrapper.instance();
-      // We want to stub componentDidUpdate, as it also calls calculateOffset
-      instance.componentDidUpdate = sinon.stub();
 
       const calcSpy = sinon.spy(instance, 'calculateOffset');
       expect(Tooltip.prototype.componentWillReceiveProps.callCount).to.equal(0);
@@ -273,30 +271,6 @@ describe('Tooltip', () => {
       expect(calcSpy.calledOnce).to.be.true;
       expect(calcSpy.args[0][0]).to.deep.equal(wrapper.props());
       Tooltip.prototype.componentWillReceiveProps.restore();
-      instance.calculateOffset.restore();
-    });
-
-    it('calls componentDidUpdate (which calls calculateOffset) on props update', () => {
-      sinon.spy(Tooltip.prototype, 'componentDidUpdate');
-      const wrapper = mount(
-        <Tooltip
-          position={position}
-          title={title}
-          content={content}
-        />
-      );
-      const instance = wrapper.instance();
-      // We want to stub componentWillReceiveProps, as it also calls calculateOffset
-      instance.componentWillReceiveProps = sinon.stub();
-
-      const calcSpy = sinon.spy(instance, 'calculateOffset');
-      expect(Tooltip.prototype.componentDidUpdate.callCount).to.equal(0);
-      expect(calcSpy.callCount).to.equal(0);
-      wrapper.setProps({ title: 'New title!' });
-      expect(Tooltip.prototype.componentDidUpdate.calledOnce).to.be.true;
-      expect(calcSpy.calledOnce).to.be.true;
-      expect(calcSpy.args[0][0]).to.deep.equal(wrapper.props());
-      Tooltip.prototype.componentDidUpdate.restore();
       instance.calculateOffset.restore();
     });
   });


### PR DESCRIPTION
Having the tooltips update the offset state in `componentDidUpdate`, while done in a way that should have prevented infinite render loops (was only called within a conditional as noted at https://reactjs.org/docs/react-component.html#componentdidupdate), it seems that in some difficult-to-reproduce circumstances, this was in fact occurring for 2 of our team members.

This fix removes the state update within `componentDidUpdate` and instead calls the `calculateOffset` method a second time in `componentDidMount` within a `requestAnimationFrame` block.  This still allows the correct positioning to be applied after browser reflow and before browser repaint, which ensures that the initial rendering is in the correct positioning, which was the original reason for the state update in `componentDidUpdate`

See [WEB-165] for details

Related PRs
---
tidepool-org/blip#596


[WEB-165]: https://tidepool.atlassian.net/browse/WEB-165