### PR TITLE
[WEB-1412] Fix incorrect disabled state criteria on stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.26.0-web-49-basics-basal-iq-auto-suspends.1",
+  "version": "1.26.0-web-1412-greyed-out-widget-fix.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -379,7 +379,12 @@ class Stat extends PureComponent {
 
     const state = {
       chartTitle: props.title,
-      isDisabled: _.sum(_.map(data.data, d => _.get(d, 'deviation.value', d.value))) <= 0,
+      // Because all NaN values get converted to -1, we first filter out negative values.
+      // Stat is disabled if remaining values sum is not greater than zero
+      isDisabled: !_.sum(_.filter(
+        _.map(data.data, d => _.get(d, 'deviation.value', d.value)),
+        n => n >= 0
+      )) > 0,
     };
 
     switch (props.type) {

--- a/test/components/common/stat/Stat.test.js
+++ b/test/components/common/stat/Stat.test.js
@@ -891,7 +891,7 @@ describe('Stat', () => {
         expect(instance.getStateByType(instance.props).chartTitle).to.equal('My Stat Title');
       });
 
-      it('should set the `isDisabled` state to `true` if the sum of all data, including deviation data, is <= 0', () => {
+      it('should set the `isDisabled` state to `true` if the sum of all positive data values, including deviation data, is not > 0', () => {
         wrapper.setProps(props({
           data: _.assign({}, defaultProps.data, {
             data: [
@@ -937,6 +937,25 @@ describe('Stat', () => {
               },
               {
                 value: 0,
+              },
+            ],
+            dataPaths: {
+              summary: 'data.0',
+            },
+          }),
+        }));
+
+        expect(instance.getStateByType(instance.props).isDisabled).to.be.false;
+
+        wrapper.setProps(props({
+          data: _.assign({}, defaultProps.data, {
+            data: [
+              {
+                value: 0,
+                deviation: { value: 0.5 },
+              },
+              {
+                value: -1,
               },
             ],
             dataPaths: {


### PR DESCRIPTION
See [WEB-1412]
Edge case where the method of disabling bar stats when the sum of the bars is < 0.  NaN values are converted to -1, so in some cases where there are small positive values, the sum could still be below zero.  

Negative values are now dropped before summing values to determine the disabled state.

Related PR: https://github.com/tidepool-org/blip/pull/1021

[WEB-1412]: https://tidepool.atlassian.net/browse/WEB-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ