### PR TITLE
[WEB-805] Fix BG Log crashes for patients viewing data in time zones with irregular offsets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.11.4",
+  "version": "1.11.5-web-805-bg-log-crash.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -1,7 +1,6 @@
 import bows from 'bows';
 import crossfilter from 'crossfilter'; // eslint-disable-line import/no-unresolved
 import moment from 'moment-timezone';
-import { utcHour } from 'd3-time';
 import _ from 'lodash';
 
 import {
@@ -363,15 +362,6 @@ export class DataUtil {
     if (d.type === 'fill') {
       const localTime = d.normalTime + d.displayOffset * MS_IN_MIN;
       const normalTimeISO = moment.utc(d.normalTime).toISOString();
-
-      // Fill times need to be shifted to account for time zones offsets that do not fall exactly on
-      // the hour. This is because the times for the fills are generated with d3-time's
-      // utcHour.range, which won't work as-is for timezones with offsets that fall between hours,
-      // such as 'Asia/Kolkata' with an offset of UTC +5:30 or Canada/Newfoundland at UTC -2:30
-      // Most timezones do fall on the hour, and will not actually end up being shifted, since the
-      // modulus in those cases will be 0
-      const timezoneModulusShift = (d.displayOffset % 60) * MS_IN_MIN;
-      d.normalTime = d.normalTime - timezoneModulusShift;
 
       d.normalEnd = d.normalTime + d.duration;
       d.msPer24 = getMsPer24(d.normalTime, timezoneName);
@@ -1063,18 +1053,17 @@ export class DataUtil {
   getFillData = (endpoints, opts = {}) => {
     this.startTimer('generate fillData');
     const timezone = _.get(this, 'timePrefs.timezoneName', 'UTC');
+    const days = this.activeEndpoints.days;
     const fillHours = 3;
+    const fillBinCount = (24 / fillHours) * days;
     const duration = fillHours * MS_IN_HOUR;
 
     const start = moment.utc(endpoints[0]).tz(timezone).startOf('day').valueOf();
 
-    const end = moment.utc(start).tz(timezone)
-      .add(this.activeEndpoints.days, 'days')
-      .subtract(1, 'ms')
-      .endOf('day')
-      .valueOf();
-
-    const hourlyStarts = utcHour.range(start, end);
+    const hourlyStarts = [start];
+    for (let index = 1; index < 24 * days; index++) {
+      hourlyStarts.push(hourlyStarts[index - 1] + MS_IN_HOUR);
+    }
 
     const fillData = [];
     let prevFill = null;
@@ -1082,7 +1071,7 @@ export class DataUtil {
     _.each(hourlyStarts, startTime => {
       const fill = {
         duration,
-        time: startTime.valueOf(),
+        time: startTime,
         type: 'fill',
       };
       this.normalizeDatumOut(fill);
@@ -1102,7 +1091,7 @@ export class DataUtil {
           }
         }
 
-        fillData.push(fill);
+        if (fillData.length < fillBinCount) fillData.push(fill);
         prevFill = fill;
       }
     });

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -364,6 +364,15 @@ export class DataUtil {
       const localTime = d.normalTime + d.displayOffset * MS_IN_MIN;
       const normalTimeISO = moment.utc(d.normalTime).toISOString();
 
+      // Fill times need to be shifted to account for time zones offsets that do not fall exactly on
+      // the hour. This is because the times for the fills are generated with d3-time's
+      // utcHour.range, which won't work as-is for timezones with offsets that fall between hours,
+      // such as 'Asia/Kolkata' with an offset of UTC +5:30 or Canada/Newfoundland at UTC -2:30
+      // Most timezones do fall on the hour, and will not actually end up being shifted, since the
+      // modulus in those cases will be 0
+      const timezoneModulusShift = (d.displayOffset % 60) * MS_IN_MIN;
+      d.normalTime = d.normalTime - timezoneModulusShift;
+
       d.normalEnd = d.normalTime + d.duration;
       d.msPer24 = getMsPer24(d.normalTime, timezoneName);
       d.hourOfDay = d.msPer24 / MS_IN_HOUR;

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -2977,6 +2977,20 @@ describe('DataUtil', () => {
 
       expect(result[0].normalTime).to.equal(moment.utc(endpoints[0]).subtract(19, 'hours').valueOf()); // Start of previous day for US/Eastern, plus 5 hrs
       expect(result[0].normalEnd).to.equal(moment.utc(endpoints[0]).subtract(16, 'hours').valueOf()); // Start of previous day for US/Eastern, plus 8 hrs
+
+      dataUtil.timePrefs = { timezoneName: 'Canada/Newfoundland' };
+      result = dataUtil.getFillData(endpoints);
+      expect(result).to.be.an('array').and.have.lengthOf(8);
+
+      expect(result[0].normalTime).to.equal(moment.utc(endpoints[0]).subtract(20.5, 'hours').valueOf()); // Start of previous day for Canada/Newfoundland, plus 3.5 hrs
+      expect(result[0].normalEnd).to.equal(moment.utc(endpoints[0]).subtract(17.5, 'hours').valueOf()); // Start of previous day for Canada/Newfoundland, plus 6.5 hrs
+
+      dataUtil.timePrefs = { timezoneName: 'Asia/Kolkata' };
+      result = dataUtil.getFillData(endpoints);
+      expect(result).to.be.an('array').and.have.lengthOf(8);
+
+      expect(result[0].normalTime).to.equal(moment.utc(endpoints[0]).subtract(5.5, 'hours').valueOf()); // Start of current day for Asia/Kolkata, plus 5 hrs 30 mins
+      expect(result[0].normalEnd).to.equal(moment.utc(endpoints[0]).subtract(2.5, 'hours').valueOf()); // Start of current day for Asia/Kolkata, plus 8 hrs 30 mins
     });
 
     it('should optionally adjust for spring DST changes', () => {


### PR DESCRIPTION
See [WEB-805] for details.

The issue was that the fill data wasn’t being generated for users viewing data from a time zone that had GMT offsets that didn’t fall squarely on the hour, such as Asia/Kolkata in this case, with an offset of GMT + 5h30m, or Canada/Newfoundland, which is GMT - 3h30m.  This missing fill data was causing a JS error in the BG Log view.

The reason it wasn't was that we were using D3's `utcHour.range` method to generate the fill intervals, which messed up the `hourOfDay` calculations for these time zones.

Related PR: tidepool-org/blip#729

[WEB-805]: https://tidepool.atlassian.net/browse/WEB-805