### PR TITLE
[WEB-3547] Sample interval error fix for AGP prints

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.44.1-rc.7",
+  "version": "1.44.1-rc.8",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/bloodglucose.js
+++ b/src/utils/bloodglucose.js
@@ -231,7 +231,7 @@ export function weightedCGMCount(data) {
 export function cgmSampleFrequency(datum) {
   const deviceId = _.get(datum, 'deviceId', '');
 
-  if (datum.sampleInterval) {
+  if (datum?.sampleInterval) {
     return datum.sampleInterval;
   }
 


### PR DESCRIPTION
[WEB-3547] 

Basically, just needed an existential check on that the datum is defined when checking sample frequency.  

Related PR: https://github.com/tidepool-org/blip/pull/1557

[WEB-3547]: https://tidepool.atlassian.net/browse/WEB-3547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ