### PR TITLE
[WEB-3687|WEB-3697|WEB-3698] Handle twiist dosing decision extended bolus props + small tweaks for normal and oneButton

### DIFF
--- a/data/types.js
+++ b/data/types.js
@@ -426,7 +426,7 @@ export class DosingDecision extends Common {
       }],
       deviceTime: this.makeDeviceTime(),
       reason: 'normalBolus',
-      recommendedBolus: { normal: '2' },
+      recommendedBolus: { amount: '2' },
       requestedBolus: { normal: '1.5' },
       units: MGDL_UNITS,
     });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.47.0-web-3687-new-dosing-decision-extended-duration-props.1",
+  "version": "1.86.0-web-3687-new-dosing-decision-extended-duration-props.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.46.1-web-3698-dosing-decision-bolus-normal",
+  "version": "1.47.0-web-3687-new-dosing-decision-extended-duration-props.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.86.0-web-3687-new-dosing-decision-extended-duration-props.2",
+  "version": "1.47.0-web-3687-new-dosing-decision-extended-duration-props.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -406,11 +406,8 @@ class BolusTooltip extends PureComponent {
 
   render() {
     const { automated, oneButton } = bolusUtils.getBolusFromInsulinEvent(this.props.bolus)?.tags || {};
-    const tailColor = this.props.tailColor || automated ? colors.bolusAutomated : colors.bolus;
-
-    const borderColor = this.props.borderColor || automated
-      ? colors.bolusAutomated
-      : colors.bolus;
+    const tailColor = this.props.tailColor ?? (automated ? colors.bolusAutomated : colors.bolus);
+    const borderColor = this.props.borderColor ?? (automated ? colors.bolusAutomated : colors.bolus);
 
     const title = (
       <div className={styles.title}>

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -405,19 +405,18 @@ class BolusTooltip extends PureComponent {
   }
 
   render() {
-    const isAutomated = _.get(this.props.bolus, 'subType') === 'automated';
-    const isOneButton = bolusUtils.isOneButton(this.props.bolus);
-    const tailColor = this.props.tailColor || isAutomated ? colors.bolusAutomated : colors.bolus;
+    const { automated, oneButton } = bolusUtils.getBolusFromInsulinEvent(this.props.bolus)?.tags || {};
+    const tailColor = this.props.tailColor || automated ? colors.bolusAutomated : colors.bolus;
 
-    const borderColor = this.props.borderColor || isAutomated
+    const borderColor = this.props.borderColor || automated
       ? colors.bolusAutomated
       : colors.bolus;
 
     const title = (
       <div className={styles.title}>
         <div className={styles.types}>
-          {isOneButton && <div>{this.deviceLabels[ONE_BUTTON_BOLUS]}</div>}
-          {isAutomated && <div>{this.deviceLabels[AUTOMATED_BOLUS]}</div>}
+          {oneButton && <div>{this.deviceLabels[ONE_BUTTON_BOLUS]}</div>}
+          {automated && <div>{this.deviceLabels[AUTOMATED_BOLUS]}</div>}
         </div>
         {formatLocalizedFromUTC(this.props.bolus.normalTime, this.props.timePrefs, 'h:mm a')}
       </div>

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -226,14 +226,10 @@ export class DataUtil {
       d.sampleInterval = sampleInterval;
     }
 
-    // Use normal instead of deprecated amount for recommendedBolus and requestedBolus
-    if (d.type === 'dosingDecision') {
-      _.each([d.recommendedBolus, d.requestedBolus], (bolus) => {
-        if (_.isObject(bolus)) {
-          bolus.normal = _.get(bolus, 'normal', _.get(bolus, 'amount'));
-          delete bolus.amount;
-        }
-      });
+    // Use `normal` instead of deprecated `amount` for requestedBolus
+    if (d.type === 'dosingDecision' && d.requestedBolus?.amount) {
+      d.requestedBolus.normal = d.requestedBolus.amount;
+      delete d.requestedBolus.amount;
     }
 
     // We validate datums before converting the time and deviceTime to hammerTime integers,

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -333,13 +333,14 @@ export class DataUtil {
       const timeThreshold = MS_IN_MIN;
 
       // Find the dosing decision that matches the bolus by checking if there is a definitive association
-      d.dosingDecision = _.find(_.mapValues(this.bolusDosingDecisionDatumsByIdMap), ({ associations = [] }) => {
-        return _.some(associations, { reason: 'bolus', id: d.id });
-      });
+      d.dosingDecision = _.find(
+        _.mapValues(this.bolusDosingDecisionDatumsByIdMap),
+        ({ associations = [] }) => _.some(associations, { reason: 'bolus', id: d.id })
+      );
 
       // If no definitive dosing decision association is provided, such as can be the case with Tidepool
       // and DIY Loop, we look for the closest dosing decision within a time threshold
-      if (!d.dosingDecision ) {
+      if (!d.dosingDecision) {
         const proximateDosingDecisions = _.filter(
           _.mapValues(this.bolusDosingDecisionDatumsByIdMap),
           ({ time, associations }) => {

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -395,7 +395,7 @@ export function isAutomated(insulinEvent) {
  */
 export function isOneButton(insulinEvent) {
   const bolus = getBolusFromInsulinEvent(insulinEvent);
-  return _.get(bolus, 'deliveryContext') === 'oneButton';
+  return _.get(bolus, 'deliveryContext') === 'oneButton' || _.get(bolus, 'dosingDecision.reason') === 'oneButtonBolus';
 }
 
 /**

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -119,20 +119,24 @@ export function getProgrammed(insulinEvent) {
  */
 export function getRecommended(insulinEvent) {
   let event = insulinEvent;
+
   if (_.get(insulinEvent, 'type') === 'bolus') {
     event = event.dosingDecision || getWizardFromInsulinEvent(insulinEvent);
   }
+
   // a simple manual/"quick" bolus won't have a `recommended` field
   if (!event.recommendedBolus && !event.recommended) {
     return NaN;
   }
+
   const netRecommendation = event.recommendedBolus
-    ? _.get(event, ['recommendedBolus', 'normal'], null)
+    ? _.get(event, ['recommendedBolus', 'amount'], null)
     : _.get(event, ['recommended', 'net'], null);
 
   if (netRecommendation !== null) {
     return netRecommendation;
   }
+
   let rec = 0;
   rec += _.get(event, ['recommended', 'carb'], 0);
   rec += _.get(event, ['recommended', 'correction'], 0);
@@ -369,7 +373,7 @@ export function isUnderride(insulinEvent) {
 export function isCorrection(insulinEvent) {
   const recommended = insulinEvent.dosingDecision
     ? {
-      correction: _.get(insulinEvent, 'dosingDecision.recommendedBolus.normal'),
+      correction: _.get(insulinEvent, 'dosingDecision.recommendedBolus.amount'),
       carb: _.get(insulinEvent, 'dosingDecision.food.nutrition.carbohydrate.net', 0),
     }
     : _.get(insulinEvent, 'wizard.recommended', insulinEvent.recommended);

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -35,12 +35,14 @@ const automated = {
   normal: 5,
   normalTime: '2017-11-11T05:45:52.000Z',
   subType: 'automated',
+  tags: { automated: true },
 };
 
 const oneButton = {
   normal: 5,
   normalTime: '2017-11-11T05:45:52.000Z',
   deliveryContext: 'oneButton',
+  tags: { oneButton: true },
 };
 
 const cancelled = {

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -303,7 +303,7 @@ const withDosingDecision = {
   insulinOnBoard: 2.654,
   dosingDecision: {
     recommendedBolus: {
-      normal: 2.8,
+      amount: 2.8,
     },
     insulinOnBoard: {
       amount: 2.2354,
@@ -321,7 +321,7 @@ const withDosingDecisionOverride = {
   dosingDecision: {
     ...withDosingDecision.dosingDecision,
     recommendedBolus: {
-      normal: withDosingDecision.normal - 0.5,
+      amount: withDosingDecision.normal - 0.5,
     },
   },
 };
@@ -331,7 +331,7 @@ const withDosingDecisionUnderride = {
   dosingDecision: {
     ...withDosingDecision.dosingDecision,
     recommendedBolus: {
-      normal: withDosingDecision.normal + 0.5,
+      amount: withDosingDecision.normal + 0.5,
     },
   },
 };
@@ -340,7 +340,7 @@ const withDosingDecisionCorrection = {
   ...withDosingDecision,
   dosingDecision: {
     ...withDosingDecision.dosingDecision,
-    recommendedBolus: { normal: 0.5 },
+    recommendedBolus: { amount: 0.5 },
     food: { nutrition: { carbohydrate: { net: 0 } } },
   },
 };
@@ -552,9 +552,9 @@ describe('bolus utilities', () => {
       expect(bolusUtils.getRecommended(withNetRec)).to.equal(net);
     });
 
-    it('should return `normal` rec when `normal` rec exists on dosing decision', () => {
+    it('should return `amount` rec when `amount` rec exists on dosing decision', () => {
       const { recommendedBolus } = withDosingDecision.dosingDecision;
-      expect(bolusUtils.getRecommended(withDosingDecision)).to.equal(recommendedBolus.normal);
+      expect(bolusUtils.getRecommended(withDosingDecision)).to.equal(recommendedBolus.amount);
     });
 
     it('should return 0 when no bolus recommended, even if overridden', () => {


### PR DESCRIPTION
[WEB-3687] 
Properly handles extended twiist dosing decision data, mapping to expected fields on boluses for visualization.  Also, maps dosing decisions to bolus by definitive id associations when provided, as twiist currently does, and Loop is expected to do in the future.  Falls back to the proximate method we've been doing, with a couple of failsafes added to make sure we never end up proximally mapping a dosing decision to more than one bolus.  

Also includes a fix to ensure that a requested bolus normal is only mapped to `bolus.expectedNormal` it does not match `bolus.normal`

[WEB-3697]
Updates to one-button bolus checks to properly apply label to bolus tooltip for dosing decisions.

[WEB-3698] 
Reverted the `recommendedBolus.normal` back to `recommendedBolus.amount` in light of new insights for twiist data.

[WEB-3687]: https://tidepool.atlassian.net/browse/WEB-3687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3697]: https://tidepool.atlassian.net/browse/WEB-3697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3698]: https://tidepool.atlassian.net/browse/WEB-3698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ