### PR TITLE
Remove nodejs stable job from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-sudo: false
-
-language: node_js
-
+os: linux
 dist: jammy
+language: node_js
 
 node_js:
   - "20.8.0"
-  - "stable"
 
 cache:
   yarn: true
@@ -31,7 +28,3 @@ services:
 script:
   - npm test
   - ./artifact.sh
-
-matrix:
-  allow_failures:
-    - node_js: "stable"


### PR DESCRIPTION
Also clean up any non-breaking config warnings in the Travis UI