### PR TITLE
[WEB-1593] Fix issue where aggregations by date were being stored under the incorrect date key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.33.2",
+  "version": "1.34.0-web-1593-daily-view-offset-date-stats.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"


### PR DESCRIPTION
[WEB-1593]
Basically, the aggregation utility doesn't create a date key for each date in the given range -- only those with data of some sort.  This would cause the stat aggregations in the daily print views to show summaries for the wrong day in the event that there were days missing data.

[WEB-1593]: https://tidepool.atlassian.net/browse/WEB-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ