### PR TITLE
[WEB-3717] Fix broken tests

### DIFF
--- a/test/components/settings/Tandem.test.js
+++ b/test/components/settings/Tandem.test.js
@@ -207,7 +207,7 @@ describe('Tandem', () => {
 
     it('should render an annotation', () => {
       const annotation = mounted.find(formatClassesAsSelector(styles.annotations)).hostNodes().at(0);
-      expect(annotation.text()).contains('Tandem Control-IQ uses its own preset');
+      expect(annotation.text()).contains('Tandem\'s Control-IQ Technology uses its own preset');
     });
   });
 });

--- a/test/modules/print/SettingsPrintView.test.js
+++ b/test/modules/print/SettingsPrintView.test.js
@@ -392,7 +392,7 @@ describe('SettingsPrintView', () => {
     it('should render an annotation for Tandem C-IQ data', () => {
       Renderer = createRenderer({ ...data.tandemFlatrate, deviceId: 'tandemCIQ123' }, opts, MGDL_UNITS);
       Renderer.renderTandemProfiles();
-      sinon.assert.calledWithMatch(Renderer.doc.text, sinon.match('Tandem Control-IQ uses its own preset'));
+      sinon.assert.calledWithMatch(Renderer.doc.text, sinon.match('Tandem\'s Control-IQ Technology uses its own preset'));
     });
   });
 


### PR DESCRIPTION
When I merged in some copy changes for Tandem annotations in https://github.com/tidepool-org/viz/pull/480 for [WEB-3717], I missed that there were a couple of tests broken.  This PR fixes those tests so that `develop` is in a passing state.

[WEB-3717]: https://tidepool.atlassian.net/browse/WEB-3717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ