### PR TITLE
Allow updating devtool source map mode with environment variable [WEB-210] 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,9 +125,12 @@ const resolve = {
   ],
 };
 
+let devtool = process.env.WEBPACK_DEVTOOL_VIZ || 'source-map';
+if (process.env.WEBPACK_DEVTOOL_VIZ === false) devtool = undefined;
+
 module.exports = {
   cache: isDev,
-  devtool: isDev ? 'cheap-source-map' : undefined,
+  devtool: isDev ? devtool : undefined,
   entry,
   mode: isDev ? 'development' : 'production',
   module: {


### PR DESCRIPTION
It's at times important to have `viz` compile with a more detailed source map for debugging (at the expense of slower compile times), which this PR enables via an environment variable

Part of [WEB-210] 

[WEB-210]: https://tidepool.atlassian.net/browse/WEB-210