### PR TITLE
[WEB-1157] Trends navigation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.20.0-control-iq.5",
+  "version": "1.21.0-trends-navigation-fix.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/trends/common/TrendsContainer.js
+++ b/src/components/trends/common/TrendsContainer.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import bows from 'bows';
 import { extent } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
-import { utcDay } from 'd3-time';
 import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
@@ -346,14 +345,20 @@ export class TrendsContainer extends PureComponent {
 
   goForward() {
     const { dateDomain: { end: newStart } } = this.state;
-    const end = utcDay.offset(new Date(newStart), this.props.extentSize).toISOString();
+    const end = getLocalizedOffset(newStart, {
+      amount: this.props.extentSize,
+      units: 'days',
+    }, this.props.timePrefs).toISOString();
     const newDomain = [newStart, end];
     this.setExtent(newDomain);
   }
 
   goToMostRecent() {
     const { mostRecent: end } = this.state;
-    const start = utcDay.offset(new Date(end), -this.props.extentSize).toISOString();
+    const start = getLocalizedOffset(end, {
+      amount: -this.props.extentSize,
+      units: 'days',
+    }, this.props.timePrefs).toISOString();
     const newDomain = [start, end];
     this.setExtent(newDomain);
   }


### PR DESCRIPTION
Part of [WEB-1157]

Fixes issue where forward and 'most recent' date range calculations weren't accounting for DST changeovers.

Related PR: https://github.com/tidepool-org/blip/pull/890

[WEB-1157]: https://tidepool.atlassian.net/browse/WEB-1157