### PR TITLE
[WEB-1695] TIR filter update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.28.0",
+  "version": "1.28.0-web-1695-tir-filter-update.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -135,6 +135,36 @@ export function generateBgRangeLabels(bgPrefs, opts = {}) {
     };
   }
 
+  if (opts.segmented) {
+    return {
+      veryLow: {
+        prefix: 'below',
+        suffix: bgUnits,
+        value: `${thresholds.veryLowThreshold}`,
+      },
+      low: {
+        prefix: 'between',
+        suffix: bgUnits,
+        value: `${thresholds.veryLowThreshold}-${thresholds.targetLowerBound}`,
+      },
+      target: {
+        prefix: 'between',
+        suffix: bgUnits,
+        value: `${thresholds.targetLowerBound}-${thresholds.targetUpperBound}`,
+      },
+      high: {
+        prefix: 'between',
+        suffix: bgUnits,
+        value: `${thresholds.targetUpperBound}-${thresholds.veryHighThreshold}`,
+      },
+      veryHigh: {
+        prefix: 'above',
+        suffix: bgUnits,
+        value: `${thresholds.veryHighThreshold}`,
+      },
+    };
+  }
+
   return {
     veryLow: `below ${thresholds.veryLowThreshold} ${bgUnits}`,
     low: `between ${thresholds.veryLowThreshold} - ${thresholds.targetLowerBound} ${bgUnits}`,

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -209,6 +209,43 @@ describe('blood glucose utilities', () => {
       });
     });
 
+    it('should generate segmented formatted range labels for mg/dL BG prefs when segmented option set', () => {
+      const bgPrefs = {
+        bgBounds: bounds.mgdl,
+        bgUnits: 'mg/dL',
+      };
+
+      const result = bgUtils.generateBgRangeLabels(bgPrefs, { segmented: true });
+
+      expect(result).to.eql({
+        veryLow: {
+          prefix: 'below',
+          suffix: bgPrefs.bgUnits,
+          value: '55',
+        },
+        low: {
+          prefix: 'between',
+          suffix: bgPrefs.bgUnits,
+          value: '55-70',
+        },
+        target: {
+          prefix: 'between',
+          suffix: bgPrefs.bgUnits,
+          value: '70-180',
+        },
+        high: {
+          prefix: 'between',
+          suffix: bgPrefs.bgUnits,
+          value: '180-300',
+        },
+        veryHigh: {
+          prefix: 'above',
+          suffix: bgPrefs.bgUnits,
+          value: '300',
+        },
+      });
+    });
+
     it('should generate formatted range labels for mmol/L BG prefs', () => {
       const bgPrefs = {
         bgBounds: bounds.mmoll,
@@ -240,6 +277,43 @@ describe('blood glucose utilities', () => {
         target: '3.9-10.0',
         high: '10.0-16.7',
         veryHigh: '>16.7',
+      });
+    });
+
+    it('should generate segmented formatted range labels for mmol/L BG prefs when segmented option set', () => {
+      const bgPrefs = {
+        bgBounds: bounds.mmoll,
+        bgUnits: 'mmol/L',
+      };
+
+      const result = bgUtils.generateBgRangeLabels(bgPrefs, { segmented: true });
+
+      expect(result).to.eql({
+        veryLow: {
+          prefix: 'below',
+          suffix: bgPrefs.bgUnits,
+          value: '3.1',
+        },
+        low: {
+          prefix: 'between',
+          suffix: bgPrefs.bgUnits,
+          value: '3.1-3.9',
+        },
+        target: {
+          prefix: 'between',
+          suffix: bgPrefs.bgUnits,
+          value: '3.9-10.0',
+        },
+        high: {
+          prefix: 'between',
+          suffix: bgPrefs.bgUnits,
+          value: '10.0-16.7',
+        },
+        veryHigh: {
+          prefix: 'above',
+          suffix: bgPrefs.bgUnits,
+          value: '16.7',
+        },
       });
     });
   });


### PR DESCRIPTION
to support [WEB-1695], adds a new `segmented` option for generating range labels
paired with https://github.com/tidepool-org/blip/pull/1087
[WEB-1695]: https://tidepool.atlassian.net/browse/WEB-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ