### PR TITLE
[WEB-775] Filter out non-control-iq upload data if control-iq data is present

### DIFF
--- a/data/types.js
+++ b/data/types.js
@@ -30,7 +30,7 @@ export const generateGUID = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace
 
 class Common {
   constructor(opts = {}) {
-    this.deviceId = 'Test Page Data - 123';
+    this.deviceId = opts.deviceId || 'Test Page Data - 123';
     this.source = opts.source || 'testpage';
     this.conversionOffset = 0;
     this.uploadId = opts.uploadId || 'uploadId123';
@@ -331,6 +331,7 @@ export class Upload extends Common {
     this.source = opts.source;
     this.deviceTime = opts.deviceTime;
     this.deviceModel = opts.deviceModel;
+    this.deviceManufacturers = opts.deviceManufacturers;
     this.deviceSerialNumber = opts.deviceSerialNumber;
 
     this.time = this.makeTime();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.20.0-rc.1",
+  "version": "1.20.0-rc.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -801,7 +801,7 @@ export class DataUtil {
           if (deviceManufacturer === 'Dexcom' && isContinuous) {
             label = t('Dexcom API');
           } else {
-            label = [deviceManufacturer, deviceModel].join(' ');
+            label = _.reject([deviceManufacturer, deviceModel], _.isEmpty).join(' ');
           }
         }
 
@@ -833,7 +833,7 @@ export class DataUtil {
       }
     });
 
-    this.setExcludedDevices(excludedDevices);
+    this.setExcludedDevices(_.uniq(excludedDevices));
 
     this.endTimer('setDevices');
   }

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -80,6 +80,7 @@ export function defineBasicsAggregations(bgPrefs, manufacturer, pumpUpload = {})
     let title = '';
     let summaryTitle;
     let perRow = 3;
+    const active = true;
 
     switch (section) {
       case 'basals':
@@ -145,6 +146,7 @@ export function defineBasicsAggregations(bgPrefs, manufacturer, pumpUpload = {})
     }
 
     sections[section] = {
+      active,
       dimensions,
       perRow,
       summaryTitle,

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -80,7 +80,6 @@ export function defineBasicsAggregations(bgPrefs, manufacturer, pumpUpload = {})
     let title = '';
     let summaryTitle;
     let perRow = 3;
-    const active = true;
 
     switch (section) {
       case 'basals':
@@ -146,7 +145,6 @@ export function defineBasicsAggregations(bgPrefs, manufacturer, pumpUpload = {})
     }
 
     sections[section] = {
-      active,
       dimensions,
       perRow,
       summaryTitle,


### PR DESCRIPTION
Part of [WEB-775].

This PR is to exclude pre-control-iq tandem uploads by default if we have data from the same device from a version of uploader supports control-iq data. 

Otherwise, we have duplicate data - specifically because the 'shape' of the bolus and basal datums changed due to the 'automated' subTypes, which in turn cause the generated datum id's to differ, and jellyfish deduplication does not happen.

To distinguish between data from uploads from a control-iq-capable pump prior to the adding of the automated subTypes, on the latest uploader version, we add begin the deviceId with `tandemCIQ` instead of just `tandem`, and, if we have, for instance, a `tandemCIQ123456789` device, we filter out, if present, by default,  the `tandem123456789` device.

[WEB-775]: https://tidepool.atlassian.net/browse/WEB-775