### PR TITLE
[WEB-1338] Export bg range label util

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.27.0-web-1078-daily-view-date-picker.1",
+  "version": "1.27.0-web-1338-patient-list-cgm-stats.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/controls/ClipboardButton.js
+++ b/src/components/common/controls/ClipboardButton.js
@@ -17,12 +17,12 @@ const t = i18next.t.bind(i18next);
 class ClipboardButton extends PureComponent {
   static propTypes = {
     buttonTitle: PropTypes.string.isRequired,
-    buttonText: PropTypes.string.isRequired,
+    buttonText: PropTypes.node.isRequired,
     clipboardText: PropTypes.string,
     getText: PropTypes.func,
     onClick: PropTypes.func,
     onSuccess: PropTypes.func,
-    successText: PropTypes.string.isRequired,
+    successText: PropTypes.node.isRequired,
   };
 
   static defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ import CBGTooltip from './components/daily/cbgtooltip/CBGTooltip';
 import FoodTooltip from './components/daily/foodtooltip/FoodTooltip';
 
 import { formatBgValue } from './utils/format';
-import { isCustomBgRange, reshapeBgClassesToBgBounds } from './utils/bloodglucose';
+import { generateBgRangeLabels, isCustomBgRange, reshapeBgClassesToBgBounds } from './utils/bloodglucose';
 import { getTotalBasalFromEndpoints, getGroupDurations } from './utils/basal';
 import { DEFAULT_BG_BOUNDS } from './utils/constants';
 
@@ -100,6 +100,7 @@ const utils = {
   },
   bg: {
     formatBgValue,
+    generateBgRangeLabels,
     isCustomBgRange,
     reshapeBgClassesToBgBounds,
   },


### PR DESCRIPTION
Exports the `generateBgRangeLabels` util to support https://github.com/tidepool-org/blip/pull/1054