### PR TITLE
WEB-3537 - Fix scrolling issue

### DIFF
--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -476,7 +476,7 @@ class Stat extends PureComponent {
 
         _.assign(chartProps, {
           alignment: 'middle',
-          containerComponent: <VictoryContainer responsive={false} />,
+          containerComponent: <VictoryContainer responsive={false} style={{ touchAction: 'auto' }} />,
           cornerRadius: { topLeft: 2, bottomLeft: 2, topRight: 2, bottomRight: 2 },
           data: _.map(chartData, (d, i) => ({
             ...d,
@@ -568,7 +568,7 @@ class Stat extends PureComponent {
 
         _.assign(chartProps, {
           alignment: 'middle',
-          containerComponent: <VictoryContainer responsive={false} />,
+          containerComponent: <VictoryContainer responsive={false} style={{ touchAction: 'auto' }} />,
           cornerRadius: { topLeft: 2, bottomLeft: 2, topRight: 2, bottomRight: 2 },
           data: _.map(chartData, (d, i) => ({
             ...d,


### PR DESCRIPTION
[WEB-3537]

The issue is that tapping and holding a VictoryChart with your thumb doesn't scroll the page. 

Looks like we're not the only ones who ran into this issue: https://github.com/FormidableLabs/victory/issues/1037#issuecomment-623048143

[WEB-3537]: https://tidepool.atlassian.net/browse/WEB-3537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Resolved:

https://github.com/user-attachments/assets/d7eed1da-accc-4757-a28d-901bedc96619


