### PR TITLE
[WEB-981] Customizable print date ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.14.0",
+  "version": "1.15.0-web-981-customizable-print-dates.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.15.0-web-981-customizable-print-dates.1",
+  "version": "1.15.0-web-981-customizable-print-dates.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -459,13 +459,16 @@ class BasicsPrintView extends PrintView {
 
     const columnWidth = this.getActiveColumnWidth();
 
-    this.renderSectionHeading(title, {
+    let headingMoveDown = 0.25;
+
+    const renderSectionHeading = (moveDown = 0) => this.renderSectionHeading(title, {
       width: columnWidth,
       fontSize: this.largeFontSize,
-      moveDown: 0.25,
+      moveDown,
     });
 
     if (disabled) {
+      renderSectionHeading(headingMoveDown);
       this.renderEmptyText(emptyText);
     } else {
       const isSiteChange = type === 'siteChange';
@@ -516,18 +519,60 @@ class BasicsPrintView extends PrintView {
         return values;
       });
 
+      this.doc.fontSize(this.largeFontSize);
+      const headingHeight = this.doc.heightOfString(' ');
+      let headingYPos = this.doc.y;
+
       this.doc.fontSize(this.smallFontSize);
+      const headerHeight = this.doc.heightOfString(' ');
 
-      const currentYPos = this.doc.y;
-      const headerHeight = this.doc.currentLineHeight();
+      this.doc.moveDown(headingMoveDown);
+      const currentYPos = headingHeight + this.doc.y;
 
-      this.doc.y = currentYPos + (headerHeight - 9.25);
+      this.doc.y = currentYPos + headerHeight;
 
       this.calendar.pos[type] = {
-        y: currentYPos + headerHeight + 4,
+        y: currentYPos + headerHeight + 4.25,
         pageIndex: this.currentPageIndex,
       };
 
+      if (!this.calendar.rowHeight) {
+        // Calculate row height by rendering a single row with invisible fill and stroke
+        this.doc.fillOpacity(0);
+        this.doc.strokeOpacity(0);
+        this.lockFillandStroke();
+
+        this.renderTable(this.calendar.columns, [rows[0]], {
+          bottomMargin: 0,
+        });
+
+        this.calendar.rowHeight = this.doc.y - this.calendar.pos[type].y;
+
+        // Reset fill and stroke opacities
+        this.unlockFillandStroke();
+        this.doc.fillOpacity(1);
+        this.doc.strokeOpacity(1);
+      } else {
+        // Check to see if there's room on the current page, and if not, render on a new page
+        const calendarHeight = this.calendar.pos[type].y + (this.calendar.rowHeight * rows.length);
+
+        if (calendarHeight + bottomMargin > this.chartArea.bottomEdge) {
+          this.doc.addPage();
+          this.doc.moveDown(headingMoveDown);
+          headingMoveDown = 0;
+          headingYPos = this.chartArea.topEdge;
+
+          this.calendar.pos[type] = {
+            y: headingYPos + headingHeight + headerHeight + 4.25,
+            pageIndex: this.currentPageIndex,
+          };
+        }
+      }
+
+      this.doc.y = headingYPos;
+      renderSectionHeading(headingMoveDown);
+
+      this.doc.fontSize(this.smallFontSize);
       this.renderTable(this.calendar.columns, rows, {
         bottomMargin,
       });

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -483,12 +483,12 @@ class BasicsPrintView extends PrintView {
         let dayType = day.type;
 
         if (isSiteChange) {
-          if (dayType !== 'future') {
+          if (dayType === 'inRange') {
             dayType = data[day.date] ? SITE_CHANGE : NO_SITE_CHANGE;
           }
 
           if (dayType === NO_SITE_CHANGE && priorToFirstSiteChange) {
-            dayType = 'past';
+            dayType = 'outOfRange';
           }
 
           if (dayType === SITE_CHANGE && priorToFirstSiteChange) {
@@ -547,7 +547,7 @@ class BasicsPrintView extends PrintView {
       const xPos = pos.x + padding.left;
       const yPos = pos.y + padding.top;
 
-      this.setFill(type === 'future' ? this.colors.lightGrey : 'black', 1);
+      this.setFill(type === 'outOfRange' ? this.colors.lightGrey : 'black', 1);
 
       this.doc
         .fontSize(this.extraSmallFontSize)

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -555,8 +555,7 @@ class BasicsPrintView extends PrintView {
       } else {
         // Check to see if there's room on the current page, and if not, render on a new page
         const calendarHeight = this.calendar.pos[type].y + (this.calendar.rowHeight * rows.length);
-
-        if (calendarHeight + bottomMargin > this.chartArea.bottomEdge) {
+        if (calendarHeight > this.chartArea.bottomEdge) {
           this.doc.addPage();
           this.doc.moveDown(headingMoveDown);
           headingMoveDown = 0;

--- a/src/modules/print/BgLogPrintView.js
+++ b/src/modules/print/BgLogPrintView.js
@@ -41,8 +41,7 @@ class BgLogPrintView extends PrintView {
     this.doc.addPage();
 
     const dates = _.keys(this.aggregationsByDate.dataByDate).sort();
-    const numDays = _.min([this.numDays, dates.length]);
-    this.chartDates = _.slice(dates, -Math.abs(numDays)).reverse();
+    this.chartDates = dates.reverse();
 
     // Auto-bind callback methods
     this.getBGLabelYOffset = this.getBGLabelYOffset.bind(this);

--- a/src/modules/print/BgLogPrintView.js
+++ b/src/modules/print/BgLogPrintView.js
@@ -190,6 +190,10 @@ class BgLogPrintView extends PrintView {
 
     this.summaryTable = {};
 
+    if (this.chartArea.bottomEdge - this.doc.y < 45) {
+      this.doc.addPage();
+    }
+
     this.doc.x = this.leftEdge + this.bgChart.columnWidth;
 
     this.summaryTable.columnWidth = (this.chartArea.width - this.bgChart.columnWidth) / 4;
@@ -223,7 +227,7 @@ class BgLogPrintView extends PrintView {
     ];
 
     this.renderTable(this.summaryTable.columns, this.summaryTable.rows, {
-      bottomMargin: 20,
+      bottomMargin: 0,
       columnDefaults: {
         align: 'center',
         headerAlign: 'center',

--- a/src/modules/print/DailyPrintView.js
+++ b/src/modules/print/DailyPrintView.js
@@ -206,9 +206,10 @@ class DailyPrintView extends PrintView {
   }
 
   calculateChartMinimums(chartArea) {
+    const legendHeight = this.doc.fontSize(9).currentLineHeight() * 5;
     this.doc.fontSize(this.defaultFontSize);
     const { topEdge, bottomEdge } = chartArea;
-    const totalHeight = bottomEdge - topEdge;
+    const totalHeight = bottomEdge - legendHeight - topEdge;
     const perChart = totalHeight / 3.25;
     this.chartMinimums = {
       notesEtc: perChart * (3 / 20),

--- a/src/modules/print/PrintView.js
+++ b/src/modules/print/PrintView.js
@@ -332,13 +332,25 @@ class PrintView {
     });
   }
 
+  lockFillandStroke() {
+    this.fillLocked = true;
+    this.strokeLocked = true;
+  }
+
+  unlockFillandStroke() {
+    this.fillLocked = false;
+    this.strokeLocked = false;
+  }
+
   setFill(color = 'black', opacity = 1) {
+    if (this.fillLocked) return;
     this.doc
       .fillColor(color)
       .fillOpacity(opacity);
   }
 
   setStroke(color = 'black', opacity = 1) {
+    if (this.strokeLocked) return;
     this.doc
       .strokeColor(color)
       .strokeOpacity(opacity);

--- a/src/modules/print/PrintView.js
+++ b/src/modules/print/PrintView.js
@@ -938,7 +938,7 @@ class PrintView {
   setFooterSize() {
     this.doc.fontSize(this.footerFontSize);
     const lineHeight = this.doc.currentLineHeight();
-    this.chartArea.bottomEdge = this.chartArea.bottomEdge - lineHeight * 9;
+    this.chartArea.bottomEdge = this.chartArea.bottomEdge - lineHeight * 3;
 
     return this;
   }

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -295,17 +295,16 @@ export function processBasicsAggregations(aggregations, data, patient, manufactu
  */
 export function findBasicsDays(range, timezone = 'UTC') {
   const days = [];
-  let currentDate = moment.utc(range[0]).tz(timezone).toDate();
-  const dateOfUpload = moment.utc(range[1]).subtract(1, 'ms').tz(timezone).format('YYYY-MM-DD');
-  while (currentDate < moment.utc(range[1]).subtract(1, 'ms').tz(timezone).endOf('isoWeek')) {
+  const rangeStartDate = moment.utc(range[0]).tz(timezone).format('YYYY-MM-DD');
+  const rangeEndDate = moment.utc(range[1]).tz(timezone).format('YYYY-MM-DD');
+  let currentDate = moment.utc(range[0]).tz(timezone).startOf('isoWeek').toDate();
+  while (currentDate < moment.utc(range[1]).tz(timezone).endOf('isoWeek')) {
     const date = moment.utc(currentDate).tz(timezone).format('YYYY-MM-DD');
     const dateObj = { date };
-    if (date < dateOfUpload) {
-      dateObj.type = 'past';
-    } else if (date === dateOfUpload) {
-      dateObj.type = 'mostRecent';
+    if (date < rangeStartDate || date > rangeEndDate) {
+      dateObj.type = 'outOfRange';
     } else {
-      dateObj.type = 'future';
+      dateObj.type = 'inRange';
     }
     days.push(dateObj);
     currentDate = moment.utc(currentDate).tz(timezone).add(1, 'days').toDate();
@@ -320,7 +319,7 @@ export function findBasicsDays(range, timezone = 'UTC') {
  * @returns {String} ISO date string relative to provided timezone
  */
 export function findBasicsStart(timestamp, timezone = 'UTC') {
-  return moment.utc(Date.parse(timestamp)).tz(timezone)
+  return moment.utc(_.isInteger(timestamp) ? timestamp : Date.parse(timestamp)).tz(timezone)
     .startOf('isoWeek')
     .subtract(14, 'days')
     .toDate();

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -296,7 +296,7 @@ export function processBasicsAggregations(aggregations, data, patient, manufactu
 export function findBasicsDays(range, timezone = 'UTC') {
   const days = [];
   const rangeStartDate = moment.utc(range[0]).tz(timezone).format('YYYY-MM-DD');
-  const rangeEndDate = moment.utc(range[1]).tz(timezone).format('YYYY-MM-DD');
+  const rangeEndDate = moment.utc(range[1]).tz(timezone).subtract(1, 'ms').format('YYYY-MM-DD');
   let currentDate = moment.utc(range[0]).tz(timezone).startOf('isoWeek').toDate();
   while (currentDate < moment.utc(range[1]).tz(timezone).endOf('isoWeek')) {
     const date = moment.utc(currentDate).tz(timezone).format('YYYY-MM-DD');

--- a/stories/print/BasicsViewPrintPDF.js
+++ b/stories/print/BasicsViewPrintPDF.js
@@ -26,8 +26,6 @@ import PrintView from '../../src/modules/print/PrintView';
 import * as profiles from '../../data/patient/profiles';
 import * as settings from '../../data/patient/settings';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
-
 /* global PDFDocument, blobStream, window */
 
 const stories = storiesOf('Basics View PDF', module);
@@ -40,37 +38,16 @@ try {
   queries = {};
 }
 
-const bgBounds = {
-  [MGDL_UNITS]: {
-    veryHighThreshold: 250,
-    targetUpperBound: 180,
-    targetLowerBound: 70,
-    veryLowThreshold: 54,
-  },
-  [MMOLL_UNITS]: {
-    veryHighThreshold: 13.9,
-    targetUpperBound: 10,
-    targetLowerBound: 3.9,
-    veryLowThreshold: 3.0,
-  },
-};
-
-function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
+function openPDF(dataUtil, { patient }) {
   const doc = new PDFDocument({ autoFirstPage: false, bufferPages: true, margin: MARGIN });
   const stream = doc.pipe(blobStream());
   const opts = {
-    bgPrefs: {
-      bgBounds: bgBounds[bgUnits],
-      bgUnits,
-    },
-    timePrefs: {
-      timezoneAware: true,
-      timezoneName: 'US/Eastern',
-    },
+    bgPrefs: queries.basics.bgPrefs,
+    timePrefs: queries.basics.timePrefs,
     patient,
   };
 
-  const data = queries ? dataUtil.query(queries.basics) : {};
+  const data = queries.basics ? dataUtil.query(queries.basics) : {};
 
   createPrintView('basics', data, opts, doc).render();
   PrintView.renderPageNumbers(doc);
@@ -82,60 +59,63 @@ function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
   });
 }
 
-const notes = `Run \`window.downloadPrintViewData()\` from the console on a Tidepool Web data view.
-Save the resulting file to the \`local/\` directory of viz as \`print-view.json\`,
+const notes = `Run the \`accountTool.py export\` from the \`tidepool-org/tools-private\` repo.
+Save the resulting file to the \`local/\` directory of viz as \`rawData.json\`.
+
+After generating a PDF in Tidepool web using the same account you just exported data from,
+run \`window.downloadPDFDataQueries()\` from the console on a Tidepool Web data view.
+Save the resulting file to the \`local/\` directory of viz as \`PDFDataQueries.json\`,
 and then use this story to iterate on the Basics Print PDF outside of Tidepool Web!`;
 
 profiles.longName = _.cloneDeep(profiles.standard);
 profiles.longName.profile.fullName = 'Super Duper Long Patient Name';
 
-stories.add(`cannula prime (${MGDL_UNITS})`, ({ dataUtil }) => (
+stories.add('cannula prime', ({ dataUtil }) => (
   <button
-    onClick={() => openPDF(dataUtil, { patient: {
-      ...profiles.standard,
-      ...settings.cannulaPrimeSelected,
-    } })}
+    onClick={() => openPDF(dataUtil, {
+      patient: {
+        ...profiles.standard,
+        ...settings.cannulaPrimeSelected,
+      },
+    })}
   >
     Open PDF in new tab
   </button>
 ), { notes });
 
-stories.add(`tubing prime (${MMOLL_UNITS})`, ({ dataUtil }) => (
+stories.add('tubing prime', ({ dataUtil }) => (
   <button
     onClick={() => openPDF(dataUtil, {
       patient: {
         ...profiles.standard,
         ...settings.tubingPrimeSelected,
       },
-      bgUnits: MMOLL_UNITS,
     })}
   >
     Open PDF in new tab
   </button>
 ), { notes });
 
-stories.add(`reservoir change (${MGDL_UNITS})`, ({ dataUtil }) => (
+stories.add('reservoir change', ({ dataUtil }) => (
   <button
     onClick={() => openPDF(dataUtil, {
       patient: {
         ...profiles.standard,
         ...settings.reservoirChangeSelected,
       },
-      bgUnits: MGDL_UNITS,
     })}
   >
     Open PDF in new tab
   </button>
 ), { notes });
 
-stories.add(`site change source undefined (${MMOLL_UNITS})`, ({ dataUtil }) => (
+stories.add('site change source undefined', ({ dataUtil }) => (
   <button
     onClick={() => openPDF(dataUtil, {
       patient: {
         ...profiles.standard,
         ...settings.siteChangeSourceUndefined,
       },
-      bgUnits: MMOLL_UNITS,
     })}
   >
     Open PDF in new tab

--- a/stories/print/BgLogViewPrintPDF.js
+++ b/stories/print/BgLogViewPrintPDF.js
@@ -25,8 +25,6 @@ import PrintView from '../../src/modules/print/PrintView';
 
 import * as profiles from '../../data/patient/profiles';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
-
 /* global PDFDocument, blobStream, window */
 
 const stories = storiesOf('BG Log View PDF', module);
@@ -39,40 +37,16 @@ try {
   queries = {};
 }
 
-const bgBounds = {
-  [MGDL_UNITS]: {
-    veryHighThreshold: 250,
-    targetUpperBound: 180,
-    targetLowerBound: 70,
-    veryLowThreshold: 54,
-  },
-  [MMOLL_UNITS]: {
-    veryHighThreshold: 13.9,
-    targetUpperBound: 10,
-    targetLowerBound: 3.9,
-    veryLowThreshold: 3.0,
-  },
-};
-
-function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
+function openPDF(dataUtil, { patient }) {
   const doc = new PDFDocument({ autoFirstPage: false, bufferPages: true, margin: MARGIN });
   const stream = doc.pipe(blobStream());
   const opts = {
-    bgPrefs: {
-      bgBounds: bgBounds[bgUnits],
-      bgUnits,
-    },
-    timePrefs: {
-      timezoneAware: true,
-      timezoneName: 'US/Eastern',
-    },
-    numDays: {
-      bgLog: 30,
-    },
+    bgPrefs: queries.bgLog.bgPrefs,
+    timePrefs: queries.bgLog.timePrefs,
     patient,
   };
 
-  const data = queries ? dataUtil.query(queries.bgLog) : {};
+  const data = queries.bgLog ? dataUtil.query(queries.bgLog) : {};
 
   createPrintView('bgLog', data, opts, doc).render();
   PrintView.renderPageNumbers(doc);
@@ -84,18 +58,16 @@ function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
   });
 }
 
-const notes = `Run \`window.downloadPrintViewData()\` from the console on a Tidepool Web data view.
-Save the resulting file to the \`local/\` directory of viz as \`print-view.json\`,
+const notes = `Run the \`accountTool.py export\` from the \`tidepool-org/tools-private\` repo.
+Save the resulting file to the \`local/\` directory of viz as \`rawData.json\`.
+
+After generating a PDF in Tidepool web using the same account you just exported data from,
+run \`window.downloadPDFDataQueries()\` from the console on a Tidepool Web data view.
+Save the resulting file to the \`local/\` directory of viz as \`PDFDataQueries.json\`,
 and then use this story to iterate on the BG Log Print PDF outside of Tidepool Web!`;
 
-stories.add(`standard account (${MGDL_UNITS})`, ({ dataUtil }) => (
+stories.add('standard account', ({ dataUtil }) => (
   <button onClick={() => openPDF(dataUtil, { patient: profiles.standard })}>
-    Open PDF in new tab
-  </button>
-), { notes });
-
-stories.add(`standard account (${MMOLL_UNITS})`, ({ dataUtil }) => (
-  <button onClick={() => openPDF(dataUtil, { patient: profiles.standard, bgUnits: MMOLL_UNITS })}>
     Open PDF in new tab
   </button>
 ), { notes });

--- a/stories/print/CombinedViewPrintPDF.js
+++ b/stories/print/CombinedViewPrintPDF.js
@@ -96,8 +96,12 @@ function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
   });
 }
 
-const notes = `Run \`window.downloadPrintViewData()\` from the console on a Tidepool Web data view.
-Save the resulting file to the \`local/\` directory of viz as \`print-view.json\`,
+const notes = `Run the \`accountTool.py export\` from the \`tidepool-org/tools-private\` repo.
+Save the resulting file to the \`local/\` directory of viz as \`rawData.json\`.
+
+After generating a PDF in Tidepool web using the same account you just exported data from,
+run \`window.downloadPDFDataQueries()\` from the console on a Tidepool Web data view.
+Save the resulting file to the \`local/\` directory of viz as \`PDFDataQueries.json\`,
 and then use this story to iterate on the Combined Print PDF outside of Tidepool Web!`;
 
 profiles.longName = _.cloneDeep(profiles.standard);

--- a/stories/print/DailyViewPrintPDF.js
+++ b/stories/print/DailyViewPrintPDF.js
@@ -25,8 +25,6 @@ import PrintView from '../../src/modules/print/PrintView';
 
 import * as profiles from '../../data/patient/profiles';
 
-import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
-
 /* global PDFDocument, blobStream, window */
 
 const stories = storiesOf('Daily View PDF', module);
@@ -39,40 +37,16 @@ try {
   queries = {};
 }
 
-const bgBounds = {
-  [MGDL_UNITS]: {
-    veryHighThreshold: 250,
-    targetUpperBound: 180,
-    targetLowerBound: 70,
-    veryLowThreshold: 54,
-  },
-  [MMOLL_UNITS]: {
-    veryHighThreshold: 13.9,
-    targetUpperBound: 10,
-    targetLowerBound: 3.9,
-    veryLowThreshold: 3.0,
-  },
-};
-
-function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
+function openPDF(dataUtil, { patient }) {
   const doc = new PDFDocument({ autoFirstPage: false, bufferPages: true, margin: MARGIN });
   const stream = doc.pipe(blobStream());
   const opts = {
-    bgPrefs: {
-      bgBounds: bgBounds[bgUnits],
-      bgUnits,
-    },
-    timePrefs: {
-      timezoneAware: true,
-      timezoneName: 'US/Eastern',
-    },
-    numDays: {
-      daily: 15,
-    },
+    bgPrefs: queries.daily.bgPrefs,
+    timePrefs: queries.daily.timePrefs,
     patient,
   };
 
-  const data = queries ? dataUtil.query(queries.daily) : {};
+  const data = queries.daily ? dataUtil.query(queries.daily) : {};
 
   createPrintView('daily', data, opts, doc).render();
   PrintView.renderPageNumbers(doc);
@@ -84,21 +58,19 @@ function openPDF(dataUtil, { patient, bgUnits = MGDL_UNITS }) {
   });
 }
 
-const notes = `Run \`window.downloadPrintViewData()\` from the console on a Tidepool Web data view.
-Save the resulting file to the \`local/\` directory of viz as \`print-view.json\`,
+const notes = `Run the \`accountTool.py export\` from the \`tidepool-org/tools-private\` repo.
+Save the resulting file to the \`local/\` directory of viz as \`rawData.json\`.
+
+After generating a PDF in Tidepool web using the same account you just exported data from,
+run \`window.downloadPDFDataQueries()\` from the console on a Tidepool Web data view.
+Save the resulting file to the \`local/\` directory of viz as \`PDFDataQueries.json\`,
 and then use this story to iterate on the Daily Print PDF outside of Tidepool Web!`;
 
 profiles.longName = _.cloneDeep(profiles.standard);
 profiles.longName.profile.fullName = 'Super Duper Long Patient Name';
 
-stories.add(`standard account (${MGDL_UNITS})`, ({ dataUtil }) => (
+stories.add('standard account', ({ dataUtil }) => (
   <button onClick={() => openPDF(dataUtil, { patient: profiles.standard })}>
-    Open PDF in new tab
-  </button>
-), { notes });
-
-stories.add(`standard account (${MMOLL_UNITS})`, ({ dataUtil }) => (
-  <button onClick={() => openPDF(dataUtil, { patient: profiles.standard, bgUnits: MMOLL_UNITS })}>
     Open PDF in new tab
   </button>
 ), { notes });

--- a/test/modules/print/BasicsPrintView.test.js
+++ b/test/modules/print/BasicsPrintView.test.js
@@ -633,7 +633,9 @@ describe('BasicsPrintView', () => {
       });
 
       sinon.assert.calledWith(Renderer.renderSectionHeading, 'My Active Section');
-      sinon.assert.calledOnce(Renderer.renderTable);
+
+      // Table rendered once with just one row, to calculate height, and then with all the rows
+      sinon.assert.calledTwice(Renderer.renderTable);
       sinon.assert.calledWith(Renderer.renderTable, [
         sinon.match({ header: 'Mon', renderer: Renderer.renderCalendarCell }),
         sinon.match({ header: 'Tue', renderer: Renderer.renderCalendarCell }),

--- a/test/modules/print/DailyPrintView.test.js
+++ b/test/modules/print/DailyPrintView.test.js
@@ -194,8 +194,9 @@ describe('DailyPrintView', () => {
   describe('calculateChartMinimums', () => {
     it('should calculate the minimum area available to the charts', () => {
       Renderer.calculateChartMinimums(Renderer.initialChartArea);
+      const legendHeight = Renderer.doc.fontSize(9).currentLineHeight() * 5;
       const { topEdge, bottomEdge } = Renderer.initialChartArea;
-      const totalHeight = bottomEdge - topEdge;
+      const totalHeight = bottomEdge - legendHeight - topEdge;
 
       expect(Renderer.chartMinimums.total).to.equal(totalHeight / 3.25);
     });

--- a/test/modules/print/PrintView.test.js
+++ b/test/modules/print/PrintView.test.js
@@ -1708,7 +1708,7 @@ describe('PrintView', () => {
     });
 
     it('should set the footer size', () => {
-      const bottomEdge = Renderer.chartArea.bottomEdge - Renderer.doc.currentLineHeight() * 9;
+      const bottomEdge = Renderer.chartArea.bottomEdge - Renderer.doc.currentLineHeight() * 3;
 
       Renderer.setFooterSize();
       expect(Renderer.chartArea.bottomEdge).to.equal(bottomEdge);

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -278,7 +278,7 @@ describe('basics data utils', () => {
     });
   });
 
-  describe('findBasicsDays', () => {
+  describe.only('findBasicsDays', () => {
     it('should always return at least 7 days, Monday thru Friday', () => {
       expect(_.map(dataUtils.findBasicsDays([
         '2015-09-07T07:00:00.000Z',
@@ -338,18 +338,18 @@ describe('basics data utils', () => {
       ]);
     });
 
-    it('should categorize each date as past, mostRecent or future', () => {
+    it('should categorize each date as `inRange` or `outOfRange`', () => {
       expect(dataUtils.findBasicsDays([
-        '2015-09-07T00:00:00.000Z',
+        '2015-09-09T00:00:00.000Z',
         '2015-09-10T12:00:00.000Z',
       ], 'Pacific/Auckland')).to.deep.equal([
-        { date: '2015-09-07', type: 'past' },
-        { date: '2015-09-08', type: 'past' },
-        { date: '2015-09-09', type: 'past' },
-        { date: '2015-09-10', type: 'mostRecent' },
-        { date: '2015-09-11', type: 'future' },
-        { date: '2015-09-12', type: 'future' },
-        { date: '2015-09-13', type: 'future' },
+        { date: '2015-09-07', type: 'outOfRange' },
+        { date: '2015-09-08', type: 'outOfRange' },
+        { date: '2015-09-09', type: 'inRange' },
+        { date: '2015-09-10', type: 'inRange' },
+        { date: '2015-09-11', type: 'outOfRange' },
+        { date: '2015-09-12', type: 'outOfRange' },
+        { date: '2015-09-13', type: 'outOfRange' },
       ]);
     });
   });

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -278,7 +278,7 @@ describe('basics data utils', () => {
     });
   });
 
-  describe.only('findBasicsDays', () => {
+  describe('findBasicsDays', () => {
     it('should always return at least 7 days, Monday thru Friday', () => {
       expect(_.map(dataUtils.findBasicsDays([
         '2015-09-07T07:00:00.000Z',


### PR DESCRIPTION
See [WEB-981] for details.

This involved updating the PDF logic to optimize chart placements in order to, for instance, prevent a basics calendar from rendering over page breaks.

Also, the storybooks are updated to leverage the PDF data queries from blip.

Related PR: tidepool-org/blip#829

[WEB-981]: https://tidepool.atlassian.net/browse/WEB-981