### PR TITLE
[WEB-2055] Fix for checking whether or not a basics section has data or not

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.35.0-web-2348-tide-cohort-tables.1",
+  "version": "1.35.0-web-2055-basics-basals-updates.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -233,8 +233,8 @@ export function processBasicsAggregations(aggregations, data, patient, manufactu
   /* eslint-disable no-param-reassign, max-len */
   const aggregationData = _.cloneDeep(data);
 
-  const hasDataInRange = processedData => (
-    processedData && (_.keys(processedData.byDate).length > 0)
+  const hasDataInRange = (processedData = {}) => (
+    _.get(processedData.summary, 'total', _.keys(processedData.byDate).length) > 0
   );
 
   const getEmptyText = (aggregation, aggregationKey) => {

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -83,7 +83,7 @@ const oneWeekDates = [
   },
 ];
 
-describe('basics data utils', () => {
+describe.only('basics data utils', () => {
   describe('defineBasicsAggregations', () => {
     const sectionNames = [
       'basals',
@@ -312,6 +312,21 @@ describe('basics data utils', () => {
 
       // fingersticks gets disabled when no data
       expect(result.fingersticks.disabled).to.be.true;
+    });
+
+    it('should prioritize checking summary.total over existence oc byDate keys to check data availability', () => {
+      const aggregationsData = {
+        ...data,
+        basals: {
+          basal: { byDate: { dateKey1: {}, dateKey2: {} }, summary: { total: 0 } },
+          automatedSuspend: { byDate: {} },
+        },
+        boluses: { byDate: { dateKey1: {}, dateKey2: {} } },
+      };
+      const result = dataUtils.processBasicsAggregations(aggregations, aggregationsData, patient, manufacturer);
+
+      expect(result.basals.disabled).to.be.true;
+      expect(result.boluses.disabled).to.be.false;
     });
 
     it('should set empty text for sections for which there is no data available', () => {

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -314,7 +314,7 @@ describe('basics data utils', () => {
       expect(result.fingersticks.disabled).to.be.true;
     });
 
-    it('should prioritize checking summary.total over existence oc byDate keys to check data availability', () => {
+    it('should prioritize checking summary.total over existence of byDate keys to check data availability', () => {
       const aggregationsData = {
         ...data,
         basals: {

--- a/test/utils/basics/data.test.js
+++ b/test/utils/basics/data.test.js
@@ -83,7 +83,7 @@ const oneWeekDates = [
   },
 ];
 
-describe.only('basics data utils', () => {
+describe('basics data utils', () => {
   describe('defineBasicsAggregations', () => {
     const sectionNames = [
       'basals',


### PR DESCRIPTION
[WEB-2055]

The function that checks for the existence of data for a given Basics section now prioritizes checking the `summary.total` value, when available, which is more dependable than counting the aggregated data by date keys, which can be present, but have no data within them.

Related PR: https://github.com/tidepool-org/blip/pull/1267

[WEB-2055]: https://tidepool.atlassian.net/browse/WEB-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ