### PR TITLE
[WEB-3396] Use cgm sampleInterval property when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.44.1-rc.4",
+  "version": "1.44.1-rc.5",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -230,16 +230,17 @@ export function weightedCGMCount(data) {
  */
 export function cgmSampleFrequency(datum) {
   const deviceId = _.get(datum, 'deviceId', '');
+
+  if (datum.sampleInterval) {
+    return datum.sampleInterval;
+  }
+
   if (deviceId.indexOf('AbbottFreeStyleLibre3') === 0) {
     return 5 * MS_IN_MIN;
   }
 
   if (deviceId.indexOf('AbbottFreeStyleLibre') === 0) {
     return 15 * MS_IN_MIN;
-  }
-
-  if (deviceId.indexOf('tandemCIQ') === 0 && _.get(datum, 'payload.fsl2')) {
-    return MS_IN_MIN;
   }
 
   return 5 * MS_IN_MIN;

--- a/test/utils/bloodglucose.test.js
+++ b/test/utils/bloodglucose.test.js
@@ -507,8 +507,7 @@ describe('blood glucose utilities', () => {
       expect(bgUtils.cgmSampleFrequency(libre3Datum)).to.equal(5 * MS_IN_MIN);
 
       const libre2CIQDatum = {
-        deviceId: 'tandemCIQ_XXXXX',
-        payload: { fsl2: true },
+        sampleInterval: MS_IN_MIN,
       };
 
       const g7CIQDatum = {


### PR DESCRIPTION
[WEB-3396]

Use cgm sampleInterval property when available for determining the sample frequency to use in stats.

Related PR: https://github.com/tidepool-org/blip/pull/1544

[WEB-3396]: https://tidepool.atlassian.net/browse/WEB-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ