### PR TITLE
[WEB-3030] Fix Twiist Loop override durations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.44.1-rc.3",
+  "version": "1.44.1-rc.4",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -545,11 +545,10 @@ export class DataUtil {
       const isOverrideEvent = d.subType === 'pumpSettingsOverride';
 
       if (_.isFinite(d.duration)) {
-        // Loop is reporting these durations in seconds instead of the milliseconds historically
-        // used by Tandem.
-        // For now, until a fix is present, we'll convert.  Once a fix is present, we will only
-        // convert for Loop versions prior to the fix.
-        if (isOverrideEvent && isLoop(d)) d.duration = d.duration * 1000;
+        // DIY and Tidepool Loop are reporting these durations in seconds instead of the milliseconds.
+        // For now, until a fix is present, we'll convert for Tidepool Loop and DIY Loop.
+        // Once a fix is present, we will only convert for DIY and Tidepool Loop versions prior to the fix.
+        if (isOverrideEvent && (isTidepoolLoop(d) || isDIYLoop(d))) d.duration = d.duration * 1000;
         d.normalEnd = d.normalTime + d.duration;
 
         // If the provided duration extends into the future, we truncate the normalEnd to the

--- a/src/utils/basics/data.js
+++ b/src/utils/basics/data.js
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import i18next from 'i18next';
 
-import { getPumpVocabulary, getUppercasedManufacturer, isLoop, isTwiistLoop } from '../device';
+import { getPumpVocabulary, getUppercasedManufacturer, isDIYLoop, isLoop, isTidepoolLoop, isTwiistLoop } from '../device';
 import {
   generateBgRangeLabels,
   reshapeBgClassesToBgBounds,
@@ -130,7 +130,7 @@ export function defineBasicsAggregations(bgPrefs, manufacturer, pumpUpload = {})
           { path: 'summary.subtotals', key: 'underride', label: t('Underride'), percentage: true, selectorIndex: 6, hideEmpty: hideEmptyWizardDimensions },
         ];
 
-        if (isLoop(pumpUpload.settings)) {
+        if (isTidepoolLoop(pumpUpload.settings) || isDIYLoop(pumpUpload.settings)) {
           dimensions[1].label = t('Meal');
           dimensions.splice(3, 1);
           dimensions[2].selectorIndex = 6;


### PR DESCRIPTION
[WEB-3030]

Also contains a small fix for the extended bolus filter being unintentionally removed for twiist loop

Related PR: https://github.com/tidepool-org/blip/pull/1542

[WEB-3030]: https://tidepool.atlassian.net/browse/WEB-3030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ