### PR TITLE
[WEB-2620] Fix bgm count for basics readings in range stat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.37.0-rc.3",
+  "version": "1.37.0-rc.4",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/viz",
-  "version": "1.37.0-rc.2",
+  "version": "1.37.0-rc.3",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -241,7 +241,7 @@ class BasicsPrintView extends PrintView {
             text: 'BG Distribution',
             note: t('{{source}} data from {{count}} readings', {
               source: statBgSourceLabels[this.bgSource],
-              count: readingsInRange.data?.raw?.total,
+              count: readingsInRange.data?.raw?.counts?.total,
             }),
           },
           secondaryFormatKey: 'tooltip',

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -834,8 +834,8 @@ class BasicsPrintView extends PrintView {
       });
 
       const tableColumns = this.defineStatColumns({
-        labelWidth: columnWidth * 0.8,
-        valueWidth: columnWidth * 0.2,
+        labelWidth: columnWidth * 0.78,
+        valueWidth: columnWidth * 0.22,
         height: 20,
         labelHeader: primaryDimension.label,
         valueHeader: (primaryDimension.value || 0).toString(),

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -398,7 +398,7 @@ export const getStatAnnotations = (data, type, opts = {}) => {
     annotations.push(t('**Why is this stat empty?**\n\nThere is not enough data present in this view to calculate it.'));
   } else if (_.includes(bgStats, type)) {
     if (bgSource === 'smbg') {
-      annotations.push(t('Derived from _**{{total}}**_ {{smbgLabel}} readings.', { total: data.total, smbgLabel: statBgSourceLabels.smbg }));
+      annotations.push(t('Derived from _**{{total}}**_ {{smbgLabel}} readings.', { total: _.get(data, 'counts.total', data.total), smbgLabel: statBgSourceLabels.smbg }));
     }
   }
 

--- a/test/modules/print/BasicsPrintView.test.js
+++ b/test/modules/print/BasicsPrintView.test.js
@@ -956,8 +956,8 @@ describe('BasicsPrintView', () => {
 
       sinon.assert.calledOnce(Renderer.defineStatColumns);
       sinon.assert.calledWith(Renderer.defineStatColumns, {
-        labelWidth: 80,
-        valueWidth: 20,
+        labelWidth: 78,
+        valueWidth: 22,
         height: 20,
         labelHeader: 'Total basal events',
         valueHeader: '10',

--- a/test/modules/print/BasicsPrintView.test.js
+++ b/test/modules/print/BasicsPrintView.test.js
@@ -375,11 +375,11 @@ describe('BasicsPrintView', () => {
       Renderer.renderAggregatedStats();
       sinon.assert.neverCalledWith(Renderer.renderHorizontalBarStat, null);
 
-      Renderer.stats.readingsInRange = { data: { raw: { total: 11 } } };
+      Renderer.stats.readingsInRange = { data: { raw: { counts: { total: 11 } } } };
       Renderer.bgSource = 'smbg';
       Renderer.renderAggregatedStats();
       sinon.assert.calledWith(Renderer.renderHorizontalBarStat,
-        { data: { raw: { total: 11 } } },
+        { data: { raw: { counts: { total: 11 } } } },
         {
           heading: {
             text: 'BG Distribution',


### PR DESCRIPTION
[WEB-2620]

Missed updating the data path for counts in the readings in range stat annotations.  Also fixes a small text-wrapping issue on the basics summary tables that I noticed.

Related PR: https://github.com/tidepool-org/blip/pull/1305

[WEB-2620]: https://tidepool.atlassian.net/browse/WEB-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ