### PR TITLE
[WEB-732] Allow returning raw data for debugging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.11.0-rc.5",
+  "version": "1.11.0-rc.6",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.11.0-rc.4",
+  "version": "1.11.0-rc.5",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -257,10 +257,16 @@ export class DataUtil {
   normalizeDatumOut = (d, fields = []) => {
     if (this.returnRawData) {
       /* eslint-disable no-underscore-dangle */
-      d.time = d._time;
-      d.deviceTime = d._deviceTime;
-      delete d._time;
-      delete d._deviceTime;
+      if (d._time) {
+        d.time = d._time;
+        delete d._time;
+      }
+
+      if (d._deviceTime) {
+        d.deviceTime = d._deviceTime;
+        delete d._deviceTime;
+      }
+
       delete d.tags;
 
       if (_.includes(['bolus', 'wizard'], d.type)) {
@@ -898,6 +904,10 @@ export class DataUtil {
     this.endTimer('setBgPrefs');
   };
 
+  setReturnRawData = (returnRaw = false) => {
+    this.returnRawData = returnRaw;
+  };
+
   query = (query = {}) => {
     this.log('Query', query);
 
@@ -915,7 +925,7 @@ export class DataUtil {
       stats,
       timePrefs,
       types,
-      raw = false,
+      raw,
     } = query;
 
     // N.B. Must ensure that we get the desired endpoints in UTC time so that when we display in
@@ -924,8 +934,7 @@ export class DataUtil {
     // Clear all previous filters
     this.clearFilters();
 
-    this.returnRawData = raw;
-
+    this.setReturnRawData(raw);
     this.setBgSources(bgSource);
     this.setTypes(types);
     this.setStats(stats);
@@ -981,8 +990,8 @@ export class DataUtil {
 
     if (metaData) result.metaData = this.getMetaData(metaData);
 
-    // Always reset `returnRawData` to false after each query
-    this.returnRawData = false;
+    // Always reset `returnRawData` to `false` after each query
+    this.setReturnRawData(false);
 
     this.log('Result', result);
 

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -255,7 +255,30 @@ export class DataUtil {
   };
 
   normalizeDatumOut = (d, fields = []) => {
-    if (this.returnRawData) return;
+    if (this.returnRawData) {
+      /* eslint-disable no-underscore-dangle */
+      d.time = d._time;
+      d.deviceTime = d._deviceTime;
+      delete d._time;
+      delete d._deviceTime;
+      delete d.tags;
+
+      if (_.includes(['bolus', 'wizard'], d.type)) {
+        const isWizard = d.type === 'wizard';
+        const fieldToRestore = isWizard ? 'bolus' : 'wizard';
+        if (_.get(d, [fieldToRestore, 'id'])) d[fieldToRestore] = d[fieldToRestore].id;
+      }
+
+      if (d.type === 'message') {
+        delete d.type;
+        delete d.messageText;
+        delete d.parentMessage;
+        delete d.time;
+      }
+
+      return;
+      /* eslint-enable no-underscore-dangle */
+    }
 
     const { timezoneName } = this.timePrefs || {};
     const normalizeAllFields = fields[0] === '*';

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -3246,6 +3246,8 @@ describe('DataUtil', () => {
   describe('addBasalOverlappingStart', () => {
     /* eslint-disable no-param-reassign */
     const normalizeExpectedDatum = d => {
+      d._time = d.time;
+      d._deviceTime = d.deviceTime;
       d.time = Date.parse(d.time);
       d.deviceTime = Date.parse(d.deviceTime);
       d.normalTime = d.deviceTime;


### PR DESCRIPTION
Also stores a copy of the `time` and `deviceTime` fields in their original ISO date string format for easier date inference (vs. deciphering a unix timestamp)

See [WEB-732] for details.

Goes with tidepool-org/blip#649

[WEB-732]: https://tidepool.atlassian.net/browse/WEB-732