### PR TITLE
Allow DataUtil storybook to use raw data from the API or blip console downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.22.0-web-1202-pdf-bgm-range-percentages.1",
+  "version": "1.22.0-storybook-blip-raw-data.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -178,7 +178,7 @@ export class DataUtil {
     // for easier reference when debugging.
     /* eslint-disable no-underscore-dangle */
     d._time = d.time;
-    d._deviceTime = d.deviceTime;
+    d._deviceTime = d.deviceTime || d.time;
     /* eslint-enable no-underscore-dangle */
     d.time = Date.parse(d.time);
     d.deviceTime = d.deviceTime ? Date.parse(d.deviceTime) : d.time;

--- a/stories/data/DataUtil.js
+++ b/stories/data/DataUtil.js
@@ -48,8 +48,10 @@ const GROUP_UNITS = 'UNITS';
 const GROUP_STATS = 'STATS';
 const GROUP_RESULTS = 'RESULTS';
 
-const notes = `Run the \`accountTool.py export\` from the \`tidepool-org/tools-private\` repo.
-Save the resulting file to the \`local/\` directory of viz as \`rawData.json\`,
+const notes = `**RUN** the \`accountTool.py export\` command from the \`tidepool-org/tools-private\` repo
+\n\r**OR** Run \`downloadPatientData({raw: true})\` from the console in a Tidepool Web data view
+\n\r**OR** Fetch data directly from the Tidepool API, and
+\n\r**THEN** Save the resulting file to the \`local/\` directory of viz as \`rawData.json\`,
 and then use this story to generate DataUtil queries outside of Tidepool Web!`;
 
 const Results = ({ results, showData, showStats }) => {

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -21,7 +21,18 @@ addDecorator(withKnobs);
 let data;
 try {
   // eslint-disable-next-line global-require, import/no-unresolved
-  data = _.flatten(_.map(require('../local/rawData.json'), v => v.data));
+  data = require('../local/rawData.json');
+  let dataSource = 'the Tidepool API';
+
+  if (data?.data?.current?.data) {
+    data = _.flatten(_.values(data.data.current.data));
+    dataSource = 'a Tidepool Web console export';
+  } else if (data?.[0].dataset) {
+    data = _.flatten(_.map(data, v => v.data));
+    dataSource = 'a Tidepool Account Tool export';
+  }
+
+  console.log(`Loading dataset provided by ${dataSource}`);
 } catch (e) {
   data = { data: [] };
 }


### PR DESCRIPTION
This is to allow us to use a variety of download sources in the DataUtil storybook, rather than just the private `accountTool.py` exports.

Main driving factor is a clinic IT team that would like to play with it.

Related PR: https://github.com/tidepool-org/blip/pull/971