### PR TITLE
[WEB-2503,WEB-2504,WEB-2506] Fix bugs in matched device generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.35.0-rc.1",
+  "version": "1.35.0-rc.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/AggregationUtil.js
+++ b/src/utils/AggregationUtil.js
@@ -44,7 +44,6 @@ export class AggregationUtil {
 
   aggregateBasals = group => {
     this.dataUtil.filter.byType('basal');
-    this.dataUtil.filter.byDeviceIds(this.excludedDevices);
 
     let reducer = reductio();
     reducer.dataList(true);
@@ -81,7 +80,6 @@ export class AggregationUtil {
 
   aggregateBoluses = group => {
     this.dataUtil.filter.byType('bolus');
-    this.dataUtil.filter.byDeviceIds(this.excludedDevices);
 
     const reducer = reductio();
     reducer.dataList(true);
@@ -106,7 +104,6 @@ export class AggregationUtil {
 
   aggregateFingersticks = group => {
     this.dataUtil.filter.byType('smbg');
-    this.dataUtil.filter.byDeviceIds(this.excludedDevices);
 
     let reducer = reductio();
     reducer.dataList(true);
@@ -151,7 +148,6 @@ export class AggregationUtil {
 
   aggregateSiteChanges = group => {
     this.dataUtil.filter.byType('deviceEvent');
-    this.dataUtil.filter.byDeviceIds(this.excludedDevices);
 
     const reducer = reductio();
     reducer.dataList(true);
@@ -172,7 +168,6 @@ export class AggregationUtil {
   aggregateDataByDate = group => {
     const types = _.map(this.dataUtil.types, d => d.type);
     this.dataUtil.filter.byTypes(types);
-    this.dataUtil.filter.byDeviceIds(this.excludedDevices);
 
     const reducer = reductio();
     reducer.dataList(true);
@@ -183,7 +178,6 @@ export class AggregationUtil {
   };
 
   aggregateStatsByDate = group => {
-    this.dataUtil.filter.byDeviceIds(this.excludedDevices);
     const reducer = reductio();
     reducer.dataList(true);
 
@@ -457,7 +451,6 @@ export class AggregationUtil {
         }
       });
     });
-
 
     return {
       byDate: processedData,

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -488,7 +488,7 @@ export function basicsText(patient, data, stats, aggregations) {
     );
   }
 
-  const devices = _.filter(metaData?.devices, ({ id }) => metaData?.matchedDevices[id]);
+  const devices = _.filter(metaData?.devices, ({ id }) => metaData?.matchedDevices?.[id]);
 
   if (devices.length) {
     const textLines = [

--- a/src/utils/bgLog/data.js
+++ b/src/utils/bgLog/data.js
@@ -59,7 +59,7 @@ export function bgLogText(patient, data, stats) {
   ].join('\t'))).join('\n');
 
 
-  const devices = _.filter(metaData?.devices, ({ id }) => metaData?.matchedDevices[id]);
+  const devices = _.filter(metaData?.devices, ({ id }) => metaData?.matchedDevices?.[id]);
 
   if (devices.length) {
     const textLines = [

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -92,6 +92,7 @@ export function trendsText(patient, data, stats, chartPrefs) {
       },
     },
     metaData,
+    query,
     timePrefs,
   } = data;
 
@@ -109,7 +110,14 @@ export function trendsText(patient, data, stats, chartPrefs) {
 
   trendsString += utils.statsText(stats, textUtil, bgPrefs);
 
-  const devices = _.filter(metaData?.devices, ({ id }) => metaData?.matchedDevices[id]);
+  const bgSourceDeviceTypeMap = {
+    cbg: 'cgm',
+    smbg: 'bgm',
+  };
+
+  const devices = _.filter(metaData?.devices, device => (
+    metaData?.matchedDevices?.[device.id] && device[bgSourceDeviceTypeMap[query?.bgSource]]
+  ));
 
   if (devices.length) {
     const textLines = [

--- a/src/utils/trends/data.js
+++ b/src/utils/trends/data.js
@@ -115,8 +115,11 @@ export function trendsText(patient, data, stats, chartPrefs) {
     smbg: 'bgm',
   };
 
+  // Only match pumps or devices that match the currently selected bg source
   const devices = _.filter(metaData?.devices, device => (
-    metaData?.matchedDevices?.[device.id] && device[bgSourceDeviceTypeMap[query?.bgSource]]
+    metaData?.matchedDevices?.[device.id] && (
+      device.pump || device[bgSourceDeviceTypeMap[query?.bgSource]]
+    )
   ));
 
   if (devices.length) {

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -471,27 +471,22 @@ describe('DataUtil', () => {
       expect(dataUtil.latestDatumByType.wizard.id).to.eql(newWizard.id);
     });
 
-    it('should create and/or update the `matchedDevices`', () => {
+    it('should initialize the `matchedDevices` property if not already set', () => {
+      // Initialize if undefined
       delete dataUtil.matchedDevices;
       expect(dataUtil.matchedDevices).to.be.undefined;
 
       dataUtil.addData(defaultData, defaultPatientId);
 
-      expect(dataUtil.matchedDevices).to.eql({
-        'Test Page Data - 123': true,
-        'Dexcom-XXX-XXXX': true,
-        DevId0987654321: true,
-      });
+      expect(dataUtil.matchedDevices).to.eql({});
+
+      // Persist if defined
+      dataUtil.matchedDevices = { foo: 'bar' };
 
       const newWizard = new Types.Wizard({ deviceTime: '2018-02-01T04:00:00', ...useRawData, deviceId: 'newDeviceID' });
       dataUtil.addData([newWizard], defaultPatientId);
 
-      expect(dataUtil.matchedDevices).to.eql({
-        'Test Page Data - 123': true,
-        'Dexcom-XXX-XXXX': true,
-        DevId0987654321: true,
-        newDeviceID: true,
-      });
+      expect(dataUtil.matchedDevices).to.eql({ foo: 'bar' });
     });
 
     it('should call `normalizeDatumIn` on each incoming datum', () => {
@@ -1136,19 +1131,6 @@ describe('DataUtil', () => {
       dataUtil.normalizeDatumOut(datum, fields);
 
       sinon.assert.calledWith(dataUtil.normalizeDatumOutTime, datum, fields);
-    });
-
-    it('should add newly-encountered device Ids to the `matchedDevices` property', () => {
-      const datum1 = { type: 'foo', deviceId: 'foo' };
-      const datum2 = { type: 'bar', deviceId: 'bar' };
-
-      dataUtil.matchedDevices = {};
-
-      dataUtil.normalizeDatumOut(datum1);
-      expect(dataUtil.matchedDevices).to.eql({ foo: true });
-
-      dataUtil.normalizeDatumOut(datum2);
-      expect(dataUtil.matchedDevices).to.eql({ foo: true, bar: true });
     });
 
     it('should add the `deviceSerialNumber` from the `uploadMap` when `uploadId` is present and the field is requested', () => {
@@ -3110,13 +3092,13 @@ describe('DataUtil', () => {
         dataUtil.clearFilters,
         dataUtil.setBgSources,
         dataUtil.clearFilters,
+        dataUtil.clearMatchedDevices,
         dataUtil.setTypes,
         dataUtil.setBgPrefs,
         dataUtil.setTimePrefs,
         dataUtil.setEndpoints,
         dataUtil.setActiveDays,
         dataUtil.setExcludedDevices,
-        dataUtil.clearMatchedDevices,
       );
     });
 
@@ -3667,12 +3649,7 @@ describe('DataUtil', () => {
       ]);
 
       expect(result.excludedDevices).to.eql([]);
-
-      expect(result.matchedDevices).to.eql({
-        'Test Page Data - 123': true,
-        'Dexcom-XXX-XXXX': true,
-        DevId0987654321: true,
-      });
+      expect(result.matchedDevices).to.eql({});
     });
 
     it('should return metaData requested via a string', () => {

--- a/test/utils/trends/data.test.js
+++ b/test/utils/trends/data.test.js
@@ -144,15 +144,17 @@ describe('[trends] data utils', () => {
       timePrefs,
       metaData: {
         devices: [
-          { id: 'deviceWithLabelId', label: 'Device With Label' },
-          { id: 'deviceWithoutLabelId' },
-          { id: 'deviceNotUsedInCurrentDataId' },
+          { id: 'deviceWithLabelId', label: 'Device With Label', pump: true, cgm: false, bgm: false },
+          { id: 'deviceWithoutLabelId', pump: false, cgm: true, bgm: false },
+          { id: 'deviceNotUsedInCurrentDataId', pump: false, cgm: true, bgm: false },
+          { id: 'deviceNotMatchingCurrentBgSource', pump: false, cgm: false, bgm: true },
         ],
         matchedDevices: {
           deviceWithLabelId: true,
           deviceWithoutLabelId: true,
         },
       },
+      query: { bgSource: 'cbg' },
     };
 
     let textUtilStub;
@@ -231,6 +233,7 @@ describe('[trends] data utils', () => {
       sinon.assert.calledWith(textUtilStub.buildTextLine, 'Device With Label');
       sinon.assert.calledWith(textUtilStub.buildTextLine, 'deviceWithoutLabelId');
       sinon.assert.neverCalledWith(textUtilStub.buildTextLine, 'deviceNotUsedInCurrentDataId');
+      sinon.assert.neverCalledWith(textUtilStub.buildTextLine, 'deviceNotMatchingCurrentBgSource');
     });
   });
 });


### PR DESCRIPTION
[WEB-2503], [WEB-2504], [WEB-2506] 
Related PR: https://github.com/tidepool-org/blip/pull/1272

The previous method of determining matched devices as datums were normalized was insufficient.

It left many edge cases, especially for stat and aggregations, where it would work in some cases where data happened to be normalized as part of the stat generation process, but it wasn't guaranteed.

This now uses a crossfilter change handler that will generate the matched devices whenever the `byType` filter is changed to any datum types we visualize.  I'm using a `matchDevices` property on the DataUtil to control when this behavior occurs since we only want to do this while generating data for the `current` range period, and not the `prev` and `next` ones that get generated for some of the data views.

We also needed to control when we clear the matched devices, since we don't always query for the chart/stat/aggregation data in the same calls.

One final change that I implemented during the course of development was to remove some redundant `byDeviceId` excluded devices filters in the `AggregationUtil`, since they will always be already filtered out in `DataUtil.query` prior to the individual aggregations being generated.

[WEB-2503]: https://tidepool.atlassian.net/browse/WEB-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-2506]: https://tidepool.atlassian.net/browse/WEB-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WEB-2504]: https://tidepool.atlassian.net/browse/WEB-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ