### PR TITLE
[WEB-3179] dep updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.44.0",
+  "version": "1.44.0-web-3179-dep-updates.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"
@@ -88,8 +88,8 @@
     "text-table": "0.2.0",
     "translate-svg-path": "0.0.1",
     "util": "0.12.5",
-    "victory": "31.3.0",
-    "victory-core": "31.2.0",
+    "victory": "32.0.0",
+    "victory-core": "32.0.0",
     "voilab-pdf-table": "0.5.1"
   },
   "devDependencies": {
@@ -166,7 +166,7 @@
     "babel-core": "6.x || ^7.0.0-bridge.0",
     "classnames": "2.x",
     "react": "16.x",
-    "react-addons-update": "16.x",
+    "react-addons-update": "15.6.x",
     "react-dom": "16.x",
     "react-redux": "8.x",
     "redux": "4.x"

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "text-table": "0.2.0",
     "translate-svg-path": "0.0.1",
     "util": "0.12.5",
-    "victory": "33.0.0",
-    "victory-core": "33.0.0",
+    "victory": "37.3.5",
+    "victory-core": "37.3.5",
     "voilab-pdf-table": "0.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.44.0-web-3179-dep-updates.1",
+  "version": "1.44.0-web-3179-dep-updates.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "text-table": "0.2.0",
     "translate-svg-path": "0.0.1",
     "util": "0.12.5",
-    "victory": "32.0.0",
-    "victory-core": "32.0.0",
+    "victory": "33.0.0",
+    "victory-core": "33.0.0",
     "voilab-pdf-table": "0.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.44.0-web-3179-dep-updates.2",
+  "version": "1.44.0-web-3179-dep-updates.3",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/stat/BgBar.js
+++ b/src/components/common/stat/BgBar.js
@@ -32,7 +32,7 @@ export const BgBar = props => {
   const widths = {
     low: scale.y(bgBounds.targetLowerBound) * widthCorrection,
     target: scale.y(bgBounds.targetUpperBound - bgBounds.targetLowerBound) * widthCorrection,
-    high: scale.y(domain.x[1] - bgBounds.targetUpperBound) * widthCorrection,
+    high: scale.y(domain.y[1] - bgBounds.targetUpperBound) * widthCorrection,
   };
 
   const barRadius = barWidth / 2;

--- a/src/components/common/stat/BgBarLabel.js
+++ b/src/components/common/stat/BgBarLabel.js
@@ -27,6 +27,7 @@ export const BgBarLabel = props => {
         verticalAnchor="middle"
         dy={-(barWidth / 2 - 1)}
         x={scale.y(domain.y[1])}
+        dx={0}
       />
     </g>
   );

--- a/src/components/common/stat/BgBarLabel.js
+++ b/src/components/common/stat/BgBarLabel.js
@@ -26,7 +26,7 @@ export const BgBarLabel = props => {
         textAnchor="end"
         verticalAnchor="middle"
         dy={-(barWidth / 2 - 1)}
-        x={scale.y(domain.x[1])}
+        x={scale.y(domain.y[1])}
       />
     </g>
   );

--- a/src/components/common/stat/HoverBar.js
+++ b/src/components/common/stat/HoverBar.js
@@ -40,6 +40,7 @@ export const HoverBar = props => {
             stroke: 'transparent',
             fill: 'transparent',
           }}
+          {...props.events}
         />
       </g>
       <g className="barBg" pointerEvents="none">

--- a/src/components/common/stat/HoverBar.js
+++ b/src/components/common/stat/HoverBar.js
@@ -18,7 +18,7 @@ export const HoverBar = props => {
       y: _.noop,
     },
     width,
-    y,
+    x
   } = props;
 
   const barGridWidth = barWidth / 6;
@@ -34,7 +34,7 @@ export const HoverBar = props => {
           y={scale.x(index + 1) - (barWidth / 2) - (barSpacing / 2)}
           rx={barGridRadius}
           ry={barGridRadius}
-          width={scale.y(domain.x[1])}
+          width={scale.y(domain.y[1])}
           height={barWidth + barSpacing}
           style={{
             stroke: 'transparent',
@@ -49,7 +49,7 @@ export const HoverBar = props => {
           y={scale.x(index + 1) - (barGridWidth / 2)}
           rx={barGridRadius}
           ry={barGridRadius}
-          width={scale.y(domain.x[1]) - chartLabelWidth}
+          width={scale.y(domain.y[1]) - chartLabelWidth}
           height={barGridWidth}
           style={{
             stroke: 'transparent',
@@ -61,7 +61,7 @@ export const HoverBar = props => {
         <Bar
           {...props}
           width={scale.y(domain.x[1]) - chartLabelWidth}
-          y={y * widthCorrection}
+          x={x * widthCorrection}
         />
       </g>
     </g>

--- a/src/components/common/stat/HoverBarLabel.js
+++ b/src/components/common/stat/HoverBarLabel.js
@@ -20,6 +20,12 @@ export const HoverBarLabel = props => {
     style = {},
     text,
     tooltipText,
+    // Victory animate sometimes passes undefined to the y prop which errors out the label rendering
+    // but eventually settles on the correct value for the final render, but we default to 15 (the lowest
+    // common observed value) to avoid the error
+    // There's a lot of strange behavior with animate and it's being completely rewritten
+    // see: https://github.com/FormidableLabs/victory/issues/2104
+    y = 15,
   } = props;
 
   const tooltipFontSize = _.min([barWidth / 2, 12]);
@@ -68,6 +74,7 @@ export const HoverBarLabel = props => {
         textAnchor="end"
         verticalAnchor="middle"
         x={scale.y(domain.y[1])}
+        y={y}
         dx={-(labelUnitsTextSize.width * 1.9)}
       />
       <VictoryLabel
@@ -78,6 +85,7 @@ export const HoverBarLabel = props => {
         textAnchor="end"
         verticalAnchor="middle"
         x={scale.y(domain.y[1])}
+        y={y}
         dx={0}
       />
       {tooltipTextSize.width > 0 && (
@@ -86,6 +94,7 @@ export const HoverBarLabel = props => {
           cornerRadius={tooltipRadius}
           datum={tooltipDatum}
           x={scale.y(domain.y[1]) - style.paddingLeft - tooltipTextSize.width - (tooltipRadius * 2)}
+          y={y}
           dx={0}
           flyoutStyle={{
             display: disabled ? 'none' : 'inherit',

--- a/src/components/common/stat/HoverBarLabel.js
+++ b/src/components/common/stat/HoverBarLabel.js
@@ -82,14 +82,15 @@ export const HoverBarLabel = props => {
           cornerRadius={tooltipRadius}
           datum={tooltipDatum}
           x={scale.y(domain.y[1]) - style.paddingLeft - tooltipTextSize.width - (tooltipRadius * 2)}
+          dx={0}
           flyoutStyle={{
             display: disabled ? 'none' : 'inherit',
             stroke: colors.axis,
             strokeWidth: 2,
             fill: colors.white,
           }}
-          width={tooltipTextSize.width + (tooltipRadius * 2)}
-          height={tooltipHeight}
+          flyoutWidth={tooltipTextSize.width + (tooltipRadius * 2)}
+          flyoutHeight={tooltipHeight}
           pointerLength={0}
           pointerWidth={0}
           renderInPortal={false}

--- a/src/components/common/stat/HoverBarLabel.js
+++ b/src/components/common/stat/HoverBarLabel.js
@@ -54,7 +54,11 @@ export const HoverBarLabel = props => {
     _y: _.max([datum._y, 0]),
   };
 
-  return (
+  // Victory animate sometimes passes undefined to the y prop which errors out the label rendering
+  // but eventually settles on the correct value for the final render
+  // There's a lot of strange behavior with animate and it's being completely rewritten
+  // see: https://github.com/FormidableLabs/victory/issues/2104
+  return props.y ? (
     <g className="HoverBarLabel">
       <VictoryLabel
         {...props}
@@ -99,7 +103,7 @@ export const HoverBarLabel = props => {
         />
       )}
     </g>
-  );
+  ) : null;
 };
 
 HoverBarLabel.propTypes = {

--- a/src/components/common/stat/HoverBarLabel.js
+++ b/src/components/common/stat/HoverBarLabel.js
@@ -60,11 +60,7 @@ export const HoverBarLabel = props => {
     _y: _.max([datum._y, 0]),
   };
 
-  // Victory animate sometimes passes undefined to the y prop which errors out the label rendering
-  // but eventually settles on the correct value for the final render
-  // There's a lot of strange behavior with animate and it's being completely rewritten
-  // see: https://github.com/FormidableLabs/victory/issues/2104
-  return props.y ? (
+  return (
     <g className="HoverBarLabel">
       <VictoryLabel
         {...props}
@@ -112,7 +108,7 @@ export const HoverBarLabel = props => {
         />
       )}
     </g>
-  ) : null;
+  );
 };
 
 HoverBarLabel.propTypes = {

--- a/src/components/common/stat/HoverBarLabel.js
+++ b/src/components/common/stat/HoverBarLabel.js
@@ -63,7 +63,7 @@ export const HoverBarLabel = props => {
         style={labelStyle}
         textAnchor="end"
         verticalAnchor="middle"
-        x={scale.y(domain.x[1])}
+        x={scale.y(domain.y[1])}
         dx={-(labelUnitsTextSize.width * 1.9)}
       />
       <VictoryLabel
@@ -73,7 +73,7 @@ export const HoverBarLabel = props => {
         style={labelUnitsStyle}
         textAnchor="end"
         verticalAnchor="middle"
-        x={scale.y(domain.x[1])}
+        x={scale.y(domain.y[1])}
         dx={0}
       />
       {tooltipTextSize.width > 0 && (
@@ -81,7 +81,7 @@ export const HoverBarLabel = props => {
           {...props}
           cornerRadius={tooltipRadius}
           datum={tooltipDatum}
-          x={scale.y(domain.x[1]) - style.paddingLeft - tooltipTextSize.width - (tooltipRadius * 2)}
+          x={scale.y(domain.y[1]) - style.paddingLeft - tooltipTextSize.width - (tooltipRadius * 2)}
           flyoutStyle={{
             display: disabled ? 'none' : 'inherit',
             stroke: colors.axis,

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -502,7 +502,7 @@ class Stat extends PureComponent {
               barWidth={barWidth}
               bgPrefs={props.bgPrefs}
               domain={domain}
-              text={(datum = {}) => {
+              text={({datum={}}) => {
                 const datumRef = _.get(chartData, datum.index, datum);
                 const { value } = formatDatum(
                   _.get(datumRef, 'deviation', datumRef),
@@ -511,7 +511,7 @@ class Stat extends PureComponent {
                 );
                 return `${value}`;
               }}
-              tooltipText={(datum = {}) => {
+              tooltipText={({datum = {}}) => {
                 const { value, suffix } = formatDatum(
                   _.get(chartData, datum.index, datum),
                   props.dataFormat.tooltip,
@@ -525,11 +525,11 @@ class Stat extends PureComponent {
           renderer: VictoryBar,
           style: {
             data: {
-              fill: datum => this.getDatumColor(datum),
+              fill: ({datum}) => this.getDatumColor(datum),
               width: () => barWidth,
             },
             labels: {
-              fill: datum => this.getDatumColor(_.assign({}, datum, formatDatum(
+              fill: ({datum}) => this.getDatumColor(_.assign({}, datum, formatDatum(
                 datum,
                 props.dataFormat.label,
                 props
@@ -647,11 +647,11 @@ class Stat extends PureComponent {
           renderer: VictoryBar,
           style: {
             data: {
-              fill: datum => (datum._y === 0 ? 'transparent' : this.getDatumColor(datum)),
+              fill: ({datum}) => (datum._y === 0 ? 'transparent' : this.getDatumColor(datum)),
               width: () => barWidth,
             },
             labels: {
-              fill: datum => this.getDatumColor(_.assign({}, datum, formatDatum(
+              fill: ({datum}) => this.getDatumColor(_.assign({}, datum, formatDatum(
                 datum,
                 props.dataFormat.label,
                 props

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -465,8 +465,8 @@ class Stat extends PureComponent {
         height = chartProps.height || barWidth * 6;
 
         domain = {
-          x: [0, bgUnits === MGDL_UNITS ? MGDL_CLAMP_TOP : MMOLL_CLAMP_TOP],
-          y: [0, 1],
+          x: [0, 1],
+          y: [0, bgUnits === MGDL_UNITS ? MGDL_CLAMP_TOP : MMOLL_CLAMP_TOP],
         };
 
         padding = {
@@ -557,8 +557,8 @@ class Stat extends PureComponent {
         }
 
         domain = {
-          x: [0, 1],
-          y: [0, chartData.length],
+          x: [0, chartData.length],
+          y: [0, 1],
         };
 
         padding = {

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -502,7 +502,7 @@ class Stat extends PureComponent {
               barWidth={barWidth}
               bgPrefs={props.bgPrefs}
               domain={domain}
-              text={({datum={}}) => {
+              text={({ datum = {} }) => {
                 const datumRef = _.get(chartData, datum.index, datum);
                 const { value } = formatDatum(
                   _.get(datumRef, 'deviation', datumRef),
@@ -511,7 +511,7 @@ class Stat extends PureComponent {
                 );
                 return `${value}`;
               }}
-              tooltipText={({datum = {}}) => {
+              tooltipText={({ datum = {} }) => {
                 const { value, suffix } = formatDatum(
                   _.get(chartData, datum.index, datum),
                   props.dataFormat.tooltip,
@@ -525,11 +525,11 @@ class Stat extends PureComponent {
           renderer: VictoryBar,
           style: {
             data: {
-              fill: ({datum}) => this.getDatumColor(datum),
+              fill: ({ datum }) => this.getDatumColor(datum),
               width: () => barWidth,
             },
             labels: {
-              fill: ({datum}) => this.getDatumColor(_.assign({}, datum, formatDatum(
+              fill: ({ datum }) => this.getDatumColor(_.assign({}, datum, formatDatum(
                 datum,
                 props.dataFormat.label,
                 props
@@ -647,11 +647,11 @@ class Stat extends PureComponent {
           renderer: VictoryBar,
           style: {
             data: {
-              fill: ({datum}) => (datum._y === 0 ? 'transparent' : this.getDatumColor(datum)),
+              fill: ({ datum }) => (datum._y === 0 ? 'transparent' : this.getDatumColor(datum)),
               width: () => barWidth,
             },
             labels: {
-              fill: ({datum}) => this.getDatumColor(_.assign({}, datum, formatDatum(
+              fill: ({ datum }) => this.getDatumColor(_.assign({}, datum, formatDatum(
                 datum,
                 props.dataFormat.label,
                 props

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -37,6 +37,7 @@ const config = {
         },
       },
       plugins: [...config.plugins, ...custom.plugins],
+      devtool: 'inline-source-map',
     };
 
     return finalConfig;

--- a/test/components/common/stat/BgBar.test.js
+++ b/test/components/common/stat/BgBar.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import _ from 'lodash';
+import { Rect } from 'victory-core';
 
 import BgBar from '../../../../src/components/common/stat/BgBar';
 import colors from '../../../../src/styles/colors.css';
@@ -121,9 +122,9 @@ describe('BgBar', () => {
     it('should render a three-bar scale with arcs on each end', () => {
       expect(bgScale().children()).to.have.length(5);
       expect(bgScale().childAt(0).is('Arc')).to.be.true;
-      expect(bgScale().childAt(1).is('Rect')).to.be.true;
-      expect(bgScale().childAt(2).is('Rect')).to.be.true;
-      expect(bgScale().childAt(3).is('Rect')).to.be.true;
+      expect(bgScale().childAt(1).is(Rect)).to.be.true;
+      expect(bgScale().childAt(2).is(Rect)).to.be.true;
+      expect(bgScale().childAt(3).is(Rect)).to.be.true;
       expect(bgScale().childAt(4).is('Arc')).to.be.true;
     });
 
@@ -221,8 +222,8 @@ describe('BgBar', () => {
 
     it('should render 2 standard deviation markers', () => {
       expect(bgDeviation().children()).to.have.length(2);
-      expect(bgDeviation().childAt(0).is('Rect')).to.be.true;
-      expect(bgDeviation().childAt(1).is('Rect')).to.be.true;
+      expect(bgDeviation().childAt(0).is(Rect)).to.be.true;
+      expect(bgDeviation().childAt(1).is(Rect)).to.be.true;
     });
 
     it('should render the deviation markers with the proper colors', () => {

--- a/test/components/common/stat/BgBar.test.js
+++ b/test/components/common/stat/BgBar.test.js
@@ -45,8 +45,8 @@ describe('BgBar', () => {
     chartLabelWidth: 80,
     datum: avgGlucoseDatum,
     domain: {
-      x: [0, MGDL_CLAMP_TOP],
-      y: [0, 1],
+      x: [0, 1],
+      y: [0, MGDL_CLAMP_TOP],
     },
     scale: {
       x: val => val,

--- a/test/components/common/stat/HoverBar.test.js
+++ b/test/components/common/stat/HoverBar.test.js
@@ -24,7 +24,7 @@ describe('HoverBar', () => {
       y: () => width,
     },
     width,
-    y: 80,
+    x: 80,
   };
 
   beforeEach(() => {
@@ -51,13 +51,13 @@ describe('HoverBar', () => {
     expect(wrapper.find('.barBg').childAt(0).props().width).to.equal(220); // width - chartLabelWidth
   });
 
-  it('should render a bar with a width corresponding to the y prop value, corrected for the rendering area width', () => {
+  it('should render a bar with a width corresponding to the x prop value, corrected for the rendering area width', () => {
     // actual chart rendering width is corrected due to the chart labels taking some space
     const widthCorrection = (width - defaultProps.chartLabelWidth) / width;
     expect(widthCorrection).to.equal(0.7333333333333333); // (220 / 300), as per default props
 
     expect(wrapper.find('Bar')).to.have.length(1);
     expect(wrapper.find('Bar').props().width).to.equal(220);
-    expect(wrapper.find('Bar').props().y).to.equal(58.666666666666664); // (defaultProps.y * widthCorrection)
+    expect(wrapper.find('Bar').props().x).to.equal(58.666666666666664); // (defaultProps.x * widthCorrection)
   });
 });

--- a/test/components/common/stat/HoverBar.test.js
+++ b/test/components/common/stat/HoverBar.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { Bar, Rect } from 'victory';
 
 import HoverBar from '../../../../src/components/common/stat/HoverBar';
 import colors from '../../../../src/styles/colors.css';
@@ -37,7 +38,7 @@ describe('HoverBar', () => {
 
   it('should render a full-width transparent hover target area', () => {
     expect(wrapper.find('.HoverBarTarget')).to.have.length(1);
-    expect(wrapper.find('.HoverBarTarget').childAt(0).is('Rect')).to.be.true;
+    expect(wrapper.find('.HoverBarTarget').childAt(0).is(Rect)).to.be.true;
     expect(wrapper.find('.HoverBarTarget').childAt(0).props().style.stroke).to.equal('transparent');
     expect(wrapper.find('.HoverBarTarget').childAt(0).props().style.fill).to.equal('transparent');
     expect(wrapper.find('.HoverBarTarget').childAt(0).props().width).to.equal(width);
@@ -45,7 +46,7 @@ describe('HoverBar', () => {
 
   it('should render a properly colored bar backround the full width of the rendering area', () => {
     expect(wrapper.find('.barBg')).to.have.length(1);
-    expect(wrapper.find('.barBg').childAt(0).is('Rect')).to.be.true;
+    expect(wrapper.find('.barBg').childAt(0).is(Rect)).to.be.true;
     expect(wrapper.find('.barBg').childAt(0).props().style.stroke).to.equal('transparent');
     expect(wrapper.find('.barBg').childAt(0).props().style.fill).to.equal(colors.axis);
     expect(wrapper.find('.barBg').childAt(0).props().width).to.equal(220); // width - chartLabelWidth
@@ -56,8 +57,8 @@ describe('HoverBar', () => {
     const widthCorrection = (width - defaultProps.chartLabelWidth) / width;
     expect(widthCorrection).to.equal(0.7333333333333333); // (220 / 300), as per default props
 
-    expect(wrapper.find('Bar')).to.have.length(1);
-    expect(wrapper.find('Bar').props().width).to.equal(220);
-    expect(wrapper.find('Bar').props().x).to.equal(58.666666666666664); // (defaultProps.x * widthCorrection)
+    expect(wrapper.find(Bar)).to.have.length(1);
+    expect(wrapper.find(Bar).props().width).to.equal(220);
+    expect(wrapper.find(Bar).props().x).to.equal(58.666666666666664); // (defaultProps.x * widthCorrection)
   });
 });

--- a/test/components/common/stat/Stat.test.js
+++ b/test/components/common/stat/Stat.test.js
@@ -1544,8 +1544,8 @@ describe('Stat', () => {
         const result = instance.getChartPropsByType(instance.props);
 
         expect(result.domain).to.eql({
-          x: [0, MGDL_CLAMP_TOP],
-          y: [0, 1],
+          x: [0, 1],
+          y: [0, MGDL_CLAMP_TOP],
         });
       });
 
@@ -1557,8 +1557,8 @@ describe('Stat', () => {
         const result = instance.getChartPropsByType(instance.props);
 
         expect(result.domain).to.eql({
-          x: [0, MMOLL_CLAMP_TOP],
-          y: [0, 1],
+          x: [0, 1],
+          y: [0, MMOLL_CLAMP_TOP],
         });
       });
 
@@ -1718,8 +1718,8 @@ describe('Stat', () => {
         const result = instance.getChartPropsByType(instance.props);
 
         expect(result.domain).to.eql({
-          x: [0, 1],
-          y: [0, 2],
+          x: [0, 2],
+          y: [0, 1],
         });
 
         // Remove a datum

--- a/test/components/common/stat/Stat.test.js
+++ b/test/components/common/stat/Stat.test.js
@@ -1482,10 +1482,10 @@ describe('Stat', () => {
 
       it('should set `containerComponent` to a non-responsive `VictoryContainer` component', () => {
         const result = instance.getChartPropsByType(instance.props);
-        const containerComponentInstance = shallow(result.containerComponent).instance();
+        const containerComponent = mount(result.containerComponent);
 
-        expect(containerComponentInstance).to.be.instanceOf(VictoryContainer);
-        expect(containerComponentInstance.props.responsive).to.be.false;
+        expect(containerComponent.is(VictoryContainer)).to.be.true;
+        expect(containerComponent.prop('responsive')).to.be.false;
       });
 
       it('should set `dataComponent` to a `BgBar` component with necessary props', () => {
@@ -1657,10 +1657,10 @@ describe('Stat', () => {
 
       it('should set `containerComponent` to a non-responsive `VictoryContainer` component', () => {
         const result = instance.getChartPropsByType(instance.props);
-        const containerComponentInstance = shallow(result.containerComponent).instance();
+        const containerComponent = mount(result.containerComponent);
 
-        expect(containerComponentInstance).to.be.instanceOf(VictoryContainer);
-        expect(containerComponentInstance.props.responsive).to.be.false;
+        expect(containerComponent.is(VictoryContainer)).to.be.true;
+        expect(containerComponent.prop('responsive')).to.be.false;
       });
 
       it('should set `dataComponent` to a `HoverBar` component with necessary props', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,8 +4274,8 @@ __metadata:
     translate-svg-path: 0.0.1
     url-loader: 4.1.1
     util: 0.12.5
-    victory: 33.0.0
-    victory-core: 33.0.0
+    victory: 37.3.5
+    victory-core: 37.3.5
     voilab-pdf-table: 0.5.1
     webpack: 5.94.0
     webpack-cli: 5.1.4
@@ -4386,6 +4386,75 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 45624a955c064dda167f8aae5560918307110e3a1221989b5957c52842208c2ee29e099c9120615b1dde66afe7a7c3db627c754e328f574a0ae313644e43ceef
+  languageName: node
+  linkType: hard
+
+"@types/d3-array@npm:^3.0.3":
+  version: 3.2.1
+  resolution: "@types/d3-array@npm:3.2.1"
+  checksum: 8a41cee0969e53bab3f56cc15c4e6c9d76868d6daecb2b7d8c9ce71e0ececccc5a8239697cc52dadf5c665f287426de5c8ef31a49e7ad0f36e8846889a383df4
+  languageName: node
+  linkType: hard
+
+"@types/d3-color@npm:*":
+  version: 3.1.3
+  resolution: "@types/d3-color@npm:3.1.3"
+  checksum: 8a0e79a709929502ec4effcee2c786465b9aec51b653ba0b5d05dbfec3e84f418270dd603002d94021885061ff592f614979193bd7a02ad76317f5608560e357
+  languageName: node
+  linkType: hard
+
+"@types/d3-ease@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-ease@npm:3.0.2"
+  checksum: 0885219966294bfc99548f37297e1c75e75da812a5f3ec941977ebb57dcab0a25acec5b2bbd82d09a49d387daafca08521ca269b7e4c27ddca7768189e987b54
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:^3.0.1":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "*"
+  checksum: efd2770e174e84fc7316fdafe03cf3688451f767dde1fa6211610137f495be7f3923db7e1723a6961a0e0e9ae0ed969f4f47c038189fa0beb1d556b447922622
+  languageName: node
+  linkType: hard
+
+"@types/d3-path@npm:*":
+  version: 3.1.0
+  resolution: "@types/d3-path@npm:3.1.0"
+  checksum: 1e81b56ed33ba1ac954a8c42c78c3fcf2716927fe5d01b2003591193ad3b639572a3dfcedd9bf78b6b73215a5cfb01cede8f25c936e95ac18fbe3858f9b62f5c
+  languageName: node
+  linkType: hard
+
+"@types/d3-scale@npm:^4.0.2":
+  version: 4.0.8
+  resolution: "@types/d3-scale@npm:4.0.8"
+  dependencies:
+    "@types/d3-time": "*"
+  checksum: 3b1906da895564f73bb3d0415033d9a8aefe7c4f516f970176d5b2ff7a417bd27ae98486e9a9aa0472001dc9885a9204279a1973a985553bdb3ee9bbc1b94018
+  languageName: node
+  linkType: hard
+
+"@types/d3-shape@npm:^3.1.0":
+  version: 3.1.7
+  resolution: "@types/d3-shape@npm:3.1.7"
+  dependencies:
+    "@types/d3-path": "*"
+  checksum: 776b982e2c4fc04763782af5100993c02bca338632ff2c76d2423ace398300ba7c48cd745f95b5f51edefabbfd026c45829a146c411f8facde09ef92580b20ce
+  languageName: node
+  linkType: hard
+
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@types/d3-time@npm:3.0.4"
+  checksum: 0c296884571ce70c4bbd4ea9cd1c93c0c8aee602c6c806b056187dd4ee49daf70c2f41da94b25ba0d796edf8ca83cbb87fe6d1cdda7ca669ab800170ece1c12b
+  languageName: node
+  linkType: hard
+
+"@types/d3-timer@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-timer@npm:3.0.2"
+  checksum: 1643eebfa5f4ae3eb00b556bbc509444d88078208ec2589ddd8e4a24f230dd4cf2301e9365947e70b1bee33f63aaefab84cd907822aae812b9bc4871b98ab0e1
   languageName: node
   linkType: hard
 
@@ -7185,33 +7254,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:3.2.4":
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:3.2.4, d3-array@npm:^3.1.6":
   version: 3.2.4
   resolution: "d3-array@npm:3.2.4"
   dependencies:
     internmap: 1 - 2
   checksum: a5976a6d6205f69208478bb44920dd7ce3e788c9dceb86b304dbe401a4bfb42ecc8b04c20facde486e9adcb488b5d1800d49393a3f81a23902b68158e12cddd0
-  languageName: node
-  linkType: hard
-
-"d3-array@npm:^1.2.0":
-  version: 1.2.4
-  resolution: "d3-array@npm:1.2.4"
-  checksum: d0be1fa7d72dbfac8a3bcffbb669d42bcb9128d8818d84d2b1df0c60bbe4c8e54a798be0457c55a219b399e2c2fabcbd581cbb130eb638b5436b0618d7e56000
-  languageName: node
-  linkType: hard
-
-"d3-collection@npm:1":
-  version: 1.0.7
-  resolution: "d3-collection@npm:1.0.7"
-  checksum: 9c6b910a9da0efb021e294509f98263ca4f62d10b997bb30ccfb6edd582b703da36e176b968b5bac815fbb0f328e49643c38cf93b5edf8572a179ba55cf4a09d
-  languageName: node
-  linkType: hard
-
-"d3-color@npm:1":
-  version: 1.4.1
-  resolution: "d3-color@npm:1.4.1"
-  checksum: a214b61458b5fcb7ad1a84faed0e02918037bab6be37f2d437bf0e2915cbd854d89fbf93754f17b0781c89e39d46704633d05a2bfae77e6209f0f4b140f9894b
   languageName: node
   linkType: hard
 
@@ -7222,17 +7270,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-ease@npm:^1.0.0":
-  version: 1.0.7
-  resolution: "d3-ease@npm:1.0.7"
-  checksum: 117811d51dfc4a126e8d23d249252df792fbbe30a93615e1d67158c482eff69b900e45a4cc92746fe65b1143287455406a89aae04eb4ca1ba5b1dc2a42af5b85
-  languageName: node
-  linkType: hard
-
-"d3-format@npm:1":
-  version: 1.4.5
-  resolution: "d3-format@npm:1.4.5"
-  checksum: 1b8b2c0bca182173bccd290a43e8b635a83fc8cfe52ec878c7bdabb997d47daac11f2b175cebbe73f807f782ad655f542bdfe18180ca5eb3498a3a82da1e06ab
+"d3-ease@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: 06e2ee5326d1e3545eab4e2c0f84046a123dcd3b612e68858219aa034da1160333d9ce3da20a1d3486d98cb5c2a06f7d233eee1bc19ce42d1533458bd85dedcd
   languageName: node
   linkType: hard
 
@@ -7243,28 +7284,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-interpolate@npm:1, d3-interpolate@npm:^1.1.1":
-  version: 1.4.0
-  resolution: "d3-interpolate@npm:1.4.0"
-  dependencies:
-    d3-color: 1
-  checksum: d98988bd1e2f59d01f100d0a19315ad8f82ef022aa09a65aff76f747a44f9b52f2d64c6578b8f47e01f2b14a8f0ef88f5460d11173c0dd2d58238c217ac0ec03
-  languageName: node
-  linkType: hard
-
-"d3-interpolate@npm:1.2.0 - 3":
+"d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-interpolate@npm:3.0.1"
   dependencies:
     d3-color: 1 - 3
   checksum: a42ba314e295e95e5365eff0f604834e67e4a3b3c7102458781c477bd67e9b24b6bb9d8e41ff5521050a3f2c7c0c4bbbb6e187fd586daa3980943095b267e78b
-  languageName: node
-  linkType: hard
-
-"d3-path@npm:1":
-  version: 1.0.9
-  resolution: "d3-path@npm:1.0.9"
-  checksum: d4382573baf9509a143f40944baeff9fead136926aed6872f7ead5b3555d68925f8a37935841dd51f1d70b65a294fe35c065b0906fb6e42109295f6598fc16d0
   languageName: node
   linkType: hard
 
@@ -7275,7 +7300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-scale@npm:4.0.2":
+"d3-scale@npm:4.0.2, d3-scale@npm:^4.0.2":
   version: 4.0.2
   resolution: "d3-scale@npm:4.0.2"
   dependencies:
@@ -7288,45 +7313,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-scale@npm:^1.0.0":
-  version: 1.0.7
-  resolution: "d3-scale@npm:1.0.7"
-  dependencies:
-    d3-array: ^1.2.0
-    d3-collection: 1
-    d3-color: 1
-    d3-format: 1
-    d3-interpolate: 1
-    d3-time: 1
-    d3-time-format: 2
-  checksum: c889c510aa0380b23e3a595be6b143b7053351ab6fe212918aa1ae80353a9ccde81064c2afa95dbdcd936fbb0c69dd560de291cbbea80d068a4390a3f67596aa
-  languageName: node
-  linkType: hard
-
-"d3-shape@npm:3.2.0":
+"d3-shape@npm:3.2.0, d3-shape@npm:^3.1.0":
   version: 3.2.0
   resolution: "d3-shape@npm:3.2.0"
   dependencies:
     d3-path: ^3.1.0
   checksum: de2af5fc9a93036a7b68581ca0bfc4aca2d5a328aa7ba7064c11aedd44d24f310c20c40157cb654359d4c15c3ef369f95ee53d71221017276e34172c7b719cfa
-  languageName: node
-  linkType: hard
-
-"d3-shape@npm:^1.0.0, d3-shape@npm:^1.2.0":
-  version: 1.3.7
-  resolution: "d3-shape@npm:1.3.7"
-  dependencies:
-    d3-path: 1
-  checksum: 46566a3ab64a25023653bf59d64e81e9e6c987e95be985d81c5cedabae5838bd55f4a201a6b69069ca862eb63594cd263cac9034afc2b0e5664dfe286c866129
-  languageName: node
-  linkType: hard
-
-"d3-time-format@npm:2":
-  version: 2.3.0
-  resolution: "d3-time-format@npm:2.3.0"
-  dependencies:
-    d3-time: 1
-  checksum: 5445eaaf2b3b2095cdc1fa75dfd2f361a61c39b677dcc1c2ba4cb6bc0442953de0fbaaa397d7d7a9325ad99c63d869f162a713e150e826ff8af482615664cb3f
   languageName: node
   linkType: hard
 
@@ -7339,14 +7331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time@npm:1":
-  version: 1.1.0
-  resolution: "d3-time@npm:1.1.0"
-  checksum: 33fcfff94ff093dde2048c190ecca8b39fe0ec8b3c61e9fc39c5f6072ce5b86dd2b91823f086366995422bbbac7f74fd9abdb7efe4f292a73b1c6197c699cc78
-  languageName: node
-  linkType: hard
-
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3.1.0":
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3.1.0, d3-time@npm:^3.0.0":
   version: 3.1.0
   resolution: "d3-time@npm:3.1.0"
   dependencies:
@@ -7355,14 +7340,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-timer@npm:^1.0.0":
-  version: 1.0.10
-  resolution: "d3-timer@npm:1.0.10"
-  checksum: f7040953672deb2dfa03830ace80dbbcb212f80890218eba15dcca6f33f74102d943023ccc2a563295195cd8c63639bb2410ef1691c8fecff4a114fdf5c666f4
+"d3-timer@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 1cfddf86d7bca22f73f2c427f52dfa35c49f50d64e187eb788dcad6e927625c636aa18ae4edd44d084eb9d1f81d8ca4ec305dae7f733c15846a824575b789d73
   languageName: node
   linkType: hard
 
-"d3-voronoi@npm:^1.1.2":
+"d3-voronoi@npm:^1.1.4":
   version: 1.1.4
   resolution: "d3-voronoi@npm:1.1.4"
   checksum: d28a74bc62f2b936b0d3b51d5be8d2366afca4fd7026d7ee8f655600650bf0c985da38a8c3ae46bfa315b5f524f3ca1c5211437cf1c8c737cc1da681e015baee
@@ -7610,12 +7595,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delaunay-find@npm:0.0.5":
-  version: 0.0.5
-  resolution: "delaunay-find@npm:0.0.5"
+"delaunay-find@npm:0.0.6":
+  version: 0.0.6
+  resolution: "delaunay-find@npm:0.0.6"
   dependencies:
     delaunator: ^4.0.0
-  checksum: 8bc62c16cab6840b5f42639b820498db527659bcc6a4973aec1f78c083a6401fed6a8c0e727f8eb3c19455e9ee146caf28ba92f1ce6506d92451a72217adef22
+  checksum: 072e197a4317dd06ff8349dfa6731f62d322c7ba4697d4a323da7798676f5c429c4ac691ae5207f7c7da567eca7c71dada896206cbd7995e6e9d145101734c31
   languageName: node
   linkType: hard
 
@@ -11230,6 +11215,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.1, json5@npm:^1.0.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
@@ -14075,10 +14067,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-fast-compare@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "react-fast-compare@npm:2.0.4"
-  checksum: 06046595f90a4e3e3a56f40a8078c00aa71bdb064ddb98343f577f546aa22e888831fd45f009c93b34707cc842b4c637737e956fd13d6f80607ee92fb9cf9a1c
+"react-fast-compare@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "react-fast-compare@npm:3.2.2"
+  checksum: 2071415b4f76a3e6b55c84611c4d24dcb12ffc85811a2840b5a3f1ff2d1a99be1020d9437ee7c6e024c9f4cbb84ceb35e48cf84f28fcb00265ad2dfdd3947704
   languageName: node
   linkType: hard
 
@@ -16853,351 +16845,417 @@ __metadata:
   languageName: node
   linkType: hard
 
-"victory-area@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-area@npm:33.1.7"
+"victory-area@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-area@npm:37.3.5"
   dependencies:
-    d3-shape: ^1.2.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: e3c6e9c08655c9097dc6eff8c08d9141909d101a03f1a1600e05035537ca808a1954de154d2a0b8a09b3c411743725db5b830cca9e5c25c6146f424b99a57583
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: c6769023a4d657d8cf03e7eaddf7edc5ddb70269e74c8a13f6bd247a42eb4677b205c5094ddd14dfd33694d401744efa8998ded38ce930e25d1d44f4d34f0957
   languageName: node
   linkType: hard
 
-"victory-axis@npm:^33.0.0, victory-axis@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-axis@npm:33.1.7"
+"victory-axis@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-axis@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: bd17f40e71949272a3464e6a9f04669416fd8abece24d5d07376598cb294eba2d4c79174d9b7171c9984bf1e119adb9f04a60774df6635a31dc67871e2001759
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 2011097a9241ce43dce8cfdf1018977b4a958093a661edcf88849215336b792a9ccf9bb9851605a20f2752c87c5b5fb82cb9c86dcdf5943450faa73a7f5f9052
   languageName: node
   linkType: hard
 
-"victory-bar@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-bar@npm:33.1.7"
+"victory-bar@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-bar@npm:37.3.5"
   dependencies:
-    d3-shape: ^1.2.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: fab73fb5b70b9de6af77eff6a9aac371bc08fb185ec98cd7fe143acfada007680fbc4539e673f4b2512926c323f741c85879f830cf85b2c964c7b84eba863c76
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: be1c95b8c1320eac20bff9504f579e2eb5e7f1fed7d8363246194535b8dc7e0316a2b62cdeac4bb43898adc93345a28ee946014ef7015206b4f85543ef2ee365
   languageName: node
   linkType: hard
 
-"victory-box-plot@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-box-plot@npm:33.1.7"
+"victory-box-plot@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-box-plot@npm:37.3.5"
   dependencies:
-    d3-array: ^1.2.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 69b2bba65ece747d187cf5b1418a1ad0d4acad9708bf5ed7bfe7f45e6774a1e43b902dd0b2b5aee673cbf9433314c98ecea61e18828363e9bc2a8b66e31532fa
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 93c8bf2fd523be7f1c30d67fe7574ead43f2e63f914094f27ebd61bebf219dbd2e0f8f4e8382d6eee2aec4bb0261463e8801384145e86c5fdadc2c37fb22c280
   languageName: node
   linkType: hard
 
-"victory-brush-container@npm:^33.0.0, victory-brush-container@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-brush-container@npm:33.1.7"
+"victory-brush-container@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-brush-container@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 9cc1df25bd3e21f504044552d758de96d9a47c06166a6210f469e00afc4c997e38c00212588d17e8178139f224625a42a4c1421d7c19f078d44d084c84775b1f
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 73f989ecd527440c5409282256b8ed2f7425baf17727e3d98286915fc424106cf62320167d3d11c03bba80154a6611235eb1a9ece3b568c92897b1378be158f5
   languageName: node
   linkType: hard
 
-"victory-brush-line@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-brush-line@npm:33.1.7"
+"victory-brush-line@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-brush-line@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 1f9391c6de0f6d0b119449decbe230ec2e5d20f8048f50db6658e9fb1cb8307fe9a25d91e504510328ead858b51711af8dcc90da3c55cda4c9472d540576fc96
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: d544fc2c668b048b7d1896fc699e876b2df29882df7272bda917f149a3e2c2947686d06c5c871c67a8f999dd438eab91432aa62fb84e97fab6be05293f5bf7e9
   languageName: node
   linkType: hard
 
-"victory-candlestick@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-candlestick@npm:33.1.7"
+"victory-candlestick@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-candlestick@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: ec97ee4752d45de2272c65c7efea766ef72b0b11ecb334c01197044e4bae4264412fed0e17085ea93c2e3728d2f99d127972e6cd418cc097422c3c677e52f4ef
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 60b91488cb29b6d68fd724c3248274f0c6590c16e833bb85b1fbaa64e0f56791e081fce963ff90ec054da64348212d74b6f5ea337f4e1667b5494a2f6d173e90
   languageName: node
   linkType: hard
 
-"victory-chart@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-chart@npm:33.1.7"
+"victory-canvas@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-canvas@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-    victory-axis: ^33.1.7
-    victory-core: ^33.1.7
-    victory-polar-axis: ^33.1.7
-    victory-shared-events: ^33.1.7
-  checksum: 14d7aecc34edbe71f44fd8ac1f951a1a78afa066ddb2a41d335414955b5ade3eef3d8a5539f6de88533a7daf40ec6a1338b363e8d69fcc77da027f0d65c9b3bb
+    lodash: ^4.17.19
+    victory-bar: 37.3.5
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 4358554efddf4eb23326aaedb68b393925d2483cfe2dbad7163c28185de3fef4cf12011b6fdad1bddccc8dbe71c2450dc1af349dfc73e48cfb8103de9f854ea6
   languageName: node
   linkType: hard
 
-"victory-core@npm:33.0.0":
-  version: 33.0.0
-  resolution: "victory-core@npm:33.0.0"
+"victory-chart@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-chart@npm:37.3.5"
   dependencies:
-    d3-ease: ^1.0.0
-    d3-interpolate: ^1.1.1
-    d3-scale: ^1.0.0
-    d3-shape: ^1.2.0
-    d3-timer: ^1.0.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-  checksum: b8d46a3c1d1998b89769a4ad37ed23f9b5be28f6fa2986cb1e2bc2b4dbb57514f77d502c8bbcecb98d9cf06ba025001256e02689af091783597f75ce34e71c00
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-axis: 37.3.5
+    victory-core: 37.3.5
+    victory-polar-axis: 37.3.5
+    victory-shared-events: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 44d42fafac9a108b0641817e937834d88085ebc4857236ff4c92bd02d858c4243e1e6525a34ec41718d993583bb869182ef3153278a20e71d9986691b7674b54
   languageName: node
   linkType: hard
 
-"victory-core@npm:^33.0.0, victory-core@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-core@npm:33.1.7"
+"victory-core@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-core@npm:37.3.5"
   dependencies:
-    d3-ease: ^1.0.0
-    d3-interpolate: ^1.1.1
-    d3-scale: ^1.0.0
-    d3-shape: ^1.2.0
-    d3-timer: ^1.0.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-  checksum: 85421dec884e4b8a4336ba2bf1458ec3789ecd30821029b0de5c6e6ccb9cdf13345bd4624ea26f4404cc3fba0e43be817c6d5cbc0f5e145b5bc93fcc4df5e3ea
+    lodash: ^4.17.21
+    react-fast-compare: ^3.2.0
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: cb021419e6cfee495868b7a2e419235b6858f2d17b0a1ab2a7b79429e759e836985a04a9ca8446aa928e76d51f185cedd4eae82204168e4b3420084a429f1533
   languageName: node
   linkType: hard
 
-"victory-create-container@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-create-container@npm:33.1.7"
+"victory-create-container@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-create-container@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    victory-brush-container: ^33.1.7
-    victory-core: ^33.1.7
-    victory-cursor-container: ^33.1.7
-    victory-selection-container: ^33.1.7
-    victory-voronoi-container: ^33.1.7
-    victory-zoom-container: ^33.1.7
-  checksum: dbca1615b49383652066df9362888d1eb60c6ee57c3925a436b1fc9e1ff7f78d11892f3241aad27e401793cb29d85f315bb769c500462872d72eb3d68a2a375d
+    lodash: ^4.17.19
+    victory-brush-container: 37.3.5
+    victory-core: 37.3.5
+    victory-cursor-container: 37.3.5
+    victory-selection-container: 37.3.5
+    victory-voronoi-container: 37.3.5
+    victory-zoom-container: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: f7b946245f0cc2cb7017521902a892d603006e00ca73190c7a1ccd335c3367db9c4af4bd3c28e3b03a345800b39a5dc8ef00efc7032f92827df09aa0b6d962e6
   languageName: node
   linkType: hard
 
-"victory-cursor-container@npm:^33.0.0, victory-cursor-container@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-cursor-container@npm:33.1.7"
+"victory-cursor-container@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-cursor-container@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 4023443be79098b8b348b17c93a02c8f91e413ad1cb9ee918888baf136eb6645f22c0e1d714e99648952c6843a3caac09bdba73fd2c3b3f0efb6618836b98a91
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: f5b2224e9a920909287f79ac7978f44bd6eabb3394afc79116cd7e452368575e1e7e6907ce7f0a5626aa826b5bdebe4c7684402eab69fb9b93b1da42f76e1ce2
   languageName: node
   linkType: hard
 
-"victory-errorbar@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-errorbar@npm:33.1.7"
+"victory-errorbar@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-errorbar@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 6bc8b87fe519be04fbdf3ccc167ca1cd44cbbfafe8b9690ed35bbb1f33126b17f0b504ac2a729daff9ffa1cd99f32a8cad6e2d3accd2d17c69e7ca8b3e591031
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: c3008f16ef98e0447545e1a060a9c6a7849693c815e0b2e148877e79937d94e2554204e4f8ae3eb30cff0570232df5e181313fa925fb81b4f963cb83d128fe87
   languageName: node
   linkType: hard
 
-"victory-group@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-group@npm:33.1.7"
+"victory-group@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-group@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-    victory-core: ^33.1.7
-  checksum: 7c1e2149f84b139e3cef1ada8aab858f984dcffd57363fbe6ae0827216fad9287cd3a8977eb0effbc24987c9b5196c664f563bff1988a3dcfede40d185440591
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-core: 37.3.5
+    victory-shared-events: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 0b661a9d4fa8dfd4674f9461883eedc4b4755659803e5d249b63df13a5c9ac1f75e00a23d4d8f80a1c34f30ac467aa8a0b509bfb978d9211814ca7fc0c53e304
   languageName: node
   linkType: hard
 
-"victory-legend@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-legend@npm:33.1.7"
+"victory-histogram@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-histogram@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 18beecdc93568b1d1fce2262df7a4d8c5901c20f11d549b43f155dad83255803a5780216b0bb5552c5f2853d240c45f9157ae3315f662c05912941bfc4c1aef8
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-bar: 37.3.5
+    victory-core: 37.3.5
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 62e55975eb9d64fbcbf1af41eb5115bfc6d79e788e8171445cd38006147320576d385e01c643e2c0cb4a2ae087c7fa2f076e885a2c2dbfda53ff10a4f7996746
   languageName: node
   linkType: hard
 
-"victory-line@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-line@npm:33.1.7"
+"victory-legend@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-legend@npm:37.3.5"
   dependencies:
-    d3-shape: ^1.2.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 9ebe413e89f1ece3d6c32c97235bd095e67efaef14d204cbce8fe66b6c9cc6b3923f6f1dc8ecc49021adc8de1f2412f45d2e9754c32b9e2092ddff1ae63f1bf2
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 53a06bfef56066a0cfffcca54233f40befaebd6cfa96e014e09d6691bb59789225fb19652f43ec4de25acc62cbde8e89d34aa7c7196e838d459134542cb1aa4e
   languageName: node
   linkType: hard
 
-"victory-pie@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-pie@npm:33.1.7"
+"victory-line@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-line@npm:37.3.5"
   dependencies:
-    d3-shape: ^1.0.0
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: b7abe09beeb7ca9de37aa3eb2a5c8cccb4beee27c78efea66100019988390caf3ecaba6b4b981553aa60a464b6bdbe0fab338abaaa55cd725ab35891318be53d
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: d602a12e759ee59d542acc82de25c5910833cf03836d12d9ef8ab026a954baddc2df60d331cfbf6b44eb1617da543f6d2f11a8cce43038d94eeb2a8db16d022c
   languageName: node
   linkType: hard
 
-"victory-polar-axis@npm:^33.0.0, victory-polar-axis@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-polar-axis@npm:33.1.7"
+"victory-pie@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-pie@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: c7bc1e3cc20f8788576448b96728f2c6d2f447273cd7ef2abe5c77ae4ae0616fe2cfaa54ae4c3f0f08d1f0626a792f33db9f6ec03e449cdd0dd3c49ddd87a6a9
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+    victory-vendor: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: ce4054abf483c654298271e693202945402b9e38dc1fb98827701277a1b14cde5c5f77fc04b497de4603dc133665bf104679e47734d24ce2bf2d45eb84ca4922
   languageName: node
   linkType: hard
 
-"victory-scatter@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-scatter@npm:33.1.7"
+"victory-polar-axis@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-polar-axis@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 6cf56addfac480e585590092e8506d5cd36603287102d808df57c197bbd213413d792fbc2ff6f1b2b5ef6ae9a2033e1a34872eeb9af861325a7e97597c521f38
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 506f8f1be5762afe16bb0e5fbb329b511e5b676524ffba3a82ecd39e1532864f280e6ebf723824a856fd1c86e633cba5deecf2a6dcf9d20203aca52940f9b303
   languageName: node
   linkType: hard
 
-"victory-selection-container@npm:^33.0.0, victory-selection-container@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-selection-container@npm:33.1.7"
+"victory-scatter@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-scatter@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 0c7deba9775add9c105007dc8237589fee5ac5aa077a300a85864342f4e90c1066263b91e8c54cecb786b9a88ff55b7abeb38279913636496e1605530b7be5d4
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 3f0908b34646e31232e6d728633b5f0e652830c7f2f3eec7f91354575677ce236e31a317a59bf80f5f80cf8cc2adb3b20595f4a3280d3fd976a18f2d79fb8c55
   languageName: node
   linkType: hard
 
-"victory-shared-events@npm:^33.0.0, victory-shared-events@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-shared-events@npm:33.1.7"
+"victory-selection-container@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-selection-container@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-    victory-core: ^33.1.7
-  checksum: 5f88c36e4ede86a3cf85614703970d7b195d28f5d6db777e108a1781412783c685bfc85e0f0d2262537aae7aeeb61a277b6b71430e5149664c81a7e06b6d206f
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: d98f220a74e6c3ff417a0c991eede28d78acca4cf97f86dcce2c9a966b5d084cdd2cd5a67c4dbb5da23d064ee808f3adb8b206401c3012a41f63973b237293b0
   languageName: node
   linkType: hard
 
-"victory-stack@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-stack@npm:33.1.7"
+"victory-shared-events@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-shared-events@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-    victory-core: ^33.1.7
-  checksum: c4ede1104dd5637440a18db65ddee39ea7ac877e9ff2feaa7d57fe77e76e990d4ec659bd35e45c24dad2a16198c0173250f42e7baca9b1c91ff099d4cfd5f3a3
+    json-stringify-safe: ^5.0.1
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 01a61c1a94c979a22d52c90fd834d24728bb23664ac30ee161d62ce34f41f782d90956c5f345d4b3b7e598d903584eb026a244ea19d6208c99956bcd06be8e0f
   languageName: node
   linkType: hard
 
-"victory-tooltip@npm:^33.0.0, victory-tooltip@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-tooltip@npm:33.1.7"
+"victory-stack@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-stack@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: ca8aa54c76c3549478981f9f9b1db19ecbeb85211ed1eb2aefecc3bfc3010ea855c89b8ddd03efb7a66b31e6e4cb371c3b7a1a17cf89e3a5f60405e3361e125a
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-core: 37.3.5
+    victory-shared-events: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 3eedf72b2c35fdd9ade500075230478a641041f677ec384d8e3fcaafebd4b2bc12bd8c49d10c8c0b94916d8ece1217bbe3808ec38af08679bc486724390127e8
   languageName: node
   linkType: hard
 
-"victory-voronoi-container@npm:^33.0.0, victory-voronoi-container@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-voronoi-container@npm:33.1.7"
+"victory-tooltip@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-tooltip@npm:37.3.5"
   dependencies:
-    delaunay-find: 0.0.5
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-    victory-tooltip: ^33.1.7
-  checksum: d43d6e48645b641978e8a3011f23757f8282038cf10d617eeed8487fc097e44e493f89382de11213bfdb0acc4463993bbb00b2388c26cc6fdef19b86841cafb5
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 76b78b8673972d146dd6ca4b7e2b7612bb505c598d478126bcbd172bb8cceb54809cafdb02598d5ef242b7fc1735fb07dff1159a340501402b57a16f790b22d9
   languageName: node
   linkType: hard
 
-"victory-voronoi@npm:^33.0.0":
-  version: 33.1.7
-  resolution: "victory-voronoi@npm:33.1.7"
+"victory-vendor@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-vendor@npm:37.3.5"
   dependencies:
-    d3-voronoi: ^1.1.2
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: e1f8db04efba68f6a431515a5561a63db987e6e63cf65d6e7fdc0bccf3424421ef29d2166ea5fdead8e051abb31d47f9d6637620af2efa44eccba9a2f0c3879c
+    "@types/d3-array": ^3.0.3
+    "@types/d3-ease": ^3.0.0
+    "@types/d3-interpolate": ^3.0.1
+    "@types/d3-scale": ^4.0.2
+    "@types/d3-shape": ^3.1.0
+    "@types/d3-time": ^3.0.0
+    "@types/d3-timer": ^3.0.0
+    d3-array: ^3.1.6
+    d3-ease: ^3.0.1
+    d3-interpolate: ^3.0.1
+    d3-scale: ^4.0.2
+    d3-shape: ^3.1.0
+    d3-time: ^3.0.0
+    d3-timer: ^3.0.1
+  checksum: 6dfd0dc0e8c1eaade896b472c7e8d9977ca751be88fb478f2a6eec34dd5d6412be4410399550f4096de47c36af968910f8d67892d0c1a5242b057d5b5ca3a5dc
   languageName: node
   linkType: hard
 
-"victory-zoom-container@npm:^33.0.0, victory-zoom-container@npm:^33.1.7":
-  version: 33.1.7
-  resolution: "victory-zoom-container@npm:33.1.7"
+"victory-voronoi-container@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-voronoi-container@npm:37.3.5"
   dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    victory-core: ^33.1.7
-  checksum: 36a53ee8ad640fb612351490ec88531270fa0ba7bcf443264dd4fcf5798c21b8504fe8a505b84f7474b7f94e3388fb76c13e5c604b43580e1f4c15b82b4f356f
+    delaunay-find: 0.0.6
+    lodash: ^4.17.19
+    react-fast-compare: ^3.2.0
+    victory-core: 37.3.5
+    victory-tooltip: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: e02199145961851c4377296413e0b780ec617c7c1139a7fbe2cce90299487c50e756011a7c4f1347f3fecc7a5df915d5430eff00bc555526dae806dbe4c820cd
   languageName: node
   linkType: hard
 
-"victory@npm:33.0.0":
-  version: 33.0.0
-  resolution: "victory@npm:33.0.0"
+"victory-voronoi@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-voronoi@npm:37.3.5"
   dependencies:
-    victory-area: ^33.0.0
-    victory-axis: ^33.0.0
-    victory-bar: ^33.0.0
-    victory-box-plot: ^33.0.0
-    victory-brush-container: ^33.0.0
-    victory-brush-line: ^33.0.0
-    victory-candlestick: ^33.0.0
-    victory-chart: ^33.0.0
-    victory-core: ^33.0.0
-    victory-create-container: ^33.0.0
-    victory-cursor-container: ^33.0.0
-    victory-errorbar: ^33.0.0
-    victory-group: ^33.0.0
-    victory-legend: ^33.0.0
-    victory-line: ^33.0.0
-    victory-pie: ^33.0.0
-    victory-polar-axis: ^33.0.0
-    victory-scatter: ^33.0.0
-    victory-selection-container: ^33.0.0
-    victory-shared-events: ^33.0.0
-    victory-stack: ^33.0.0
-    victory-tooltip: ^33.0.0
-    victory-voronoi: ^33.0.0
-    victory-voronoi-container: ^33.0.0
-    victory-zoom-container: ^33.0.0
-  checksum: 0ddf4cc512487c908cfa35af26b37e116b0a25a0459e0d46662997816e94454faf0484488640fa11f6367c67064edc3b9582f85ba2f2c332273b0bf24c45fae2
+    d3-voronoi: ^1.1.4
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 343e6a3ae12960f07fa221e12265e75d1d1cf80a6e0ddb84e1f4bb38ae3f252dd6af4dde74a4f426abb2a226570a12af8a6291caabaacf680782267a537190cc
+  languageName: node
+  linkType: hard
+
+"victory-zoom-container@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory-zoom-container@npm:37.3.5"
+  dependencies:
+    lodash: ^4.17.19
+    victory-core: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 9ab47aa2934c3e062c5259f1456d7071c05337db9c54b3d35e25d8ae78a82e28878a7ae73f1071aff5ff3e0b0d733825293fe9e2dfdd99dfa96e7f25fb59c6e8
+  languageName: node
+  linkType: hard
+
+"victory@npm:37.3.5":
+  version: 37.3.5
+  resolution: "victory@npm:37.3.5"
+  dependencies:
+    victory-area: 37.3.5
+    victory-axis: 37.3.5
+    victory-bar: 37.3.5
+    victory-box-plot: 37.3.5
+    victory-brush-container: 37.3.5
+    victory-brush-line: 37.3.5
+    victory-candlestick: 37.3.5
+    victory-canvas: 37.3.5
+    victory-chart: 37.3.5
+    victory-core: 37.3.5
+    victory-create-container: 37.3.5
+    victory-cursor-container: 37.3.5
+    victory-errorbar: 37.3.5
+    victory-group: 37.3.5
+    victory-histogram: 37.3.5
+    victory-legend: 37.3.5
+    victory-line: 37.3.5
+    victory-pie: 37.3.5
+    victory-polar-axis: 37.3.5
+    victory-scatter: 37.3.5
+    victory-selection-container: 37.3.5
+    victory-shared-events: 37.3.5
+    victory-stack: 37.3.5
+    victory-tooltip: 37.3.5
+    victory-voronoi: 37.3.5
+    victory-voronoi-container: 37.3.5
+    victory-zoom-container: 37.3.5
+  peerDependencies:
+    react: ">=16.6.0"
+  checksum: 6693417c580810bfc59b70b6fa386d58214b4d3e14c2e10a067a83caf800a3fb93b89671d01e634b6dc84d60dc3a1781836ec6df6786c5ef21ba692ca43c84c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,8 +4274,8 @@ __metadata:
     translate-svg-path: 0.0.1
     url-loader: 4.1.1
     util: 0.12.5
-    victory: 31.3.0
-    victory-core: 31.2.0
+    victory: 32.0.0
+    victory-core: 32.0.0
     voilab-pdf-table: 0.5.1
     webpack: 5.94.0
     webpack-cli: 5.1.4
@@ -4283,7 +4283,7 @@ __metadata:
     babel-core: 6.x || ^7.0.0-bridge.0
     classnames: 2.x
     react: 16.x
-    react-addons-update: 16.x
+    react-addons-update: 15.6.x
     react-dom: 16.x
     react-redux: 8.x
     redux: 4.x
@@ -7600,6 +7600,22 @@ __metadata:
     rimraf: ^3.0.2
     slash: ^3.0.0
   checksum: 563288b73b8b19a7261c47fd21a330eeab6e2acd7c6208c49790dfd369127120dd7836cdf0c1eca216b77c94782a81507eac6b4734252d3bef2795cb366996b6
+  languageName: node
+  linkType: hard
+
+"delaunator@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "delaunator@npm:4.0.1"
+  checksum: a49f1c23edbcb79079a13577d32fcd46d0db30879c8484f742a0d840923085f2f3de35a9bfbb96eadd12201ffb7c3adf45b0f528d08b71cb547c5f8068b5d61b
+  languageName: node
+  linkType: hard
+
+"delaunay-find@npm:0.0.3":
+  version: 0.0.3
+  resolution: "delaunay-find@npm:0.0.3"
+  dependencies:
+    delaunator: ^4.0.0
+  checksum: da7d5514e89bf9e9695a74cf1e929bfa05ab39259f31ea873260c19094b6918762d5cc8dc6e3360c855660eec3b26e4b63939b5797f771ecacaa53fe6c93c5c9
   languageName: node
   linkType: hard
 
@@ -16837,104 +16853,104 @@ __metadata:
   languageName: node
   linkType: hard
 
-"victory-area@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-area@npm:31.2.0"
+"victory-area@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-area@npm:32.3.7"
   dependencies:
     d3-shape: ^1.2.0
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 56267af197297232c04f832463a28fe148d6bda5f29d82a49fbecd49f2cd35b486d9288a445ba67a3ab4c265f2d77c267dcdf96ac68f1fffbc7ea446b10166ae
+    victory-core: ^32.3.7
+  checksum: abb15808af7ca15a7123a431cc6b057d454ecff5463c373ca190de8f5bfbd8e722acaa8a49391167d657a13589c68e525e2eff8e2b3874986638265187aaa82b
   languageName: node
   linkType: hard
 
-"victory-axis@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-axis@npm:31.2.0"
+"victory-axis@npm:^32.0.0, victory-axis@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-axis@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: dea086b8ec43be8790f6806a0ff522892daa2b1d430bb338befd7f7c04a11307e95b77c18f89433f428b914cd745fce58e31d7f25f147cfc14e8401497447748
+    victory-core: ^32.3.7
+  checksum: 632023f11d6f807bd05a697483d7c55e22b5c7300129b83f0917880ac44c039f9c0198154b344df45f55a7688338f1fa24e65e396a5e0fb1036fa7d8e14e71d4
   languageName: node
   linkType: hard
 
-"victory-bar@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-bar@npm:31.2.0"
+"victory-bar@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-bar@npm:32.3.7"
   dependencies:
     d3-shape: ^1.2.0
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: b622759f818c682777caa2d7d7c1ed99cabc34280c91656d12268fdac67a0a5cbf2ed9b0b5a79a7ea4dd919ad231da44987eecd7f9e8ce61ffc7865c91fd9299
+    victory-core: ^32.3.7
+  checksum: d0e22bb5e7d6d72b7cb173428a0fb365406e92d328e29711d91241740aebed45f5d807386172f5d6aa7eb964ed7b1f90c8202291899271a33cb71b586ec43939
   languageName: node
   linkType: hard
 
-"victory-box-plot@npm:^31.3.0":
-  version: 31.3.0
-  resolution: "victory-box-plot@npm:31.3.0"
+"victory-box-plot@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-box-plot@npm:32.3.7"
   dependencies:
     d3-array: ^1.2.0
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: a5b18b7c378236cf30e3a21786c02e866885613a603040f79d06403eed0b0631bbcb60e004a3b0cc8afea01c76dd127b106f524c6feb85c839f918855026248b
+    victory-core: ^32.3.7
+  checksum: bf9418a976aec72f2abba410e46cb6736b306032517acd4f8e20637cb8cd3bafe1a8558ea507c2532c6788b19d8bcb8b66bb4f2faf4ee32b9fa5991b82cc814e
   languageName: node
   linkType: hard
 
-"victory-brush-container@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-brush-container@npm:31.2.0"
+"victory-brush-container@npm:^32.0.0, victory-brush-container@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-brush-container@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: b4749b5ee388c1c5d247234276198cae3c23eff13315181c0b8d7737ffffbe757187d4550bf7e8bd8c9321d67d26e685b859189cfb241fda15b1185438f40ba7
+    victory-core: ^32.3.7
+  checksum: 0cfbe3e50f031e28a2f4adcf8950c35515f52f778f19a3519f0cdc6c99a7aa78a0e6ee523f3b6c6988c00697ecffdc82df8887391b74cb00e7d87e539d81b68e
   languageName: node
   linkType: hard
 
-"victory-brush-line@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-brush-line@npm:31.2.0"
+"victory-brush-line@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-brush-line@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: a6a060b17102b8149a94f83e94c72f06eb877bba7c5e5154190c85890ed01565b7087604c5f580d7ac5479fee6ecb9e41045f3f2749453debdd9a68de82aff5c
+    victory-core: ^32.3.7
+  checksum: ee6c51dfe6d266c75bd1310460e32964a5893d643a15d5e93a0996b5df2bda7ff1d78cfc4fe79fcb52e2f8cb51e90ca43f83dc8cdaba15c9d77b3181f9e22425
   languageName: node
   linkType: hard
 
-"victory-candlestick@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-candlestick@npm:31.2.0"
+"victory-candlestick@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-candlestick@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 95cf304d8ae8c50087cd094c1e18dd73a453da91b75333cddf427f7906672e1163cd195e10b1b3373d1f2a4f9084d8046928d1c544e4ce1c2c1a9ca31269cf21
+    victory-core: ^32.3.7
+  checksum: c87cb28158b86c94cd6ab7d8b3ff8a546499462311299679d92423b841b103ab180be86949d0c48d4daa395d6b5fd3207bb7eaa6954e0075cb25c9b6e10b6325
   languageName: node
   linkType: hard
 
-"victory-chart@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-chart@npm:31.2.0"
+"victory-chart@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-chart@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-    victory-axis: ^31.2.0
-    victory-core: ^31.2.0
-    victory-polar-axis: ^31.2.0
-    victory-shared-events: ^31.2.0
-  checksum: 88a8861f2fae6edf38b65285990bc6a8e8026303b9e302e70a233d90d1f684d08e5bd3f06eb5ac01300ce3b1f37c8aa2f8bad2d8797e9eee75da03169eddf8d2
+    victory-axis: ^32.3.7
+    victory-core: ^32.3.7
+    victory-polar-axis: ^32.3.7
+    victory-shared-events: ^32.3.7
+  checksum: 31a805f9f7a52367c3f8a7df2056ec2e9042c16461e22dd840e0362cd8f461c93891fa891930d2b00aa8f7a36c0fc2c0ecbee147f87f5603613fe9d9f8306578
   languageName: node
   linkType: hard
 
-"victory-core@npm:31.2.0, victory-core@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-core@npm:31.2.0"
+"victory-core@npm:32.0.0":
+  version: 32.0.0
+  resolution: "victory-core@npm:32.0.0"
   dependencies:
     d3-ease: ^1.0.0
     d3-interpolate: ^1.1.1
@@ -16944,228 +16960,244 @@ __metadata:
     lodash: ^4.17.5
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-  checksum: 0b590c282a58c20f20218e97f7031cfd427c8aa6dbe08dfe169127a13d1873ef5c715015ff69c25e18e97eeaf142c2dfc3d5f89aa9eb501887c20173223ff159
+  checksum: df9f5d1cd22eb1fd497fe31ba7963136601a6048e03cd24a388c53040108f3371fcd1cbffb796f17a0c006b826abd79d89531cc1a0f4f899e5a89bb75b9ee841
   languageName: node
   linkType: hard
 
-"victory-create-container@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-create-container@npm:31.2.0"
+"victory-core@npm:^32.0.0, victory-core@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-core@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
-    victory-brush-container: ^31.2.0
-    victory-core: ^31.2.0
-    victory-cursor-container: ^31.2.0
-    victory-selection-container: ^31.2.0
-    victory-voronoi-container: ^31.2.0
-    victory-zoom-container: ^31.2.0
-  checksum: 014ecaac7415c0dace1664127b203e994720de58521f78f08e7b7f080ad8c97fdc3aa16b9ee97c4ee755bb55a411e42109d9f3d34ff164347ecd9c7d4e6eb855
-  languageName: node
-  linkType: hard
-
-"victory-cursor-container@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-cursor-container@npm:31.2.0"
-  dependencies:
-    lodash: ^4.17.5
-    prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 9c400c95702f4ce27992b943841a228a974a17b69124e3e482d45c7e6ad0f7f17ae5d528db48e260f0b1c96cba652d469fa306b4b7ea53e67bfbe046d79d347b
-  languageName: node
-  linkType: hard
-
-"victory-errorbar@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-errorbar@npm:31.2.0"
-  dependencies:
-    lodash: ^4.17.5
-    prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 2cee41517b24cd92141d6afdac7fbd2ba465f6c5ef92ecf71a36a542808ed068c42800b49f3293cb28c6161ce1eccc507f5bab7c11d88a7b93715dfd16ae3f3b
-  languageName: node
-  linkType: hard
-
-"victory-group@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-group@npm:31.2.0"
-  dependencies:
-    lodash: ^4.17.5
+    d3-ease: ^1.0.0
+    d3-interpolate: ^1.1.1
+    d3-scale: ^1.0.0
+    d3-shape: ^1.2.0
+    d3-timer: ^1.0.0
+    lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-    victory-core: ^31.2.0
-  checksum: d457c7309e1d59897c3647b9efadfa29015ec8d57d5c4813093efa925c28c06091b68dfca6d9fc6f432663cb98c7614626123ef0c2617bbfed65ddc7948edf20
+  checksum: 53d6729f5983c59b0981e467ed1a29137c05d83475028cdb5ce6cdfa807a17b7479dd065f76672c16803ada07f79cd622e13d0e077de653120fcba2f399e4fd0
   languageName: node
   linkType: hard
 
-"victory-legend@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-legend@npm:31.2.0"
+"victory-create-container@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-create-container@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
-    prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 20edeeeb4ff421e5fed166dbd55207da7ad2dfa644ec12b98c8612d3e428267fee2df9b92bf6581ca57a38a7e16a1aeb15fe9819794a5e9bc11fed26562c14df
+    lodash: ^4.17.15
+    victory-brush-container: ^32.3.7
+    victory-core: ^32.3.7
+    victory-cursor-container: ^32.3.7
+    victory-selection-container: ^32.3.7
+    victory-voronoi-container: ^32.3.7
+    victory-zoom-container: ^32.3.7
+  checksum: 30d77372a5c232eb729d0ad6ceef7aff31e71a82268622e273411bbf7b77f54d3919f43c093ed7490370bc4f58dcd67b134f3a6bd392b342dd6b0db0837d1939
   languageName: node
   linkType: hard
 
-"victory-line@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-line@npm:31.2.0"
+"victory-cursor-container@npm:^32.0.0, victory-cursor-container@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-cursor-container@npm:32.3.7"
+  dependencies:
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    victory-core: ^32.3.7
+  checksum: 4eef7a4db5f51985957345baba062acebf209c88a527178a55cee0893dd38309fa926a03e4b51056753638c03a00a5ce439c11b5255a5af9d519c0e9d3a2aea7
+  languageName: node
+  linkType: hard
+
+"victory-errorbar@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-errorbar@npm:32.3.7"
+  dependencies:
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    victory-core: ^32.3.7
+  checksum: 3b5cad489d788167d597d0ef412368b76e96b11b03349ba780b3dd54b1a8d07c138df15681ed970289f43314b9c442b605ed5e716de2dfaa2075e8d4a4b9fa50
+  languageName: node
+  linkType: hard
+
+"victory-group@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-group@npm:32.3.7"
+  dependencies:
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    react-fast-compare: ^2.0.0
+    victory-core: ^32.3.7
+  checksum: 0a44a203c0b7243306c32f96715c55f1b5106766bdcd9b002089141c6fd388aad133fc53baeb65b310b74909688fff74246c97f6e6585a9bf052ac805a53218b
+  languageName: node
+  linkType: hard
+
+"victory-legend@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-legend@npm:32.3.7"
+  dependencies:
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    victory-core: ^32.3.7
+  checksum: d8314a8645eebf5bd753bfa302f5053ce8996cf5b7f6bda4dcf7bbb5c3b0037797cef226d1a4d1d5eb675a30a5692882862b22e124055d70016c1f910d5465b3
+  languageName: node
+  linkType: hard
+
+"victory-line@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-line@npm:32.3.7"
   dependencies:
     d3-shape: ^1.2.0
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: b460f98167553c131f2ecf31caac8744b09bce9762e75ba87caf4d9e29cdfba8c5a4ec1ffc283ada0cab344bcfd33c9a85d1d7603c3fcde6d4052f2faa940003
+    victory-core: ^32.3.7
+  checksum: aba3d8adb304e8e348b78ae2f0fc028b3e6a676707ef629a55030e72f2aeaf573815d0cec017a16e40d16efa7dcc48fbf07a48d5aec39eb7e6b178e2d5484dc9
   languageName: node
   linkType: hard
 
-"victory-pie@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-pie@npm:31.2.0"
+"victory-pie@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-pie@npm:32.3.7"
   dependencies:
     d3-shape: ^1.0.0
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 333f2aeb099cb3cb4b3d6da49c1cb3a576be9b2f87faf032475e7689b291c12643b672c683751e2c86931da2b64e7d243c30215f083f562e5ac460744dad2ada
+    victory-core: ^32.3.7
+  checksum: 491a1de3592f4f2af52d26ffc0f29bd551179db60f74d8caff2c5bce215f3b41fffd383c5ef8a9ce6616256eff319f45cebb3dcea70d1b826e0f572e8e17bd2b
   languageName: node
   linkType: hard
 
-"victory-polar-axis@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-polar-axis@npm:31.2.0"
+"victory-polar-axis@npm:^32.0.0, victory-polar-axis@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-polar-axis@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: b13e62c2b32228054a7acc5dac1a3bfc76b8596fa48bb78378b1b32ce9c44e5dcd928b0fd2685655f7f3b298c086aecde8fd876c5f5844a7ee526f20aafcee77
+    victory-core: ^32.3.7
+  checksum: c68d777cb1d7dff4bea821d5c2c9449e914408d53502ce6edcd0c0a6fa42f3c76d9be243b590def842024eaf856535315390faa0660f28667d742b1514a9a43a
   languageName: node
   linkType: hard
 
-"victory-scatter@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-scatter@npm:31.2.0"
+"victory-scatter@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-scatter@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: 36801a195b208be4bac40b0bb5664e32322ced09dc4322bc84c76e006881ae39f44d16a9958c74f26f6165b7abb527db88bc6436873c31da1cf078f831dd0bf3
+    victory-core: ^32.3.7
+  checksum: 42b69cd0d23ade694929fd0fd99f5404e6ddf8bba72dba189056f13bc376c655e99a67a77e66d0541eb55fe9b55c19adf091146efa9a661403767b568bab4abc
   languageName: node
   linkType: hard
 
-"victory-selection-container@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-selection-container@npm:31.2.0"
+"victory-selection-container@npm:^32.0.0, victory-selection-container@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-selection-container@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: f5214c645b306ec05fefb8cb38b98218854fec85142cabb89ccea5004fc2473a3cd6092d64dce6e22727b3b5567f77de649c16e8a6168ebdd21d91d53d400aaa
+    victory-core: ^32.3.7
+  checksum: 94f4ed0f01fda8089af21febd6a7f708b85aa7f1559d33cbf0ab82986b7dfc03f6b0a074dc444fab894b9fc27fbe4a735d77e312bce7a54122e0e12dac4b55e5
   languageName: node
   linkType: hard
 
-"victory-shared-events@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-shared-events@npm:31.2.0"
+"victory-shared-events@npm:^32.0.0, victory-shared-events@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-shared-events@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-    victory-core: ^31.2.0
-  checksum: aacf20f75c56a6dc9e2c403756b12c398b6300c42a796d9b8816336a6021c7533e044546239f0707432cf558a58cf3c5dd7324e2a4a67a8584111fac2648b3dc
-  languageName: node
-  linkType: hard
-
-"victory-stack@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-stack@npm:31.2.0"
-  dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-    victory-core: ^31.2.0
-  checksum: 2f5212c9572c13a4b48df9d6e6ea18178b8dbcd934226fa0301794f1ee24d2e06fc3e4495a8e3aa8d924fa0a08c6bc4fd1e8f38ebe84cff8fcfe1b62aa687025
+    victory-core: ^32.3.7
+  checksum: b9f46f8170fb2ea13337fa7323e891ebc80b006ce259aa085a30f31c58806e15510a18033da20a74f91f7f5099dec4c531fb96a8c8e767921d5a8ada6ccad6fa
   languageName: node
   linkType: hard
 
-"victory-tooltip@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-tooltip@npm:31.2.0"
+"victory-stack@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-stack@npm:32.3.7"
   dependencies:
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: b2090a3fb0726331139d4ac79b74fe9de2062297946584b50c6593e588645109cbf4080b5154fa713d9045fb093ff02b9deeaaf0f4fa39bd1a01613115d95f28
+    react-fast-compare: ^2.0.0
+    victory-core: ^32.3.7
+  checksum: 59e9f102a5497237d58688e17a6edf2231117c02ad66e44b96dcbf2ceb0366a421def395f866f412b8fa6a2865094d74babcebb186ef188b0d6f0b974530cf3d
   languageName: node
   linkType: hard
 
-"victory-voronoi-container@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-voronoi-container@npm:31.2.0"
+"victory-tooltip@npm:^32.0.0, victory-tooltip@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-tooltip@npm:32.3.7"
+  dependencies:
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    victory-core: ^32.3.7
+  checksum: 83f929eaf9674696fd9eeb3145e7a0aa2db36aed4d2d113ff0dc20a864c5728a3cd9e48ab8dadc974a26da91c64d89c9c5ee430df58716a0509cbf5cf5d2861b
+  languageName: node
+  linkType: hard
+
+"victory-voronoi-container@npm:^32.0.0, victory-voronoi-container@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-voronoi-container@npm:32.3.7"
+  dependencies:
+    delaunay-find: 0.0.3
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    victory-core: ^32.3.7
+    victory-tooltip: ^32.3.7
+  checksum: 71fdce95d6428b7a739d31dafcf9b17031d72d86518d7cc407f38a64a4c9f224a3e75c23c34ce2bdc1e26266655905f9172a65fe7cd78eb320c02ad13db12d58
+  languageName: node
+  linkType: hard
+
+"victory-voronoi@npm:^32.0.0":
+  version: 32.3.7
+  resolution: "victory-voronoi@npm:32.3.7"
   dependencies:
     d3-voronoi: ^1.1.2
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-    victory-tooltip: ^31.2.0
-  checksum: 58fd0f90836abe1788af7168ffa52a3dc0b7f660f5cd0b4ad1b87ad0a7053cc762102c85bfae06e1e5a7bd80acf7df707028e3093a3ed4185f7d906a84f31dea
+    victory-core: ^32.3.7
+  checksum: 2ead8e1deb35ca137f553cf9c003eb92bc944ef1dfaeb0b70a8847f85d10e01e1bd27492d64cfcb178c99b0a16e238b949319d95e2c8d50c1af2384308f9fc14
   languageName: node
   linkType: hard
 
-"victory-voronoi@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-voronoi@npm:31.2.0"
+"victory-zoom-container@npm:^32.0.0, victory-zoom-container@npm:^32.3.7":
+  version: 32.3.7
+  resolution: "victory-zoom-container@npm:32.3.7"
   dependencies:
-    d3-voronoi: ^1.1.2
-    lodash: ^4.17.5
+    lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: bb95d83b0910422ea9f0135ceeea01996d866bd8308231a443be051b217f7b7397b6d0b37d88b1cffae85f20bdcf82ecfb2bdb15e09f1e9cdf7b19eb53b27c9e
+    victory-core: ^32.3.7
+  checksum: 63ec351e57dd8f39b6521825f075c277fd7ead48342f4f38400ee719a7d150381206302f4179d6c0adb15a816d0ac4c2a69c2af610db1c57ff28506fb82c9d64
   languageName: node
   linkType: hard
 
-"victory-zoom-container@npm:^31.2.0":
-  version: 31.2.0
-  resolution: "victory-zoom-container@npm:31.2.0"
+"victory@npm:32.0.0":
+  version: 32.0.0
+  resolution: "victory@npm:32.0.0"
   dependencies:
-    lodash: ^4.17.5
-    prop-types: ^15.5.8
-    victory-core: ^31.2.0
-  checksum: e0e1d2d92d09a572fc67f570f74b59e19de856f6379e3ee8464b36acbaa388eacb04cb1c97c4f03387ff0168b8ebada4d9bc26eff62b76224f7f56de485aff22
-  languageName: node
-  linkType: hard
-
-"victory@npm:31.3.0":
-  version: 31.3.0
-  resolution: "victory@npm:31.3.0"
-  dependencies:
-    victory-area: ^31.2.0
-    victory-axis: ^31.2.0
-    victory-bar: ^31.2.0
-    victory-box-plot: ^31.3.0
-    victory-brush-container: ^31.2.0
-    victory-brush-line: ^31.2.0
-    victory-candlestick: ^31.2.0
-    victory-chart: ^31.2.0
-    victory-core: ^31.2.0
-    victory-create-container: ^31.2.0
-    victory-cursor-container: ^31.2.0
-    victory-errorbar: ^31.2.0
-    victory-group: ^31.2.0
-    victory-legend: ^31.2.0
-    victory-line: ^31.2.0
-    victory-pie: ^31.2.0
-    victory-polar-axis: ^31.2.0
-    victory-scatter: ^31.2.0
-    victory-selection-container: ^31.2.0
-    victory-shared-events: ^31.2.0
-    victory-stack: ^31.2.0
-    victory-tooltip: ^31.2.0
-    victory-voronoi: ^31.2.0
-    victory-voronoi-container: ^31.2.0
-    victory-zoom-container: ^31.2.0
-  checksum: f73c720aa2dda91418c5d2317b30b92aaf5ae9ebd726fa1fb472ef4ef5d98df2651b7007f600a0d9b3b826eee56a08e436a4e064b446ec6a685fff2108f17c1d
+    victory-area: ^32.0.0
+    victory-axis: ^32.0.0
+    victory-bar: ^32.0.0
+    victory-box-plot: ^32.0.0
+    victory-brush-container: ^32.0.0
+    victory-brush-line: ^32.0.0
+    victory-candlestick: ^32.0.0
+    victory-chart: ^32.0.0
+    victory-core: ^32.0.0
+    victory-create-container: ^32.0.0
+    victory-cursor-container: ^32.0.0
+    victory-errorbar: ^32.0.0
+    victory-group: ^32.0.0
+    victory-legend: ^32.0.0
+    victory-line: ^32.0.0
+    victory-pie: ^32.0.0
+    victory-polar-axis: ^32.0.0
+    victory-scatter: ^32.0.0
+    victory-selection-container: ^32.0.0
+    victory-shared-events: ^32.0.0
+    victory-stack: ^32.0.0
+    victory-tooltip: ^32.0.0
+    victory-voronoi: ^32.0.0
+    victory-voronoi-container: ^32.0.0
+    victory-zoom-container: ^32.0.0
+  checksum: 388c994269d40b0d6255587db4c1a58754ea2456453d03df04e9c9ff1dc0b7867dfe79bc9c617acd5f9b1d3601e51260478c480adacf63fa61ea4db44e6987d5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,8 +4274,8 @@ __metadata:
     translate-svg-path: 0.0.1
     url-loader: 4.1.1
     util: 0.12.5
-    victory: 32.0.0
-    victory-core: 32.0.0
+    victory: 33.0.0
+    victory-core: 33.0.0
     voilab-pdf-table: 0.5.1
     webpack: 5.94.0
     webpack-cli: 5.1.4
@@ -7610,12 +7610,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delaunay-find@npm:0.0.3":
-  version: 0.0.3
-  resolution: "delaunay-find@npm:0.0.3"
+"delaunay-find@npm:0.0.5":
+  version: 0.0.5
+  resolution: "delaunay-find@npm:0.0.5"
   dependencies:
     delaunator: ^4.0.0
-  checksum: da7d5514e89bf9e9695a74cf1e929bfa05ab39259f31ea873260c19094b6918762d5cc8dc6e3360c855660eec3b26e4b63939b5797f771ecacaa53fe6c93c5c9
+  checksum: 8bc62c16cab6840b5f42639b820498db527659bcc6a4973aec1f78c083a6401fed6a8c0e727f8eb3c19455e9ee146caf28ba92f1ce6506d92451a72217adef22
   languageName: node
   linkType: hard
 
@@ -16853,120 +16853,104 @@ __metadata:
   languageName: node
   linkType: hard
 
-"victory-area@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-area@npm:32.3.7"
+"victory-area@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-area@npm:33.1.7"
   dependencies:
     d3-shape: ^1.2.0
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: abb15808af7ca15a7123a431cc6b057d454ecff5463c373ca190de8f5bfbd8e722acaa8a49391167d657a13589c68e525e2eff8e2b3874986638265187aaa82b
+    victory-core: ^33.1.7
+  checksum: e3c6e9c08655c9097dc6eff8c08d9141909d101a03f1a1600e05035537ca808a1954de154d2a0b8a09b3c411743725db5b830cca9e5c25c6146f424b99a57583
   languageName: node
   linkType: hard
 
-"victory-axis@npm:^32.0.0, victory-axis@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-axis@npm:32.3.7"
+"victory-axis@npm:^33.0.0, victory-axis@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-axis@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 632023f11d6f807bd05a697483d7c55e22b5c7300129b83f0917880ac44c039f9c0198154b344df45f55a7688338f1fa24e65e396a5e0fb1036fa7d8e14e71d4
+    victory-core: ^33.1.7
+  checksum: bd17f40e71949272a3464e6a9f04669416fd8abece24d5d07376598cb294eba2d4c79174d9b7171c9984bf1e119adb9f04a60774df6635a31dc67871e2001759
   languageName: node
   linkType: hard
 
-"victory-bar@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-bar@npm:32.3.7"
+"victory-bar@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-bar@npm:33.1.7"
   dependencies:
     d3-shape: ^1.2.0
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: d0e22bb5e7d6d72b7cb173428a0fb365406e92d328e29711d91241740aebed45f5d807386172f5d6aa7eb964ed7b1f90c8202291899271a33cb71b586ec43939
+    victory-core: ^33.1.7
+  checksum: fab73fb5b70b9de6af77eff6a9aac371bc08fb185ec98cd7fe143acfada007680fbc4539e673f4b2512926c323f741c85879f830cf85b2c964c7b84eba863c76
   languageName: node
   linkType: hard
 
-"victory-box-plot@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-box-plot@npm:32.3.7"
+"victory-box-plot@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-box-plot@npm:33.1.7"
   dependencies:
     d3-array: ^1.2.0
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: bf9418a976aec72f2abba410e46cb6736b306032517acd4f8e20637cb8cd3bafe1a8558ea507c2532c6788b19d8bcb8b66bb4f2faf4ee32b9fa5991b82cc814e
+    victory-core: ^33.1.7
+  checksum: 69b2bba65ece747d187cf5b1418a1ad0d4acad9708bf5ed7bfe7f45e6774a1e43b902dd0b2b5aee673cbf9433314c98ecea61e18828363e9bc2a8b66e31532fa
   languageName: node
   linkType: hard
 
-"victory-brush-container@npm:^32.0.0, victory-brush-container@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-brush-container@npm:32.3.7"
+"victory-brush-container@npm:^33.0.0, victory-brush-container@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-brush-container@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 0cfbe3e50f031e28a2f4adcf8950c35515f52f778f19a3519f0cdc6c99a7aa78a0e6ee523f3b6c6988c00697ecffdc82df8887391b74cb00e7d87e539d81b68e
+    victory-core: ^33.1.7
+  checksum: 9cc1df25bd3e21f504044552d758de96d9a47c06166a6210f469e00afc4c997e38c00212588d17e8178139f224625a42a4c1421d7c19f078d44d084c84775b1f
   languageName: node
   linkType: hard
 
-"victory-brush-line@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-brush-line@npm:32.3.7"
+"victory-brush-line@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-brush-line@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: ee6c51dfe6d266c75bd1310460e32964a5893d643a15d5e93a0996b5df2bda7ff1d78cfc4fe79fcb52e2f8cb51e90ca43f83dc8cdaba15c9d77b3181f9e22425
+    victory-core: ^33.1.7
+  checksum: 1f9391c6de0f6d0b119449decbe230ec2e5d20f8048f50db6658e9fb1cb8307fe9a25d91e504510328ead858b51711af8dcc90da3c55cda4c9472d540576fc96
   languageName: node
   linkType: hard
 
-"victory-candlestick@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-candlestick@npm:32.3.7"
+"victory-candlestick@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-candlestick@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: c87cb28158b86c94cd6ab7d8b3ff8a546499462311299679d92423b841b103ab180be86949d0c48d4daa395d6b5fd3207bb7eaa6954e0075cb25c9b6e10b6325
+    victory-core: ^33.1.7
+  checksum: ec97ee4752d45de2272c65c7efea766ef72b0b11ecb334c01197044e4bae4264412fed0e17085ea93c2e3728d2f99d127972e6cd418cc097422c3c677e52f4ef
   languageName: node
   linkType: hard
 
-"victory-chart@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-chart@npm:32.3.7"
+"victory-chart@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-chart@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-    victory-axis: ^32.3.7
-    victory-core: ^32.3.7
-    victory-polar-axis: ^32.3.7
-    victory-shared-events: ^32.3.7
-  checksum: 31a805f9f7a52367c3f8a7df2056ec2e9042c16461e22dd840e0362cd8f461c93891fa891930d2b00aa8f7a36c0fc2c0ecbee147f87f5603613fe9d9f8306578
+    victory-axis: ^33.1.7
+    victory-core: ^33.1.7
+    victory-polar-axis: ^33.1.7
+    victory-shared-events: ^33.1.7
+  checksum: 14d7aecc34edbe71f44fd8ac1f951a1a78afa066ddb2a41d335414955b5ade3eef3d8a5539f6de88533a7daf40ec6a1338b363e8d69fcc77da027f0d65c9b3bb
   languageName: node
   linkType: hard
 
-"victory-core@npm:32.0.0":
-  version: 32.0.0
-  resolution: "victory-core@npm:32.0.0"
-  dependencies:
-    d3-ease: ^1.0.0
-    d3-interpolate: ^1.1.1
-    d3-scale: ^1.0.0
-    d3-shape: ^1.2.0
-    d3-timer: ^1.0.0
-    lodash: ^4.17.5
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-  checksum: df9f5d1cd22eb1fd497fe31ba7963136601a6048e03cd24a388c53040108f3371fcd1cbffb796f17a0c006b826abd79d89531cc1a0f4f899e5a89bb75b9ee841
-  languageName: node
-  linkType: hard
-
-"victory-core@npm:^32.0.0, victory-core@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-core@npm:32.3.7"
+"victory-core@npm:33.0.0":
+  version: 33.0.0
+  resolution: "victory-core@npm:33.0.0"
   dependencies:
     d3-ease: ^1.0.0
     d3-interpolate: ^1.1.1
@@ -16976,228 +16960,244 @@ __metadata:
     lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-  checksum: 53d6729f5983c59b0981e467ed1a29137c05d83475028cdb5ce6cdfa807a17b7479dd065f76672c16803ada07f79cd622e13d0e077de653120fcba2f399e4fd0
+  checksum: b8d46a3c1d1998b89769a4ad37ed23f9b5be28f6fa2986cb1e2bc2b4dbb57514f77d502c8bbcecb98d9cf06ba025001256e02689af091783597f75ce34e71c00
   languageName: node
   linkType: hard
 
-"victory-create-container@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-create-container@npm:32.3.7"
+"victory-core@npm:^33.0.0, victory-core@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-core@npm:33.1.7"
+  dependencies:
+    d3-ease: ^1.0.0
+    d3-interpolate: ^1.1.1
+    d3-scale: ^1.0.0
+    d3-shape: ^1.2.0
+    d3-timer: ^1.0.0
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    react-fast-compare: ^2.0.0
+  checksum: 85421dec884e4b8a4336ba2bf1458ec3789ecd30821029b0de5c6e6ccb9cdf13345bd4624ea26f4404cc3fba0e43be817c6d5cbc0f5e145b5bc93fcc4df5e3ea
+  languageName: node
+  linkType: hard
+
+"victory-create-container@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-create-container@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
-    victory-brush-container: ^32.3.7
-    victory-core: ^32.3.7
-    victory-cursor-container: ^32.3.7
-    victory-selection-container: ^32.3.7
-    victory-voronoi-container: ^32.3.7
-    victory-zoom-container: ^32.3.7
-  checksum: 30d77372a5c232eb729d0ad6ceef7aff31e71a82268622e273411bbf7b77f54d3919f43c093ed7490370bc4f58dcd67b134f3a6bd392b342dd6b0db0837d1939
+    victory-brush-container: ^33.1.7
+    victory-core: ^33.1.7
+    victory-cursor-container: ^33.1.7
+    victory-selection-container: ^33.1.7
+    victory-voronoi-container: ^33.1.7
+    victory-zoom-container: ^33.1.7
+  checksum: dbca1615b49383652066df9362888d1eb60c6ee57c3925a436b1fc9e1ff7f78d11892f3241aad27e401793cb29d85f315bb769c500462872d72eb3d68a2a375d
   languageName: node
   linkType: hard
 
-"victory-cursor-container@npm:^32.0.0, victory-cursor-container@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-cursor-container@npm:32.3.7"
+"victory-cursor-container@npm:^33.0.0, victory-cursor-container@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-cursor-container@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 4eef7a4db5f51985957345baba062acebf209c88a527178a55cee0893dd38309fa926a03e4b51056753638c03a00a5ce439c11b5255a5af9d519c0e9d3a2aea7
+    victory-core: ^33.1.7
+  checksum: 4023443be79098b8b348b17c93a02c8f91e413ad1cb9ee918888baf136eb6645f22c0e1d714e99648952c6843a3caac09bdba73fd2c3b3f0efb6618836b98a91
   languageName: node
   linkType: hard
 
-"victory-errorbar@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-errorbar@npm:32.3.7"
+"victory-errorbar@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-errorbar@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 3b5cad489d788167d597d0ef412368b76e96b11b03349ba780b3dd54b1a8d07c138df15681ed970289f43314b9c442b605ed5e716de2dfaa2075e8d4a4b9fa50
+    victory-core: ^33.1.7
+  checksum: 6bc8b87fe519be04fbdf3ccc167ca1cd44cbbfafe8b9690ed35bbb1f33126b17f0b504ac2a729daff9ffa1cd99f32a8cad6e2d3accd2d17c69e7ca8b3e591031
   languageName: node
   linkType: hard
 
-"victory-group@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-group@npm:32.3.7"
+"victory-group@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-group@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-    victory-core: ^32.3.7
-  checksum: 0a44a203c0b7243306c32f96715c55f1b5106766bdcd9b002089141c6fd388aad133fc53baeb65b310b74909688fff74246c97f6e6585a9bf052ac805a53218b
+    victory-core: ^33.1.7
+  checksum: 7c1e2149f84b139e3cef1ada8aab858f984dcffd57363fbe6ae0827216fad9287cd3a8977eb0effbc24987c9b5196c664f563bff1988a3dcfede40d185440591
   languageName: node
   linkType: hard
 
-"victory-legend@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-legend@npm:32.3.7"
+"victory-legend@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-legend@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: d8314a8645eebf5bd753bfa302f5053ce8996cf5b7f6bda4dcf7bbb5c3b0037797cef226d1a4d1d5eb675a30a5692882862b22e124055d70016c1f910d5465b3
+    victory-core: ^33.1.7
+  checksum: 18beecdc93568b1d1fce2262df7a4d8c5901c20f11d549b43f155dad83255803a5780216b0bb5552c5f2853d240c45f9157ae3315f662c05912941bfc4c1aef8
   languageName: node
   linkType: hard
 
-"victory-line@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-line@npm:32.3.7"
+"victory-line@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-line@npm:33.1.7"
   dependencies:
     d3-shape: ^1.2.0
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: aba3d8adb304e8e348b78ae2f0fc028b3e6a676707ef629a55030e72f2aeaf573815d0cec017a16e40d16efa7dcc48fbf07a48d5aec39eb7e6b178e2d5484dc9
+    victory-core: ^33.1.7
+  checksum: 9ebe413e89f1ece3d6c32c97235bd095e67efaef14d204cbce8fe66b6c9cc6b3923f6f1dc8ecc49021adc8de1f2412f45d2e9754c32b9e2092ddff1ae63f1bf2
   languageName: node
   linkType: hard
 
-"victory-pie@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-pie@npm:32.3.7"
+"victory-pie@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-pie@npm:33.1.7"
   dependencies:
     d3-shape: ^1.0.0
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 491a1de3592f4f2af52d26ffc0f29bd551179db60f74d8caff2c5bce215f3b41fffd383c5ef8a9ce6616256eff319f45cebb3dcea70d1b826e0f572e8e17bd2b
+    victory-core: ^33.1.7
+  checksum: b7abe09beeb7ca9de37aa3eb2a5c8cccb4beee27c78efea66100019988390caf3ecaba6b4b981553aa60a464b6bdbe0fab338abaaa55cd725ab35891318be53d
   languageName: node
   linkType: hard
 
-"victory-polar-axis@npm:^32.0.0, victory-polar-axis@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-polar-axis@npm:32.3.7"
+"victory-polar-axis@npm:^33.0.0, victory-polar-axis@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-polar-axis@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: c68d777cb1d7dff4bea821d5c2c9449e914408d53502ce6edcd0c0a6fa42f3c76d9be243b590def842024eaf856535315390faa0660f28667d742b1514a9a43a
+    victory-core: ^33.1.7
+  checksum: c7bc1e3cc20f8788576448b96728f2c6d2f447273cd7ef2abe5c77ae4ae0616fe2cfaa54ae4c3f0f08d1f0626a792f33db9f6ec03e449cdd0dd3c49ddd87a6a9
   languageName: node
   linkType: hard
 
-"victory-scatter@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-scatter@npm:32.3.7"
+"victory-scatter@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-scatter@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 42b69cd0d23ade694929fd0fd99f5404e6ddf8bba72dba189056f13bc376c655e99a67a77e66d0541eb55fe9b55c19adf091146efa9a661403767b568bab4abc
+    victory-core: ^33.1.7
+  checksum: 6cf56addfac480e585590092e8506d5cd36603287102d808df57c197bbd213413d792fbc2ff6f1b2b5ef6ae9a2033e1a34872eeb9af861325a7e97597c521f38
   languageName: node
   linkType: hard
 
-"victory-selection-container@npm:^32.0.0, victory-selection-container@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-selection-container@npm:32.3.7"
+"victory-selection-container@npm:^33.0.0, victory-selection-container@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-selection-container@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 94f4ed0f01fda8089af21febd6a7f708b85aa7f1559d33cbf0ab82986b7dfc03f6b0a074dc444fab894b9fc27fbe4a735d77e312bce7a54122e0e12dac4b55e5
+    victory-core: ^33.1.7
+  checksum: 0c7deba9775add9c105007dc8237589fee5ac5aa077a300a85864342f4e90c1066263b91e8c54cecb786b9a88ff55b7abeb38279913636496e1605530b7be5d4
   languageName: node
   linkType: hard
 
-"victory-shared-events@npm:^32.0.0, victory-shared-events@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-shared-events@npm:32.3.7"
-  dependencies:
-    lodash: ^4.17.15
-    prop-types: ^15.5.8
-    react-fast-compare: ^2.0.0
-    victory-core: ^32.3.7
-  checksum: b9f46f8170fb2ea13337fa7323e891ebc80b006ce259aa085a30f31c58806e15510a18033da20a74f91f7f5099dec4c531fb96a8c8e767921d5a8ada6ccad6fa
-  languageName: node
-  linkType: hard
-
-"victory-stack@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-stack@npm:32.3.7"
+"victory-shared-events@npm:^33.0.0, victory-shared-events@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-shared-events@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
     react-fast-compare: ^2.0.0
-    victory-core: ^32.3.7
-  checksum: 59e9f102a5497237d58688e17a6edf2231117c02ad66e44b96dcbf2ceb0366a421def395f866f412b8fa6a2865094d74babcebb186ef188b0d6f0b974530cf3d
+    victory-core: ^33.1.7
+  checksum: 5f88c36e4ede86a3cf85614703970d7b195d28f5d6db777e108a1781412783c685bfc85e0f0d2262537aae7aeeb61a277b6b71430e5149664c81a7e06b6d206f
   languageName: node
   linkType: hard
 
-"victory-tooltip@npm:^32.0.0, victory-tooltip@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-tooltip@npm:32.3.7"
+"victory-stack@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-stack@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 83f929eaf9674696fd9eeb3145e7a0aa2db36aed4d2d113ff0dc20a864c5728a3cd9e48ab8dadc974a26da91c64d89c9c5ee430df58716a0509cbf5cf5d2861b
+    react-fast-compare: ^2.0.0
+    victory-core: ^33.1.7
+  checksum: c4ede1104dd5637440a18db65ddee39ea7ac877e9ff2feaa7d57fe77e76e990d4ec659bd35e45c24dad2a16198c0173250f42e7baca9b1c91ff099d4cfd5f3a3
   languageName: node
   linkType: hard
 
-"victory-voronoi-container@npm:^32.0.0, victory-voronoi-container@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-voronoi-container@npm:32.3.7"
+"victory-tooltip@npm:^33.0.0, victory-tooltip@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-tooltip@npm:33.1.7"
   dependencies:
-    delaunay-find: 0.0.3
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-    victory-tooltip: ^32.3.7
-  checksum: 71fdce95d6428b7a739d31dafcf9b17031d72d86518d7cc407f38a64a4c9f224a3e75c23c34ce2bdc1e26266655905f9172a65fe7cd78eb320c02ad13db12d58
+    victory-core: ^33.1.7
+  checksum: ca8aa54c76c3549478981f9f9b1db19ecbeb85211ed1eb2aefecc3bfc3010ea855c89b8ddd03efb7a66b31e6e4cb371c3b7a1a17cf89e3a5f60405e3361e125a
   languageName: node
   linkType: hard
 
-"victory-voronoi@npm:^32.0.0":
-  version: 32.3.7
-  resolution: "victory-voronoi@npm:32.3.7"
+"victory-voronoi-container@npm:^33.0.0, victory-voronoi-container@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-voronoi-container@npm:33.1.7"
+  dependencies:
+    delaunay-find: 0.0.5
+    lodash: ^4.17.15
+    prop-types: ^15.5.8
+    victory-core: ^33.1.7
+    victory-tooltip: ^33.1.7
+  checksum: d43d6e48645b641978e8a3011f23757f8282038cf10d617eeed8487fc097e44e493f89382de11213bfdb0acc4463993bbb00b2388c26cc6fdef19b86841cafb5
+  languageName: node
+  linkType: hard
+
+"victory-voronoi@npm:^33.0.0":
+  version: 33.1.7
+  resolution: "victory-voronoi@npm:33.1.7"
   dependencies:
     d3-voronoi: ^1.1.2
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 2ead8e1deb35ca137f553cf9c003eb92bc944ef1dfaeb0b70a8847f85d10e01e1bd27492d64cfcb178c99b0a16e238b949319d95e2c8d50c1af2384308f9fc14
+    victory-core: ^33.1.7
+  checksum: e1f8db04efba68f6a431515a5561a63db987e6e63cf65d6e7fdc0bccf3424421ef29d2166ea5fdead8e051abb31d47f9d6637620af2efa44eccba9a2f0c3879c
   languageName: node
   linkType: hard
 
-"victory-zoom-container@npm:^32.0.0, victory-zoom-container@npm:^32.3.7":
-  version: 32.3.7
-  resolution: "victory-zoom-container@npm:32.3.7"
+"victory-zoom-container@npm:^33.0.0, victory-zoom-container@npm:^33.1.7":
+  version: 33.1.7
+  resolution: "victory-zoom-container@npm:33.1.7"
   dependencies:
     lodash: ^4.17.15
     prop-types: ^15.5.8
-    victory-core: ^32.3.7
-  checksum: 63ec351e57dd8f39b6521825f075c277fd7ead48342f4f38400ee719a7d150381206302f4179d6c0adb15a816d0ac4c2a69c2af610db1c57ff28506fb82c9d64
+    victory-core: ^33.1.7
+  checksum: 36a53ee8ad640fb612351490ec88531270fa0ba7bcf443264dd4fcf5798c21b8504fe8a505b84f7474b7f94e3388fb76c13e5c604b43580e1f4c15b82b4f356f
   languageName: node
   linkType: hard
 
-"victory@npm:32.0.0":
-  version: 32.0.0
-  resolution: "victory@npm:32.0.0"
+"victory@npm:33.0.0":
+  version: 33.0.0
+  resolution: "victory@npm:33.0.0"
   dependencies:
-    victory-area: ^32.0.0
-    victory-axis: ^32.0.0
-    victory-bar: ^32.0.0
-    victory-box-plot: ^32.0.0
-    victory-brush-container: ^32.0.0
-    victory-brush-line: ^32.0.0
-    victory-candlestick: ^32.0.0
-    victory-chart: ^32.0.0
-    victory-core: ^32.0.0
-    victory-create-container: ^32.0.0
-    victory-cursor-container: ^32.0.0
-    victory-errorbar: ^32.0.0
-    victory-group: ^32.0.0
-    victory-legend: ^32.0.0
-    victory-line: ^32.0.0
-    victory-pie: ^32.0.0
-    victory-polar-axis: ^32.0.0
-    victory-scatter: ^32.0.0
-    victory-selection-container: ^32.0.0
-    victory-shared-events: ^32.0.0
-    victory-stack: ^32.0.0
-    victory-tooltip: ^32.0.0
-    victory-voronoi: ^32.0.0
-    victory-voronoi-container: ^32.0.0
-    victory-zoom-container: ^32.0.0
-  checksum: 388c994269d40b0d6255587db4c1a58754ea2456453d03df04e9c9ff1dc0b7867dfe79bc9c617acd5f9b1d3601e51260478c480adacf63fa61ea4db44e6987d5
+    victory-area: ^33.0.0
+    victory-axis: ^33.0.0
+    victory-bar: ^33.0.0
+    victory-box-plot: ^33.0.0
+    victory-brush-container: ^33.0.0
+    victory-brush-line: ^33.0.0
+    victory-candlestick: ^33.0.0
+    victory-chart: ^33.0.0
+    victory-core: ^33.0.0
+    victory-create-container: ^33.0.0
+    victory-cursor-container: ^33.0.0
+    victory-errorbar: ^33.0.0
+    victory-group: ^33.0.0
+    victory-legend: ^33.0.0
+    victory-line: ^33.0.0
+    victory-pie: ^33.0.0
+    victory-polar-axis: ^33.0.0
+    victory-scatter: ^33.0.0
+    victory-selection-container: ^33.0.0
+    victory-shared-events: ^33.0.0
+    victory-stack: ^33.0.0
+    victory-tooltip: ^33.0.0
+    victory-voronoi: ^33.0.0
+    victory-voronoi-container: ^33.0.0
+    victory-zoom-container: ^33.0.0
+  checksum: 0ddf4cc512487c908cfa35af26b37e116b0a25a0459e0d46662997816e94454faf0484488640fa11f6367c67064edc3b9582f85ba2f2c332273b0bf24c45fae2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The last of the first round of deep dependency updates. Much more detail in the ticket for [WEB-3179], but had to navigate through multiple layers of breaking major version updates in `victory-charts` in order to get to a `d3` subdependency version that no longer had a security issue associated with it. While I was heading to the fridge anyway, I moved `victory-charts` to the latest version instead of one major version behind latest.


paired with blip pr: https://github.com/tidepool-org/blip/pull/1499

[WEB-3179]: https://tidepool.atlassian.net/browse/WEB-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ