### PR TITLE
[WEB-717] Support carb exchanges

### DIFF
--- a/data/types.js
+++ b/data/types.js
@@ -360,6 +360,7 @@ export class Wizard extends Common {
 
     this.bgInput = opts.bgInput;
     this.carbInput = opts.carbInput;
+    this.carbUnits = opts.carbUnits;
     this.deviceTime = opts.deviceTime;
     this.insulinCarbRatio = opts.insulinCarbRatio;
     this.insulinSensitivity = opts.insulinSensitivity;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.19.0-web-717-carb-exchanges.1",
+  "version": "1.19.0-web-717-carb-exchanges.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.18.0",
+  "version": "1.19.0-web-717-carb-exchanges.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/stat/Stat.css
+++ b/src/components/common/stat/Stat.css
@@ -55,8 +55,13 @@
 }
 
 .summaryData {
-  display: inline;
+  display: inline-block;
   white-space: nowrap;
+  padding-right: 1em;
+}
+
+.summaryData:last-child {
+  padding-right: 0;
 }
 
 .summaryValue {

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -165,7 +165,9 @@ class Stat extends PureComponent {
     const summaryData = this.getFormattedDataByKey('summary');
     const showSummary = this.props.alwaysShowSummary || !this.state.isOpened;
     let summaryDataValue = _.get(summaryData, 'value');
+    let summaryDataSuffix = _.get(summaryData, 'suffix');
     if (!_.isArray(summaryDataValue)) summaryDataValue = _.compact([summaryDataValue]);
+    if (!_.isArray(summaryDataSuffix)) summaryDataSuffix = _.compact([summaryDataSuffix]);
 
     return (
       <div className={styles.chartSummary}>
@@ -177,10 +179,10 @@ class Stat extends PureComponent {
             }}
           >
             <span className={styles.summaryValue}>
-              {summaryData.value[i]}
+              {value}
             </span>
             <span className={styles.summarySuffix}>
-              {summaryData.suffix[i]}
+              {summaryDataSuffix[i]}
             </span>
           </div>
         ))}

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -164,11 +164,12 @@ class Stat extends PureComponent {
   renderChartSummary = () => {
     const summaryData = this.getFormattedDataByKey('summary');
     const showSummary = this.props.alwaysShowSummary || !this.state.isOpened;
-    const summaryDataValue = _.get(summaryData, 'value');
+    let summaryDataValue = _.get(summaryData, 'value');
+    if (!_.isArray(summaryDataValue)) summaryDataValue = _.compact([summaryDataValue]);
 
     return (
       <div className={styles.chartSummary}>
-        {summaryDataValue && showSummary && (
+        {summaryDataValue.length && showSummary && _.map(summaryDataValue, (value, i) => (
           <div
             className={styles.summaryData}
             style={{
@@ -176,13 +177,13 @@ class Stat extends PureComponent {
             }}
           >
             <span className={styles.summaryValue}>
-              {summaryData.value}
+              {summaryData.value[i]}
             </span>
             <span className={styles.summarySuffix}>
-              {summaryData.suffix}
+              {summaryData.suffix[i]}
             </span>
           </div>
-        )}
+        ))}
 
         {this.props.units && !this.state.showFooter && this.renderStatUnits()}
 

--- a/src/modules/print/DailyPrintView.js
+++ b/src/modules/print/DailyPrintView.js
@@ -42,6 +42,7 @@ import {
   getMaxDuration,
   getMaxValue,
   getNormalPercentage,
+  getWizardFromInsulinEvent,
 } from '../../utils/bolus';
 import {
   formatLocalizedFromUTC,
@@ -790,7 +791,7 @@ class DailyPrintView extends PrintView {
       const carbs = getCarbs(insulinEvent);
       const circleOffset = 1;
       const textOffset = 1.75;
-      const carbUnits = _.get(insulinEvent, 'wizard.carbUnits');
+      const carbUnits = _.get(getWizardFromInsulinEvent(insulinEvent), 'carbUnits');
       const carbFillColor = (carbUnits === 'exchanges') ? this.colors.carbExchanges : this.colors.carbs;
       if (carbs) {
         const carbsX = xScale(getBolusFromInsulinEvent(insulinEvent).normalTime);

--- a/src/modules/print/DailyPrintView.js
+++ b/src/modules/print/DailyPrintView.js
@@ -1084,7 +1084,7 @@ class DailyPrintView extends PrintView {
     const legendVerticalMiddle = legendTop + lineHeight * 2;
     const legendTextMiddle = legendVerticalMiddle - this.doc.currentLineHeight() / 2;
     const legendItemLeftOffset = 9;
-    const legendItemLabelOffset = 6;
+    const legendItemLabelOffset = 4.5;
 
     let cursor = this.margins.left + legendItemLeftOffset;
 
@@ -1117,7 +1117,7 @@ class DailyPrintView extends PrintView {
         .circle(cursor + horizOffset, legendVerticalMiddle + adjustedVertOffset, this.cbgRadius)
         .fill(this.colors[fill]);
     });
-    cursor += 16 + legendItemLabelOffset * 0.75;
+    cursor += 16 + legendItemLabelOffset;
     this.doc.fillColor('black').text(t('CGM'), cursor, legendTextMiddle);
     cursor += this.doc.widthOfString(t('CGM')) + legendItemLeftOffset * 2;
 
@@ -1133,7 +1133,7 @@ class DailyPrintView extends PrintView {
       .fill(this.colors.high);
     this.doc.circle(smbgPositions.low[0], smbgPositions.low[1], this.smbgRadius)
       .fill(this.colors.low);
-    cursor += this.smbgRadius * 3 + legendItemLabelOffset * 0.75;
+    cursor += this.smbgRadius * 3 + legendItemLabelOffset;
     this.doc.fillColor('black').text(t('BGM'), cursor, legendTextMiddle);
     cursor += this.doc.widthOfString(t('BGM')) + legendItemLeftOffset * 2;
 
@@ -1161,7 +1161,7 @@ class DailyPrintView extends PrintView {
     _.each(normalPaths, (path) => {
       this.renderEventPath(path);
     });
-    cursor += this.bolusWidth + legendItemLabelOffset * 0.75;
+    cursor += this.bolusWidth + legendItemLabelOffset;
     this.doc.fillColor('black').text(t('Bolus'), cursor, legendTextMiddle);
     cursor += this.doc.widthOfString(t('Bolus')) + legendItemLeftOffset * 2;
 
@@ -1209,7 +1209,7 @@ class DailyPrintView extends PrintView {
     _.each(underridePaths, (path) => {
       this.renderEventPath(path);
     });
-    cursor += this.bolusWidth * 3 + legendItemLabelOffset * 0.75;
+    cursor += this.bolusWidth * 3 + legendItemLabelOffset;
     this.doc.fillColor('black').text(t('Override up & down'), cursor, legendTextMiddle);
     cursor += this.doc.widthOfString(t('Override up & down')) + legendItemLeftOffset * 2;
 
@@ -1230,7 +1230,7 @@ class DailyPrintView extends PrintView {
     _.each(interruptedPaths, (path) => {
       this.renderEventPath(path);
     });
-    cursor += this.bolusWidth + legendItemLabelOffset * 0.75;
+    cursor += this.bolusWidth + legendItemLabelOffset;
     this.doc.fillColor('black').text(t('Interrupted'), cursor, legendTextMiddle);
     cursor += this.doc.widthOfString(t('Interrupted')) + legendItemLeftOffset * 2;
 
@@ -1252,7 +1252,7 @@ class DailyPrintView extends PrintView {
     _.each(extendedPaths, (path) => {
       this.renderEventPath(path);
     });
-    cursor += this.bolusWidth / 2 + 10 + legendItemLabelOffset * 0.75;
+    cursor += this.bolusWidth / 2 + 10 + legendItemLabelOffset;
     this.doc
       .fillColor('black')
       .text(t('Combo /'), cursor, legendTextMiddle - this.doc.currentLineHeight() / 2)
@@ -1309,7 +1309,7 @@ class DailyPrintView extends PrintView {
     }
 
     this.doc.fontSize(this.smallFontSize);
-    cursor += this.carbRadius + legendItemLabelOffset * 0.75;
+    cursor += this.carbRadius + legendItemLabelOffset;
     this.doc
       .fillColor('black')
       .text(t('Carbs (g)'), cursor, carbsYPos.label);
@@ -1392,7 +1392,7 @@ class DailyPrintView extends PrintView {
       data,
       xScale: legendBasalXScale,
     });
-    cursor += 50 + legendItemLabelOffset * 0.75;
+    cursor += 50 + legendItemLabelOffset;
     this.doc.fillColor('black').text(t('Basals'), cursor, legendTextMiddle);
 
     return this;

--- a/src/utils/StatUtil.js
+++ b/src/utils/StatUtil.js
@@ -85,8 +85,18 @@ export class StatUtil {
 
     const wizardCarbs = _.reduce(
       wizardData,
-      (result, datum) => result + _.get(datum, 'carbInput', 0),
-      0
+      (result, datum) => {
+        const units = _.get(datum, 'carbUnits', 'grams');
+
+        return {
+          ...result,
+          [units]: result[units] + _.get(datum, 'carbInput', 0),
+        };
+      },
+      {
+        grams: 0,
+        exchanges: 0,
+      },
     );
 
     const foodCarbs = _.reduce(
@@ -95,10 +105,16 @@ export class StatUtil {
       0
     );
 
-    let carbs = wizardCarbs + foodCarbs;
+    let carbs = {
+      grams: wizardCarbs.grams + foodCarbs,
+      exchanges: wizardCarbs.exchanges,
+    };
 
     if (this.activeDays > 1) {
-      carbs = carbs / this.activeDays;
+      carbs = {
+        grams: carbs.grams / this.activeDays,
+        exchanges: carbs.exchanges / this.activeDays,
+      };
     }
 
     return {

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -141,9 +141,18 @@ export const formatDatum = (datum = {}, format, opts = {}) => {
       break;
 
     case statFormats.carbs:
-      if (value >= 0) {
-        value = formatDecimalNumber(value);
-        suffix = 'g';
+      if (value.grams > 0 || value.exchanges > 0) {
+        const { grams, exchanges } = value;
+        value = [];
+        suffix = [];
+        if (grams > 0) {
+          value.push(formatDecimalNumber(grams));
+          suffix.push('g');
+        }
+        if (exchanges > 0) {
+          value.push(formatDecimalNumber(exchanges));
+          suffix.push('exch');
+        }
       } else {
         disableStat();
       }
@@ -444,7 +453,10 @@ export const getStatData = (data, type, opts = {}) => {
     case commonStats.carbs:
       statData.data = [
         {
-          value: ensureNumeric(data.carbs),
+          value: {
+            grams: ensureNumeric(data.carbs.grams),
+            exchanges: ensureNumeric(data.carbs.exchanges),
+          },
         },
       ];
 

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -108,7 +108,7 @@ export const formatDatum = (datum = {}, format, opts = {}) => {
     forcePlainTextValues: false,
   });
 
-  const total = _.get(opts, 'data.total.value'); // TODO: need this for percentage calcs
+  const total = _.get(opts, 'data.total.value');
 
   const disableStat = () => {
     id = 'statDisabled';
@@ -141,7 +141,7 @@ export const formatDatum = (datum = {}, format, opts = {}) => {
       break;
 
     case statFormats.carbs:
-      if (value.grams > 0 || value.exchanges > 0) {
+      if (_.isPlainObject(value) && (value.grams > 0 || value.exchanges > 0)) {
         const { grams, exchanges } = value;
         value = [];
         suffix = [];
@@ -150,7 +150,9 @@ export const formatDatum = (datum = {}, format, opts = {}) => {
           suffix.push('g');
         }
         if (exchanges > 0) {
-          value.push(formatDecimalNumber(exchanges));
+          // Note: the + converts the rounded, fixed string back to a number
+          // This allows 2.67777777 to render as 2.7 and 3.0000001 to render as 3 (not 3.0)
+          value.push(+formatDecimalNumber(exchanges, 1));
           suffix.push('exch');
         }
       } else {
@@ -454,8 +456,8 @@ export const getStatData = (data, type, opts = {}) => {
       statData.data = [
         {
           value: {
-            grams: ensureNumeric(data.carbs.grams),
-            exchanges: ensureNumeric(data.carbs.exchanges),
+            grams: ensureNumeric(_.get(data, 'carbs.grams')),
+            exchanges: ensureNumeric(_.get(data, 'carbs.exchanges')),
           },
         },
       ];

--- a/stories/components/common/stats/Stat.js
+++ b/stories/components/common/stats/Stat.js
@@ -59,7 +59,10 @@ const randomValueByType = (type, bgUnits, opts = {}) => {
       return _.random(4, 15, true);
 
     case 'carb':
-      return _.random(5, 100, true);
+      return {
+        grams: _.random(0, 100, true),
+        exchanges: _.random(0, 7, true),
+      };
 
     case 'cv':
       return _.random(24, 40, true);
@@ -676,7 +679,10 @@ stories.add('Coefficient of Variation', () => {
 let carbData = {
   data: [
     {
-      value: 60,
+      value: {
+        grams: 60,
+        exchanges: 3.5,
+      },
     },
   ],
 };

--- a/test/components/common/stat/Stat.test.js
+++ b/test/components/common/stat/Stat.test.js
@@ -337,6 +337,23 @@ describe('Stat', () => {
         expect(summaryData()).to.have.length(1);
         expect(summaryData().first().props().style.color).to.equal(colors.bolus);
       });
+
+      it('should render 2 stat values with suffixes when 2 values are provided', () => {
+        wrapper.setProps(props({
+          data: _.assign({}, defaultProps.data, {
+            data: [{
+              id: 'carbs',
+              value: [60, 3],
+              suffix: ['g', 'exch'],
+            }],
+          }),
+        }));
+        expect(summaryData()).to.have.length(2);
+        expect(summaryData().at(0).childAt(0).text()).to.equal('60');
+        expect(summaryData().at(0).childAt(1).text()).to.equal('g');
+        expect(summaryData().at(1).childAt(0).text()).to.equal('3');
+        expect(summaryData().at(1).childAt(1).text()).to.equal('exch');
+      });
     });
 
     context('summary data is not present', () => {

--- a/test/utils/StatUtil.test.js
+++ b/test/utils/StatUtil.test.js
@@ -204,6 +204,7 @@ describe('StatUtil', () => {
     new Types.Wizard({
       deviceTime: '2018-02-01T04:00:00',
       carbInput: 2,
+      carbUnits: 'exchanges',
       ...useRawData,
     }),
     new Types.Wizard({
@@ -395,7 +396,7 @@ describe('StatUtil', () => {
     it('should return the total carbs from wizard and food data when viewing 1 day', () => {
       filterEndpoints(dayEndpoints);
       expect(statUtil.getCarbsData()).to.eql({
-        carbs: 22,
+        carbs: { grams: 20, exchanges: 2 },
         total: 5,
       });
     });
@@ -403,7 +404,7 @@ describe('StatUtil', () => {
     it('should return the avg daily carbs from wizard and food data when viewing more than 1 day', () => {
       filterEndpoints(twoDayEndpoints);
       expect(statUtil.getCarbsData()).to.eql({
-        carbs: 22.5,
+        carbs: { grams: 21.5, exchanges: 1 },
         total: 7,
       });
     });

--- a/test/utils/stat.test.js
+++ b/test/utils/stat.test.js
@@ -366,18 +366,44 @@ describe('stat', () => {
     });
 
     context('carbs format', () => {
-      it('should return correctly formatted data when `value >= 0`', () => {
-        expect(stat.formatDatum({
-          value: 84.645,
-        }, statFormats.carbs)).to.include({
-          suffix: 'g',
-          value: '85',
-        });
+      it('should return correctly formatted carb data in grams or exchanges when `value > 0`', () => {
+        const onlyGrams = stat.formatDatum({
+          value: {
+            grams: 84.645,
+            exchanges: 0,
+          },
+        }, statFormats.carbs);
+
+        expect(onlyGrams.suffix).to.be.an('array').and.have.members(['g']);
+        expect(onlyGrams.value).to.be.an('array').and.have.members(['85']);
+
+        const onlyExchanges = stat.formatDatum({
+          value: {
+            grams: 0,
+            exchanges: 6.25,
+          },
+        }, statFormats.carbs);
+
+        expect(onlyExchanges.suffix).to.be.an('array').and.have.members(['exch']);
+        expect(onlyExchanges.value).to.be.an('array').and.have.members([6.3]);
+
+        const carbsAndExchanges = stat.formatDatum({
+          value: {
+            grams: 84.645,
+            exchanges: 2,
+          },
+        }, statFormats.carbs);
+
+        expect(carbsAndExchanges.suffix).to.be.an('array').and.have.members(['g', 'exch']);
+        expect(carbsAndExchanges.value).to.be.an('array').and.have.members(['85', 2]);
       });
 
-      it('should return the empty placeholder text and id when `value < 0`', () => {
+      it('should return the empty placeholder text and id when neither grams nor exchange values are > 0', () => {
         expect(stat.formatDatum({
-          value: -1,
+          value: {
+            grams: 0,
+            exchanges: 0,
+          },
         }, statFormats.carbs)).to.include({
           id: 'statDisabled',
           value: '--',
@@ -1138,14 +1164,13 @@ describe('stat', () => {
 
     it('should format and return `carbs` data', () => {
       const data = {
-        carbs: 30,
+        carbs: { grams: 30, exchanges: 2 },
       };
 
       const statData = stat.getStatData(data, commonStats.carbs, opts);
-
       expect(statData.data).to.eql([
         {
-          value: 30,
+          value: { grams: 30, exchanges: 2 },
         },
       ]);
 


### PR DESCRIPTION
See [WEB-717]

Adds support for exchange units in:
1. the Settings view I:C ratio
2. the Daily view wizard tooltips
3. the carbs stat (shown on Basics and Daily via blip)
4. The print view (Basics, Daily, Settings)

Related PRs
---
https://github.com/tidepool-org/tideline/pull/419
https://github.com/tidepool-org/blip/pull/871

[WEB-717]: https://tidepool.atlassian.net/browse/WEB-717