### PR TITLE
[WEB-3251] Set latestTimeZone metadata in data worker upon ingestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.42.1-web-3250-tandem-insulin-duration-fix.1",
+  "version": "1.42.1-web-3251-use-dosing-decision-timezone-offset.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -994,9 +994,9 @@ export class DataUtil {
     );
 
     const createLatestTimeZone = (name, d, type) => {
-      d.localizedTime = moment.utc(d.time).tz(name).format();
+      const localizedTime = moment.utc(d.time).tz(name).format();
       latestTimeZone = { name, type: d.type };
-      latestTimeZone.message = t('Defaulting to display in the timezone of most recent {{type}} at {{localizedTime}}', { ...d, type: type || d.type });
+      latestTimeZone.message = t('Defaulting to display in the timezone of most recent {{type}} at {{localizedTime}}', { localizedTime, type: type || d.type });
     };
 
     if (latestTimeZoneOffsetDatum) {

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -2805,6 +2805,177 @@ describe('DataUtil', () => {
     });
   });
 
+  describe('setLatestDiabetesDatumEnd', () => {
+    it('should be set to the most recent diabetes datum time', () => {
+      initDataUtil([
+        { ...new Types.Bolus({ ...useRawData }), time: '2024-01-01T10:00:00.000Z' },
+        { ...new Types.CBG({ ...useRawData }), time: '2024-01-01T11:00:00.000Z' },
+        { ...new Types.Bolus({ ...useRawData }), time: '2024-01-01T12:00:00.000Z' },
+      ]);
+
+      delete(dataUtil.latestDiabetesDatumEnd);
+      dataUtil.setLatestDiabetesDatumEnd();
+      expect(moment(dataUtil.latestDiabetesDatumEnd).toISOString()).to.eql('2024-01-01T12:00:00.000Z');
+    });
+
+    it('should be set to the most recent diabetes datum time + duration', () => {
+      initDataUtil([
+        { ...new Types.Bolus({ ...useRawData }), time: '2024-01-01T10:00:00.000Z' },
+        { ...new Types.Basal({ ...useRawData }), time: '2024-01-01T11:00:00.000Z', duration: MS_IN_MIN * 61 },
+        { ...new Types.Bolus({ ...useRawData }), time: '2024-01-01T12:00:00.000Z' },
+      ]);
+
+      delete(dataUtil.latestDiabetesDatumEnd);
+      dataUtil.setLatestDiabetesDatumEnd();
+      expect(moment(dataUtil.latestDiabetesDatumEnd).toISOString()).to.eql('2024-01-01T12:01:00.000Z');
+    });
+
+    it('should be set to null if there are no diabetes datums', () => {
+      initDataUtil([
+        { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T10:00:00.000Z' },
+      ]);
+
+      delete(dataUtil.latestDiabetesDatumEnd);
+      dataUtil.setLatestDiabetesDatumEnd();
+      expect(dataUtil.latestDiabetesDatumEnd).to.equal(null);
+    });
+  });
+
+  describe('setLatestTimeZone', () => {
+    context('Timezone offset provided from a recent diabetes datum', () => {
+      it('should set a valid timezone from `latestDiabetesDatum.timezoneOffset`', () => {
+        initDataUtil([
+          // should use this dosing decision even though it's not as recent as the basal, but it has a timezoneOffset
+          { ...new Types.DosingDecision({ ...useRawData }), time: '2024-01-01T10:00:00.000Z', timezoneOffset: -420 },
+          { ...new Types.Basal({ ...useRawData }), time: '2024-01-01T11:00:00.000Z', timezoneOffset: undefined },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('Etc/GMT+7');
+        expect(dataUtil.latestTimeZone.message).to.contain('Defaulting to display in the timezone of most recent dosingDecision at');
+
+
+        // should round to the nearest hour
+        initDataUtil([
+          { ...new Types.DosingDecision({ ...useRawData }), timezoneOffset: -(420 + 29) },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('Etc/GMT+7');
+
+        initDataUtil([
+          { ...new Types.DosingDecision({ ...useRawData }), timezoneOffset: -(420 + 30) },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('Etc/GMT+8');
+      });
+
+      it('should prefer a more recent latestUpload with a timezone', () => {
+        initDataUtil([
+          { ...new Types.DosingDecision({ ...useRawData }), time: '2024-01-01T10:00:00.000Z', timezoneOffset: -420 },
+          { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T11:00:00.000Z', timezone: 'US/Pacific' },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('US/Pacific');
+        expect(dataUtil.latestTimeZone.message).to.contain('Defaulting to display in the timezone of most recent upload at');
+      });
+
+      it('should prefer an older latestUpload with a timezone if it matches the timezoneOffset at the time of the latest datum', () => {
+        initDataUtil([
+          { ...new Types.DosingDecision({ ...useRawData }), time: '2024-01-01T10:00:00.000Z', timezoneOffset: -420 },
+          // should use this older upload since it has the same timezoneOffset
+          { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T09:00:00.000Z', timezone: 'US/Mountain' },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('US/Mountain');
+        expect(dataUtil.latestTimeZone.message).to.contain('Defaulting to display in the timezone of most recent upload at');
+
+        initDataUtil([
+          { ...new Types.DosingDecision({ ...useRawData }), time: '2024-01-01T10:00:00.000Z', timezoneOffset: -420 },
+          // should not use this older upload since it has a different timezoneOffset
+          { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T09:00:00.000Z', timezone: 'US/Pacific' },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('Etc/GMT+7');
+        expect(dataUtil.latestTimeZone.message).to.contain('Defaulting to display in the timezone of most recent dosingDecision at');
+      });
+
+      it('should return undefined when given an invalid timezone offset', () => {
+        initDataUtil([
+          { ...new Types.CBG({ ...useRawData }), timezoneOffset: -1000 },
+        ]);
+
+        sinon.spy(dataUtil, 'log');
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone).to.be.undefined;
+        sinon.assert.calledWith(dataUtil.log, 'Invalid latest time zone:', 'Etc/GMT+17');
+      });
+    });
+
+    context('Timezone provided from a timechange event', () => {
+      it('should set a valid timezone from `latestDiabetesDatum.timezoneOffset`', () => {
+        initDataUtil([
+          { ...new Types.DeviceEvent({ ...useRawData }), subType: 'timeChange', time: '2024-01-01T10:00:00.000Z', to: { timeZoneName: 'Europe/Budapest' } },
+          { ...new Types.Basal({ ...useRawData }), time: '2024-01-01T11:00:00.000Z', timezoneOffset: undefined },
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('Europe/Budapest');
+        expect(dataUtil.latestTimeZone.message).to.contain('Defaulting to display in the timezone of most recent time change at');
+      });
+
+      it('should returned undefined when given an invalid timezone name', () => {
+        initDataUtil([
+          { ...new Types.DeviceEvent({ ...useRawData }), subType: 'timeChange', time: '2024-01-01T10:00:00.000Z', to: { timeZoneName: 'foo/bar' } },
+        ]);
+
+        sinon.spy(dataUtil, 'log');
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone).to.be.undefined;
+        sinon.assert.calledWith(dataUtil.log, 'Invalid latest time zone:', 'foo/bar');
+      });
+    });
+
+    context('Timezone provided from a recent upload event', () => {
+      it('should set a valid timezone from `latestDiabetesDatum.timezoneOffset`', () => {
+        initDataUtil([
+          { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T10:00:00.000Z', timezone: 'Europe/Budapest' },
+          { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T11:00:00.000Z', timezone: 'US/Pacific' }, // more recent
+        ]);
+
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone.name).to.eql('US/Pacific');
+        expect(dataUtil.latestTimeZone.message).to.contain('Defaulting to display in the timezone of most recent upload at');
+      });
+
+      it('should returned undefined when given an invalid timezone name', () => {
+        initDataUtil([
+          { ...new Types.Upload({ ...useRawData }), time: '2024-01-01T11:00:00.000Z', timezone: 'bar/baz' },
+        ]);
+
+        sinon.spy(dataUtil, 'log');
+        delete(dataUtil.latestTimeZone);
+        dataUtil.setLatestTimeZone();
+        expect(dataUtil.latestTimeZone).to.be.undefined;
+        sinon.assert.calledWith(dataUtil.log, 'Invalid latest time zone:', 'bar/baz');
+      });
+    });
+  });
+
   describe('setSize', () => {
     it('should set the size property to the current data count', () => {
       const deviceEvents = [
@@ -2912,6 +3083,8 @@ describe('DataUtil', () => {
       sinon.spy(dataUtil, 'setDevices');
       sinon.spy(dataUtil, 'setLatestPumpUpload');
       sinon.spy(dataUtil, 'setIncompleteSuspends');
+      sinon.spy(dataUtil, 'setLatestDiabetesDatumEnd');
+      sinon.spy(dataUtil, 'setLatestTimeZone');
 
       dataUtil.setMetaData();
 
@@ -2926,6 +3099,8 @@ describe('DataUtil', () => {
       sinon.assert.calledOnce(dataUtil.setDevices);
       sinon.assert.calledOnce(dataUtil.setLatestPumpUpload);
       sinon.assert.calledOnce(dataUtil.setIncompleteSuspends);
+      sinon.assert.calledOnce(dataUtil.setLatestDiabetesDatumEnd);
+      sinon.assert.calledOnce(dataUtil.setLatestTimeZone);
 
       sinon.assert.callOrder(dataUtil.setEndpoints, dataUtil.setActiveDays);
     });

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -627,6 +627,7 @@ describe('DataUtil', () => {
         'bgSources',
         'latestDatumByType',
         'latestPumpUpload',
+        'latestTimeZone',
         'patientId',
         'size',
         'queryDataCount',


### PR DESCRIPTION
[WEB-3251] Will go out as part of `1.81.1` hotfix

Moved the general logic for determining the ideal timezone based on data from blip to the data worker here, as well as including the latest `dosingDecision` datums, and `timeChange` device events to address Loop and Apple Health datasets falling back to browser timezone.

The data util seems to me like a better place to do this, and we would have had to send additional data out to blip anyhow in order to utlilze the latest time change data as a potential fallback for Apple Health-only datasets. 

Also added some missing unit tests for `DataUtil.setLatestDiabetesDatumEnd` that missed adding during `1.81.0` development.

[WEB-3251]: https://tidepool.atlassian.net/browse/WEB-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ