### PR TITLE
[WEB-717] De-convert carb exchanges for Medtronic 5- and 7-series pumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.19.0-rc.5",
+  "version": "1.19.0-rc.6",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -43,6 +43,26 @@ class BolusTooltip extends PureComponent {
     return formatBgValue(val, this.props.bgPrefs);
   }
 
+  isAnimasExtended() {
+    const annotations = bolusUtils.getAnnotations(this.props.bolus);
+    const isAnimasExtended =
+      _.findIndex(annotations, { code: 'animas/bolus/extended-equal-split' }) !== -1;
+    return isAnimasExtended;
+  }
+
+  animasExtendedAnnotationMessage() {
+    let content = null;
+    if (this.isAnimasExtended()) {
+      const messages = getAnnotationMessages(bolusUtils.getBolusFromInsulinEvent(this.props.bolus));
+      content = (
+        <div className={styles.annotation}>
+          {_.find(messages, { code: 'animas/bolus/extended-equal-split' }).message.value}
+        </div>
+      );
+    }
+    return content;
+  }
+
   isMedronicDeconvertedExchange() {
     const annotations = bolusUtils.getAnnotations(this.props.bolus);
     const isMedronicDeconvertedExchange = _.findIndex(annotations, { code: 'medtronic/bolus/carb-to-exchange-ratio-deconverted' }) !== -1;
@@ -62,26 +82,6 @@ class BolusTooltip extends PureComponent {
       );
     }
 
-    return content;
-  }
-
-  isAnimasExtended() {
-    const annotations = bolusUtils.getAnnotations(this.props.bolus);
-    const isAnimasExtended =
-      _.findIndex(annotations, { code: 'animas/bolus/extended-equal-split' }) !== -1;
-    return isAnimasExtended;
-  }
-
-  animasExtendedAnnotationMessage() {
-    let content = null;
-    if (this.isAnimasExtended()) {
-      const messages = getAnnotationMessages(bolusUtils.getBolusFromInsulinEvent(this.props.bolus));
-      content = (
-        <div className={styles.annotation}>
-          {_.find(messages, { code: 'animas/bolus/extended-equal-split' }).message.value}
-        </div>
-      );
-    }
     return content;
   }
 

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -218,10 +218,11 @@ export class DataUtil {
   };
 
   /**
-   * Medtronic 5 and 7 series carb exchange data is converted to carbs at a rounded 1:15 ratio in
-   * the uploader, and needs to be de-converted back into exchanges
+   * Medtronic 5 and 7 series (which always have a deviceId starting with 'MedT-') carb exchange
+   * data is converted to carbs at a rounded 1:15 ratio in the uploader, and needs to be
+   * de-converted back into exchanges.
    */
-  needsCarbToExchangeConversion = d => d.deviceId.indexOf('MedT-') === 0 && d.carbUnits === 'exchanges' && _.isFinite(d.carbInput);
+  needsCarbToExchangeConversion = d => (d.deviceId && d.deviceId.indexOf('MedT-') === 0) && d.carbUnits === 'exchanges' && _.isFinite(d.carbInput);
 
   /**
    * When deconverting the carbs to exchanges, we use a 15:1 ratio, and round to the nearest 0.5,

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -395,7 +395,9 @@ export class DataUtil {
       if (_.isObject(d.bolus)) this.normalizeDatumOut(d.bolus, fields);
 
       if (this.needsCarbToExchangeConversion(d, d.source)) {
+        console.log('d', d);
         d.carbInput = this.getDeconvertedCarbExchange(d);
+        d.insulinCarbRatio = d.insulinCarbRatio / 100 * 15;
       }
     }
 

--- a/src/utils/StatUtil.js
+++ b/src/utils/StatUtil.js
@@ -87,10 +87,16 @@ export class StatUtil {
       wizardData,
       (result, datum) => {
         const units = _.get(datum, 'carbUnits', 'grams');
+        const source = this.dataUtil.getDataSourceFromUpload(datum);
+        let carbInput = _.get(datum, 'carbInput', 0);
+
+        if (source === 'Medtronic' && units === 'exchanges' && _.isFinite(datum.carbInput)) {
+          carbInput = this.dataUtil.getDeconvertedCarbExchange(datum);
+        }
 
         return {
           ...result,
-          [units]: result[units] + _.get(datum, 'carbInput', 0),
+          [units]: result[units] + carbInput,
         };
       },
       {

--- a/src/utils/StatUtil.js
+++ b/src/utils/StatUtil.js
@@ -88,11 +88,10 @@ export class StatUtil {
       (result, datum) => {
         const units = _.get(datum, 'carbUnits', 'grams');
         const source = this.dataUtil.getDataSourceFromUpload(datum);
-        let carbInput = _.get(datum, 'carbInput', 0);
 
-        if (source === 'Medtronic' && units === 'exchanges' && _.isFinite(datum.carbInput)) {
-          carbInput = this.dataUtil.getDeconvertedCarbExchange(datum);
-        }
+        const carbInput = this.dataUtil.needsCarbToExchangeConversion(datum, source)
+          ? this.dataUtil.getDeconvertedCarbExchange(datum)
+          : _.get(datum, 'carbInput', 0);
 
         return {
           ...result,

--- a/src/utils/StatUtil.js
+++ b/src/utils/StatUtil.js
@@ -87,9 +87,8 @@ export class StatUtil {
       wizardData,
       (result, datum) => {
         const units = _.get(datum, 'carbUnits', 'grams');
-        const source = this.dataUtil.getDataSourceFromUpload(datum);
 
-        const carbInput = this.dataUtil.needsCarbToExchangeConversion(datum, source)
+        const carbInput = this.dataUtil.needsCarbToExchangeConversion(datum)
           ? this.dataUtil.getDeconvertedCarbExchange(datum)
           : _.get(datum, 'carbInput', 0);
 

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -52,6 +52,8 @@ const medtronic600BGMessages = {
 const simpleAnnotationMessages = {
   'animas/bolus/extended-equal-split':
     t("* Animas pumps don't capture the details of how combo boluses are split between the normal and extended amounts."),
+  'medtronic/bolus/carb-to-exchange-ratio-deconverted':
+    t('* Due to how carb ratios are uploaded from this pump, there may be a slight discrepancy between the value entered on the pump and the value displayed here.'),
 };
 
 /**

--- a/src/utils/settings/textData.js
+++ b/src/utils/settings/textData.js
@@ -58,8 +58,9 @@ export function nonTandemText(patient, settings, units, manufacturer) {
   );
 
   const ratio = nonTandemData.ratio(settings, manufacturer);
+  const ratioUnits = _.get(settings, 'units.carb') === 'exchanges' ? 'U/exch' : 'g/U';
   settingsString += textUtil.buildTextTable(
-    `${ratio.title} g/U`,
+    `${ratio.title} ${ratioUnits}`,
     ratio.rows,
     ratio.columns,
   );

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -913,10 +913,13 @@ export function statsText(stats, textUtil, bgPrefs, formatFn = formatDatum) {
         opts
       );
 
+      if (!_.isArray(formatted.value)) formatted.value = _.compact([formatted.value]);
+      if (!_.isArray(formatted.suffix)) formatted.suffix = _.compact([formatted.suffix]);
+
       statsString += '\n';
       statsString += textUtil.buildTextLine({
         label: stat.title,
-        value: `${formatted.value}${formatted.suffix || (stat.units ? ` ${stat.units}` : '')}`,
+        value: _.map(formatted.value, (value, i) => `${value}${formatted.suffix[i] || (stat.units ? ` ${stat.units}` : '')}`).join(' '),
       });
     }
   });

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -190,6 +190,27 @@ const extendedAnimasUnderride = {
   },
 };
 
+const carbExchangesMedtronic = {
+  type: 'wizard',
+  bolus: {
+    normal: 5,
+    normalTime: '2017-11-11T05:45:52.000Z',
+  },
+  carbUnits: 'exchanges',
+  carbInput: 4,
+  insulinCarbRatio: 2.5,
+};
+
+const deconvertedCarbExchangeRatioMedtronic = {
+  ...carbExchangesMedtronic,
+  bolus: {
+    ...carbExchangesMedtronic.bolus,
+    annotations: [
+      { code: 'medtronic/bolus/carb-to-exchange-ratio-deconverted' },
+    ],
+  },
+};
+
 const extendedUnderride = {
   type: 'wizard',
   bolus: {
@@ -515,6 +536,13 @@ describe('BolusTooltip', () => {
     expect(wrapper.find(formatClassesAsSelector(styles.carbRatio))).to.have.length(1);
   });
 
+  it('should render carbRatio for bolus with carb exchange input', () => {
+    const wrapper = mount(<BolusTooltip {...props} bolus={carbExchangesMedtronic} />);
+    const carbRatio = wrapper.find(formatClassesAsSelector(styles.carbRatio));
+    expect(carbRatio.find(formatClassesAsSelector(styles.label)).text()).to.equal('I:C Ratio  (U/exch)');
+    expect(carbRatio.find(formatClassesAsSelector(styles.value)).text()).to.equal('2.5');
+  });
+
   it('should render delivered, bg, iob, isf and target for bg and iob bolus', () => {
     const wrapper = mount(<BolusTooltip {...props} bolus={withBGInputAndIOB} />);
     expect(wrapper.find(formatClassesAsSelector(styles.delivered))).to.have.length(1);
@@ -585,6 +613,19 @@ describe('BolusTooltip', () => {
     });
   });
 
+  describe('isMedronicDeconvertedExchange', () => {
+    it('should return true if annotations include Medtronic deconverted carb-to-exchange ratio', () => {
+      const wrapper = mount(
+        <BolusTooltip {...props} bolus={deconvertedCarbExchangeRatioMedtronic} />
+      );
+      expect(wrapper.instance().isMedronicDeconvertedExchange()).to.be.true;
+    });
+    it('should return false for non-deconverted bolus', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={normal} />);
+      expect(wrapper.instance().isMedronicDeconvertedExchange()).to.be.false;
+    });
+  });
+
   describe('getExtended', () => {
     const extendedStyle = formatClassesAsSelector(styles.extended);
     const normalStyle = formatClassesAsSelector(styles.normal);
@@ -618,6 +659,17 @@ describe('BolusTooltip', () => {
     it('should return a div for Animas extended', () => {
       const wrapper = mount(<BolusTooltip {...props} bolus={extendedAnimas} />);
       expect(shallow(wrapper.instance().animasExtendedAnnotationMessage()).type()).to.equal('div');
+    });
+    it('should return null for normal bolus', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={normal} />);
+      expect(wrapper.instance().animasExtendedAnnotationMessage()).to.be.null;
+    });
+  });
+
+  describe('medronicDeconvertedExchangeMessage', () => {
+    it('should return a div for Medtronic deconverted carb-to-exchange ratio', () => {
+      const wrapper = mount(<BolusTooltip {...props} bolus={deconvertedCarbExchangeRatioMedtronic} />);
+      expect(shallow(wrapper.instance().medronicDeconvertedExchangeMessage()).type()).to.equal('div');
     });
     it('should return null for normal bolus', () => {
       const wrapper = mount(<BolusTooltip {...props} bolus={normal} />);

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment';
-
 import DataUtil from '../../src/utils/DataUtil';
+
 import { types as Types, generateGUID } from '../../data/types';
 import { MGDL_UNITS, MS_IN_HOUR, MS_IN_MIN, MMOLL_UNITS, DEFAULT_BG_BOUNDS } from '../../src/utils/constants';
 
@@ -666,6 +666,59 @@ describe('DataUtil', () => {
     });
   });
 
+  describe('needsCarbToExchangeConversion', () => {
+    const bolus = {
+      deviceId: 'MedT-123456',
+      carbUnits: 'exchanges',
+      carbInput: 2,
+    };
+
+    it('should return true if deviceId begins with "MedT-" and carbUnits are exchanges', () => {
+      expect(dataUtil.needsCarbToExchangeConversion(bolus)).to.be.true;
+    });
+
+    it('should return false if deviceId does not begin with "MedT-" and carbUnits are exchanges', () => {
+      expect(dataUtil.needsCarbToExchangeConversion({
+        ...bolus,
+        deviceId: 'MMT-123456',
+      })).to.be.false;
+    });
+
+    it('should return false if deviceId begins with "MedT-" and carbUnits are grams', () => {
+      expect(dataUtil.needsCarbToExchangeConversion({
+        ...bolus,
+        carbUnits: 'grams',
+      })).to.be.false;
+    });
+
+    it('should return false if deviceId begins with "MedT-" and carbUnits are exchanges and carbInput is non-finite', () => {
+      expect(dataUtil.needsCarbToExchangeConversion({
+        ...bolus,
+        carbInput: '4',
+      })).to.be.false;
+    });
+  });
+
+  describe('getDeconvertedCarbExchange', () => {
+    it('should divide carbInput values by 15 and round to the nearest 0.5', () => {
+      expect(dataUtil.getDeconvertedCarbExchange({
+        carbInput: 60,
+      })).to.equal(4);
+
+      expect(dataUtil.getDeconvertedCarbExchange({
+        carbInput: 55, // 55/15 = 3.6666
+      })).to.equal(3.5);
+
+      expect(dataUtil.getDeconvertedCarbExchange({
+        carbInput: 50, // 50/15 = 3.3333
+      })).to.equal(3.5);
+
+      expect(dataUtil.getDeconvertedCarbExchange({
+        carbInput: 48, // 48/15 = 3.2
+      })).to.equal(3);
+    });
+  });
+
   describe('tagDatum', () => {
     context('basal', () => {
       const basal = new Types.Basal({ deviceTime: '2018-02-01T01:00:00', ...useRawData });
@@ -1318,6 +1371,79 @@ describe('DataUtil', () => {
 
         dataUtil.normalizeDatumOut(datumWithBolusObject, fields);
         sinon.assert.calledWithMatch(dataUtil.normalizeDatumOut, datumWithBolusObject.bolus, fields);
+      });
+
+      context('needsCarbToExchangeConversion is `true`', () => {
+        it('should convert the carbInput and insulinCarbRatio to exchanges', () => {
+          sinon.stub(dataUtil, 'needsCarbToExchangeConversion').returns(true);
+
+          const datum = {
+            type: 'wizard',
+            carbInput: 60,
+            insulinCarbRatio: 10,
+          };
+
+          dataUtil.normalizeDatumOut(datum);
+
+          expect(datum.carbInput).to.equal(4);
+          expect(datum.insulinCarbRatio).to.equal(1.5);
+        });
+
+        it('should add an annotation to the bolus object if it exists', () => {
+          sinon.stub(dataUtil, 'needsCarbToExchangeConversion').returns(true);
+
+          const datumWithoutBolus = {
+            type: 'wizard',
+            carbInput: 60,
+            insulinCarbRatio: 10,
+          };
+
+          dataUtil.normalizeDatumOut(datumWithoutBolus);
+          expect(datumWithoutBolus.bolus).to.be.undefined;
+
+          const datumWithoutBolusAnnotations = {
+            type: 'wizard',
+            carbInput: 60,
+            insulinCarbRatio: 10,
+            bolus: {},
+          };
+
+          dataUtil.normalizeDatumOut(datumWithoutBolusAnnotations);
+          expect(datumWithoutBolusAnnotations.bolus.annotations).to.have.lengthOf(1);
+          expect(datumWithoutBolusAnnotations.bolus.annotations[0]).to.eql({
+            code: 'medtronic/bolus/carb-to-exchange-ratio-deconverted',
+          });
+
+          const datumWithBolusAnnotations = {
+            type: 'wizard',
+            carbInput: 60,
+            insulinCarbRatio: 10,
+            bolus: { annotations: [{ code: 'foo' }] },
+          };
+
+          dataUtil.normalizeDatumOut(datumWithBolusAnnotations);
+          expect(datumWithBolusAnnotations.bolus.annotations).to.have.lengthOf(2);
+          expect(datumWithBolusAnnotations.bolus.annotations[1]).to.eql({
+            code: 'medtronic/bolus/carb-to-exchange-ratio-deconverted',
+          });
+        });
+      });
+
+      context('needsCarbToExchangeConversion is `false`', () => {
+        it('should not convert the carbInput and insulinCarbRatio to exchanges', () => {
+          sinon.stub(dataUtil, 'needsCarbToExchangeConversion').returns(false);
+
+          const datum = {
+            type: 'wizard',
+            carbInput: 60,
+            insulinCarbRatio: 10,
+          };
+
+          dataUtil.normalizeDatumOut(datum);
+
+          expect(datum.carbInput).to.equal(60);
+          expect(datum.insulinCarbRatio).to.equal(10);
+        });
       });
     });
 

--- a/test/utils/annotations.test.js
+++ b/test/utils/annotations.test.js
@@ -72,6 +72,16 @@ const animasBolus = {
   ],
 };
 
+const medtronicDeconvertedCarbToExchangeRatioBolus = {
+  type: 'bolus',
+  extended: 1.2,
+  duration: 18000000,
+  normalTime: '2017-11-11T05:45:52.000Z',
+  annotations: [
+    { code: 'medtronic/bolus/carb-to-exchange-ratio-deconverted' },
+  ],
+};
+
 describe('annotation utilities', () => {
   describe('getAnnotations', () => {
     it('should be a function', () => {
@@ -144,6 +154,9 @@ describe('annotation utilities', () => {
       ]);
       expect(annotations.getAnnotationMessages(animasBolus)[0].message.value).to.equal(
         "* Animas pumps don't capture the details of how combo boluses are split between the normal and extended amounts."
+      );
+      expect(annotations.getAnnotationMessages(medtronicDeconvertedCarbToExchangeRatioBolus)[0].message.value).to.equal(
+        '* Due to how carb ratios are uploaded from this pump, there may be a slight discrepancy between the value entered on the pump and the value displayed here.'
       );
     });
   });


### PR DESCRIPTION
It was discovered during testing of [WEB-717] that uploads for the Medtronic 5 and 7 series carb exchange data was converting the exchanges to carbs (and then rounding to nearest integer) at a 1:15 ratio.  

This conversion was intended to be removed when `carbUnits` was added to the data model, but it was missed.  We've decided to de-convert it on the frontend for the time being.  As well, the `insulinCarbRatio` on wizard datums needs de-conversion as well.  In that case, due to rounding and the very granular precision that might be used to input the ratios on the pump, there is potential irrecoverable precision loss.  For this, we add an annotation to the bolus tooltip for any carb ratios that could be affected.  The carb ratio on the settings view is fully precise.

There is a backend ticket created to fix the data and begin de-converting on the backend instead, at which point we will stop doing it on the frontend.

This also contains a couple of extra changes for the exchange data to show correctly in the copy-to-text button output for the basics and settings views.

[WEB-717]: https://tidepool.atlassian.net/browse/WEB-717