### PR TITLE
[WEB-1369,WEB-1370,WEB-1371] Updates to PDF and Text Stat output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.23.0-web-1188-new-device-settings.1",
+  "version": "1.23.0-web-1369-bg-range-stat-updates.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -144,7 +144,7 @@ class BasicsPrintView extends PrintView {
     this.renderCalendarSection({
       title: {
         text: this.sections.boluses.title,
-        subText: _.get(this.data, 'query.excludeDaysWithoutBolus') ? '(days with no boluses have been excluded)' : false,
+        subText: _.get(this.data, 'query.excludeDaysWithoutBolus') ? t('(days with no boluses have been excluded)') : false,
       },
       data: this.aggregationsByDate.boluses.byDate,
       type: 'bolus',
@@ -157,7 +157,7 @@ class BasicsPrintView extends PrintView {
     this.renderCalendarSection({
       title: {
         text: this.sections.siteChanges.title,
-        subText: siteChangesSubTitle ? `(from '${this.sections.siteChanges.subTitle}')` : false,
+        subText: siteChangesSubTitle ? t("(from '{{source}}')", { source: this.sections.siteChanges.subTitle }) : false,
       },
       data: this.aggregationsByDate.siteChanges.byDate,
       type: 'siteChange',
@@ -226,7 +226,7 @@ class BasicsPrintView extends PrintView {
         {
           heading: {
             text: 'BG Distribution',
-            note: `Showing ${statBgSourceLabels[this.bgSource]} data`,
+            note: t('Showing {{source}} data', { source: statBgSourceLabels[this.bgSource] }),
           },
         }
       );
@@ -238,7 +238,10 @@ class BasicsPrintView extends PrintView {
         {
           heading: {
             text: 'BG Distribution',
-            note: `Showing ${statBgSourceLabels[this.bgSource]} data`,
+            note: t('{{source}} data from {{count}} readings', {
+              source: statBgSourceLabels[this.bgSource],
+              count: readingsInRange.data?.raw?.total,
+            }),
           },
           secondaryFormatKey: 'tooltip',
         }
@@ -251,7 +254,7 @@ class BasicsPrintView extends PrintView {
     this.renderHorizontalBarStat(
       totalInsulin,
       {
-        heading: 'Avg. Daily Insulin Ratio',
+        heading: t('Avg. Daily Insulin Ratio'),
         secondaryFormatKey: 'tooltip',
         fillOpacity: 0.5,
       }
@@ -262,7 +265,7 @@ class BasicsPrintView extends PrintView {
       this.renderHorizontalBarStat(
         timeInAuto,
         {
-          heading: `Time In ${automatedLabel} Ratio`,
+          heading: t('Time In {{automatedLabel}} Ratio', { automatedLabel }),
           fillOpacity: 0.5,
         }
       );
@@ -273,7 +276,7 @@ class BasicsPrintView extends PrintView {
       this.renderHorizontalBarStat(
         timeInOverride,
         {
-          heading: `Time In ${overrideLabel}`,
+          heading: t('Time In {{overrideLabel}}', { overrideLabel }),
           fillOpacity: 0.5,
         }
       );
@@ -428,8 +431,7 @@ class BasicsPrintView extends PrintView {
           height: 35,
           fontSize: this.largeFontSize,
           font: this.boldFont,
-          noteFontSize: this.smallFontSize,
-          subTextFontSize: this.smallFontSize,
+          noteFontSize: this.smallFontSize - 1,
           align: 'left',
         },
       ];
@@ -458,6 +460,7 @@ class BasicsPrintView extends PrintView {
             { bgPrefs: this.bgPrefs, data: stat.data }
           );
 
+          if (stat.id === 'readingsInRange') secondaryValue.suffix += 'readings/day';
           note += ` (${secondaryValue.value} ${secondaryValue.suffix})`;
         }
 

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -228,6 +228,7 @@ class BasicsPrintView extends PrintView {
             text: 'BG Distribution',
             note: t('Showing {{source}} data', { source: statBgSourceLabels[this.bgSource] }),
           },
+          secondaryFormatKey: 'tooltip',
         }
       );
     }
@@ -267,6 +268,7 @@ class BasicsPrintView extends PrintView {
         {
           heading: t('Time In {{automatedLabel}} Ratio', { automatedLabel }),
           fillOpacity: 0.5,
+          secondaryFormatKey: 'tooltip',
         }
       );
     }
@@ -278,6 +280,7 @@ class BasicsPrintView extends PrintView {
         {
           heading: t('Time In {{overrideLabel}}', { overrideLabel }),
           fillOpacity: 0.5,
+          secondaryFormatKey: 'tooltip',
         }
       );
     }

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -841,9 +841,9 @@ export const getStatDefinition = (data = {}, type, opts = {}) => {
     case commonStats.readingsInRange:
       stat.alwaysShowTooltips = true;
       stat.dataFormat = {
-        label: statFormats.bgCount,
-        summary: statFormats.bgCount,
-        tooltip: statFormats.percentage,
+        label: statFormats.percentage,
+        summary: statFormats.percentage,
+        tooltip: statFormats.bgCount,
         tooltipTitle: statFormats.bgRange,
       };
       stat.legend = true;
@@ -952,10 +952,15 @@ export function statsText(stats, textUtil, bgPrefs, formatFn = formatDatum) {
     ], stat.id);
 
     const opts = { bgPrefs, data: stat.data, forcePlainTextValues: true };
+    let statTitle = `${stat.title}${stat.units ? ` (${stat.units})` : ''}`;
+
+    if (stat.id === 'readingsInRange' && stat.data?.raw?.total > 0) {
+      statTitle += t(' from {{count}} readings', { count: stat.data.raw.total });
+    }
 
     if (renderTable) {
       statsString += textUtil.buildTextTable(
-        `${stat.title}${stat.units ? ` (${stat.units})` : ''}`,
+        statTitle,
         _.map(_.reverse([...stat.data.data]), datum => {
           const formatted = formatFn(
             datum,
@@ -972,6 +977,7 @@ export function statsText(stats, textUtil, bgPrefs, formatFn = formatDatum) {
               opts
             );
 
+            if (stat.id === 'readingsInRange') secondary.suffix += ' readings/day';
             formattedText += ` (${secondary.value}${secondary.suffix || ''})`;
           }
 

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -949,6 +949,9 @@ export function statsText(stats, textUtil, bgPrefs, formatFn = formatDatum) {
 
     const renderSecondaryValue = _.includes([
       commonStats.readingsInRange,
+      commonStats.timeInAuto,
+      commonStats.timeInOverride,
+      commonStats.timeInRange,
     ], stat.id);
 
     const opts = { bgPrefs, data: stat.data, forcePlainTextValues: true };

--- a/stories/components/common/stats/Stat.js
+++ b/stories/components/common/stats/Stat.js
@@ -308,9 +308,9 @@ stories.add('Readings In Range', () => {
         collapsible={collapsible}
         data={readingsInRangeData}
         dataFormat={{
-          label: statFormats.bgCount,
-          summary: statFormats.bgCount,
-          tooltip: statFormats.percentage,
+          label: statFormats.percentage,
+          summary: statFormats.percentage,
+          tooltip: statFormats.bgCount,
           tooltipTitle: statFormats.bgRange,
         }}
         isOpened={isOpened}

--- a/test/modules/print/BasicsPrintView.test.js
+++ b/test/modules/print/BasicsPrintView.test.js
@@ -365,6 +365,7 @@ describe('BasicsPrintView', () => {
             text: 'BG Distribution',
             note: 'Showing CGM data',
           },
+          secondaryFormatKey: 'tooltip',
         }
       );
     });
@@ -374,15 +375,15 @@ describe('BasicsPrintView', () => {
       Renderer.renderAggregatedStats();
       sinon.assert.neverCalledWith(Renderer.renderHorizontalBarStat, null);
 
-      Renderer.stats.readingsInRange = 'readingsInRangeStub';
+      Renderer.stats.readingsInRange = { data: { raw: { total: 11 } } };
       Renderer.bgSource = 'smbg';
       Renderer.renderAggregatedStats();
       sinon.assert.calledWith(Renderer.renderHorizontalBarStat,
-        'readingsInRangeStub',
+        { data: { raw: { total: 11 } } },
         {
           heading: {
             text: 'BG Distribution',
-            note: 'Showing BGM data',
+            note: 'BGM data from 11 readings',
           },
           secondaryFormatKey: 'tooltip',
         }
@@ -433,6 +434,7 @@ describe('BasicsPrintView', () => {
         {
           heading: 'Time In Automated Ratio',
           fillOpacity: 0.5,
+          secondaryFormatKey: 'tooltip',
         }
       );
     });
@@ -449,6 +451,7 @@ describe('BasicsPrintView', () => {
         {
           heading: 'Time In Settings Override',
           fillOpacity: 0.5,
+          secondaryFormatKey: 'tooltip',
         }
       );
     });

--- a/test/utils/stat.test.js
+++ b/test/utils/stat.test.js
@@ -1708,9 +1708,9 @@ describe('stat', () => {
       expect(def.id).to.equal(commonStats.readingsInRange);
       expect(def.type).to.equal(statTypes.barHorizontal);
       expect(def.dataFormat).to.eql({
-        label: statFormats.bgCount,
-        summary: statFormats.bgCount,
-        tooltip: statFormats.percentage,
+        label: statFormats.percentage,
+        summary: statFormats.percentage,
+        tooltip: statFormats.bgCount,
         tooltipTitle: statFormats.bgRange,
       });
       expect(def.alwaysShowTooltips).to.be.true;
@@ -1924,8 +1924,8 @@ describe('stat', () => {
 
       stat.statsText(stats, textUtil, defaultBgPrefs, formatDatumSpy);
 
-      // 13 stats, but readingsInRange is called an extra time for the secondary value
-      sinon.assert.callCount(formatDatumSpy, 14);
+      // 13 stats, but readingsInRange, timeInAuto, timeInOverride, timeInRange are called an extra time for the secondary value
+      sinon.assert.callCount(formatDatumSpy, 17);
       sinon.assert.calledWith(formatDatumSpy, defaultStat.data.data[0], 'myFormat', sinon.match(defaultOpts));
 
       formatDatumSpy.restore();


### PR DESCRIPTION
As the functionality was tightly related, this PR covers [WEB-1369], [WEB-1370], and [WEB-1371]

Related PR: https://github.com/tidepool-org/blip/pull/995

[WEB-1369]: https://tidepool.atlassian.net/browse/WEB-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-1370]: https://tidepool.atlassian.net/browse/WEB-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-1371]: https://tidepool.atlassian.net/browse/WEB-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ