### PR TITLE
[WEB-993] Add option to exclude days with no boluses from basics calendar aggregations and stats

### DIFF
--- a/data/print/fixtures.js
+++ b/data/print/fixtures.js
@@ -49,6 +49,7 @@ export const basicsData = {
   timePrefs,
   bgPrefs,
   metaData,
+  query: { excludeDaysWithoutBolus: true },
   data: {
     current: {
       endpoints: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.15.0-web-981-customizable-print-dates.2",
+  "version": "1.16.0-web-993-disable-basic-dates.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/stat/Stat.css
+++ b/src/components/common/stat/Stat.css
@@ -39,10 +39,6 @@
   overflow: hidden;
 }
 
-.statChildren {
-  padding: 0 0.625em .375em;
-}
-
 .chartTitle {
   composes: largeSize from '../../../styles/typography.css';
   font-weight: 500;

--- a/src/components/common/stat/Stat.css
+++ b/src/components/common/stat/Stat.css
@@ -39,6 +39,10 @@
   overflow: hidden;
 }
 
+.statChildren {
+  padding: 0 0.625em .375em;
+}
+
 .chartTitle {
   composes: largeSize from '../../../styles/typography.css';
   font-weight: 500;

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -204,6 +204,12 @@ class Stat extends PureComponent {
     </div>
   );
 
+  renderChildren = () => (
+    <div className={styles.statChildren}>
+      {this.props.children}
+    </div>
+  );
+
   renderStatHeader = () => (
     <div className={styles.statHeader}>
       {this.renderChartTitle()}
@@ -346,6 +352,7 @@ class Stat extends PureComponent {
             </div>
           )}
           {this.props.type === statTypes.input && this.renderInput()}
+          {this.props.children && this.renderChildren()}
           {this.state.showFooter && this.renderStatFooter()}
         </div>
         {this.state.showMessages && this.renderTooltip()}

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -138,7 +138,10 @@ class BasicsPrintView extends PrintView {
     });
 
     this.renderCalendarSection({
-      title: this.sections.boluses.title,
+      title: {
+        text: this.sections.boluses.title,
+        subText: _.get(this.data, 'query.excludeDaysWithoutBolus') ? '(days with no boluses have been excluded)' : false,
+      },
       data: this.aggregationsByDate.boluses.byDate,
       type: 'bolus',
       disabled: this.sections.boluses.disabled,
@@ -150,7 +153,7 @@ class BasicsPrintView extends PrintView {
     this.renderCalendarSection({
       title: {
         text: this.sections.siteChanges.title,
-        subText: siteChangesSubTitle ? `from '${this.sections.siteChanges.subTitle}'` : false,
+        subText: siteChangesSubTitle ? `(from '${this.sections.siteChanges.subTitle}')` : false,
       },
       data: this.aggregationsByDate.siteChanges.byDate,
       type: 'siteChange',
@@ -591,7 +594,10 @@ class BasicsPrintView extends PrintView {
       const xPos = pos.x + padding.left;
       const yPos = pos.y + padding.top;
 
-      this.setFill(type === 'outOfRange' ? this.colors.lightGrey : 'black', 1);
+      const isEmptyBolusDay = color === this.colors.bolus && count === 0;
+      const isExcludedBolusDay = isEmptyBolusDay && _.get(this.data, 'query.excludeDaysWithoutBolus', false);
+
+      this.setFill((type === 'outOfRange' || isExcludedBolusDay) ? this.colors.lightGrey : 'black', 1);
 
       this.doc
         .fontSize(this.extraSmallFontSize)

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -237,7 +237,7 @@ class BasicsPrintView extends PrintView {
     this.renderHorizontalBarStat(
       totalInsulin,
       {
-        heading: 'Insulin Ratio',
+        heading: 'Avg. Daily Insulin Ratio',
         secondaryFormatKey: 'tooltip',
         fillOpacity: 0.5,
       }

--- a/src/utils/AggregationUtil.js
+++ b/src/utils/AggregationUtil.js
@@ -272,7 +272,11 @@ export class AggregationUtil {
       }
     });
 
-    return this.summarizeProcessedData(processedData);
+    const days = this.dataUtil.excludeDaysWithoutBolus
+      ? _.keys(processedData).length
+      : this.dataUtil.activeEndpoints.activeDays;
+
+    return this.summarizeProcessedData(processedData, days);
   };
 
   /**
@@ -557,9 +561,9 @@ export class AggregationUtil {
   };
   /* eslint-enable lodash/prefer-lodash-method */
 
-  summarizeProcessedData = (processedData) => {
+  summarizeProcessedData = (processedData, days = this.dataUtil.activeEndpoints.activeDays) => {
     const total = _.sumBy(_.values(processedData), dateData => dateData.total);
-    const avgPerDay = total / this.dataUtil.activeEndpoints.activeDays;
+    const avgPerDay = total / days;
     return {
       summary: {
         avgPerDay,

--- a/src/utils/StatUtil.js
+++ b/src/utils/StatUtil.js
@@ -23,6 +23,7 @@ export class StatUtil {
     this.bgUnits = _.get(dataUtil, 'bgPrefs.bgUnits');
     this.bgSource = _.get(dataUtil, 'bgSources.current', BGM_DATA_KEY);
     this.activeDays = dataUtil.activeEndpoints.activeDays;
+    this.bolusDays = dataUtil.activeEndpoints.bolusDays || this.activeDays;
     this.endpoints = dataUtil.activeEndpoints.range;
 
     this.log('activeDays', this.activeDays);
@@ -70,9 +71,9 @@ export class StatUtil {
       bolus: bolusData.length ? getTotalBolus(bolusData) : NaN,
     };
 
-    if (this.activeDays > 1) {
-      basalBolusData.basal = basalBolusData.basal / this.activeDays;
-      basalBolusData.bolus = basalBolusData.bolus / this.activeDays;
+    if (this.bolusDays > 1) {
+      basalBolusData.basal = basalBolusData.basal / this.bolusDays;
+      basalBolusData.bolus = basalBolusData.bolus / this.bolusDays;
     }
 
     return basalBolusData;

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -344,12 +344,18 @@ export function basicsText(patient, data, stats, aggregations) {
     },
     bgPrefs,
     timePrefs,
+    query,
   } = data;
 
   const textUtil = new utils.TextUtil(patient, endpoints.range, timePrefs);
 
   let basicsString = textUtil.buildDocumentHeader('Basics');
   basicsString += textUtil.buildDocumentDates();
+
+  if (_.get(query, 'excludeDaysWithoutBolus')) {
+    basicsString += textUtil.buildTextLine(t('Days with no boluses have been excluded from bolus calculations'));
+  }
+
   basicsString += utils.statsText(stats, textUtil, bgPrefs);
 
   const getSummaryTableData = (dimensions, statData, header) => {

--- a/stories/components/common/stats/Stat.js
+++ b/stories/components/common/stats/Stat.js
@@ -447,7 +447,14 @@ stories.add('Total Insulin', () => {
         muteOthersOnHover={muteOthersOnHover}
         title="Total Insulin"
         type={statTypes.barHorizontal}
-      />
+      >
+        <label htmlFor="no-bolus" style={{ 'font-size': '.8em' }}>
+          <input id="no-bolus" type="checkbox" style={{ margin: '0 .5em 0 0' }} />
+          <span style={{ position: 'relative', top: '-.1em' }}>
+            Exclude days with no boluses
+          </span>
+        </label>
+      </Stat>
     </Container>
   );
 });

--- a/test/components/common/stat/Stat.test.js
+++ b/test/components/common/stat/Stat.test.js
@@ -443,7 +443,7 @@ describe('Stat', () => {
         type: stat.statTypes.barHorizontal,
       }));
 
-      statLegend = () => wrapper.find(StatLegend).dive();
+      statLegend = () => wrapper.find(StatLegend).last().dive();
     });
 
     it('should render the legendTitle text for each item passed to the `StatLegend` component', () => {

--- a/test/modules/print/BasicsPrintView.test.js
+++ b/test/modules/print/BasicsPrintView.test.js
@@ -363,7 +363,7 @@ describe('BasicsPrintView', () => {
       sinon.assert.calledWith(Renderer.renderHorizontalBarStat,
         'totalInsulinStub',
         {
-          heading: 'Insulin Ratio',
+          heading: 'Avg. Daily Insulin Ratio',
           secondaryFormatKey: 'tooltip',
           fillOpacity: 0.5,
         }

--- a/test/modules/print/BasicsPrintView.test.js
+++ b/test/modules/print/BasicsPrintView.test.js
@@ -214,7 +214,10 @@ describe('BasicsPrintView', () => {
       Renderer.renderCalendars();
 
       sinon.assert.calledWithMatch(Renderer.renderCalendarSection, {
-        title: Renderer.sections.boluses.title,
+        title: {
+          text: Renderer.sections.boluses.title,
+          subText: '(days with no boluses have been excluded)',
+        },
         data: Renderer.aggregationsByDate.boluses.byDate,
         type: 'bolus',
         disabled: Renderer.sections.boluses.disabled,
@@ -229,7 +232,7 @@ describe('BasicsPrintView', () => {
       sinon.assert.calledWithMatch(Renderer.renderCalendarSection, {
         title: {
           text: Renderer.sections.siteChanges.title,
-          subText: `from '${Renderer.sections.siteChanges.subTitle}'`,
+          subText: `(from '${Renderer.sections.siteChanges.subTitle}')`,
         },
         data: Renderer.aggregationsByDate.siteChanges.byDate,
         type: 'siteChange',

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -465,6 +465,7 @@ describe('basics data utils', () => {
       },
       bgPrefs: bgPrefs[MGDL_UNITS],
       timePrefs,
+      query: { excludeDaysWithoutBolus: true },
     };
 
     const aggregations = {
@@ -538,7 +539,7 @@ describe('basics data utils', () => {
 
     it('should return formatted text for Basics data', () => {
       const result = dataUtils.basicsText(patient, data, stats, aggregations);
-      expect(result).to.equal('Basics Header, Basics Dates, Stats Text, Basics Table, Basics Table, Basics Table, Basics Table, ');
+      expect(result).to.equal('Basics Header, Basics Dates, Basics Line, Stats Text, Basics Table, Basics Table, Basics Table, Basics Table, ');
     });
 
     it('should build the document header section', () => {
@@ -550,6 +551,11 @@ describe('basics data utils', () => {
     it('should build the document dates section', () => {
       dataUtils.basicsText(patient, data, stats, aggregations);
       sinon.assert.callCount(textUtilStub.buildDocumentDates, 1);
+    });
+
+    it('should add a note regarding excluded basics bolus days', () => {
+      dataUtils.basicsText(patient, data, stats, aggregations);
+      sinon.assert.calledWith(textUtilStub.buildTextLine, 'Days with no boluses have been excluded from bolus calculations');
     });
 
     it('should build the basics stats section', () => {


### PR DESCRIPTION
See [WEB-993]

Goes with:
tidepool-org/blip#843
tidepool-org/tideline#409

[WEB-993]: https://tidepool.atlassian.net/browse/WEB-993