### PR TITLE
[WEB-3777] Use bgHistorical instead of bgForecast for bg input display on bolus tooltips for dosing decisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.47.1-rc.1",
+  "version": "1.47.1-bghistorical.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -226,19 +226,15 @@ class BolusTooltip extends PureComponent {
     const wizard = this.props.bolus;
     const recommended = bolusUtils.getRecommended(wizard);
     const suggested = _.isFinite(recommended) ? `${recommended}` : null;
-
-    const bg = wizard?.dosingDecision
-      ? _.get(wizard, 'dosingDecision.smbg.value', _.get(wizard, 'dosingDecision.bgForecast.0.value', null))
-      : _.get(wizard, 'bgInput', null);
-
-    const iob = _.get(wizard, 'insulinOnBoard', null);
+    const bg = wizard?.bgInput || null;
+    const iob = wizard?.insulinOnBoard || null;
     const carbs = bolusUtils.getCarbs(wizard);
     const carbsInput = _.isFinite(carbs) && carbs > 0;
-    let carbRatio = _.get(wizard, 'insulinCarbRatio', null);
-    let isf = _.get(wizard, 'insulinSensitivity', null);
+    let carbRatio = wizard?.insulinCarbRatio || null;
+    let isf = wizard?.insulinSensitivity || null;
 
     if (this.isLoop) {
-      const { activeSchedule, carbRatios, insulinSensitivities } = _.get(wizard, 'dosingDecision.pumpSettings', {});
+      const { activeSchedule, carbRatios, insulinSensitivities } = wizard?.dosingDecision?.pumpSettings || {};
       carbRatio = _.findLast(_.sortBy(carbRatios?.[activeSchedule] || [], 'start'), ({ start }) => start < this.msPer24)?.amount || carbRatio;
       isf = _.findLast(_.sortBy(insulinSensitivities?.[activeSchedule] || [], 'start'), ({ start }) => start < this.msPer24)?.amount || isf;
     }

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -375,7 +375,7 @@ export class DataUtil {
 
         // Translate relevant dosing decision data onto expected bolus fields
         d.carbInput = d.dosingDecision.food?.nutrition?.carbohydrate?.net;
-        d.bgInput = _.last(d.dosingDecision.bgHistorical || [])?.value;
+        d.bgInput = d?.dosingDecision?.smbg?.value || _.last(d.dosingDecision.bgHistorical || [])?.value;
         d.insulinOnBoard = d.dosingDecision.insulinOnBoard?.amount;
 
         // Loop interrupted boluses may not have expectedNormal set,

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -393,6 +393,7 @@ const withTandemTarget = {
 
 const withLoopDosingDecision = {
   type: 'bolus',
+  bgInput: 192,
   origin: { name: 'com.loopkit.Loop' },
   normal: 5,
   normalTime: '2017-11-11T05:45:52.000Z',
@@ -400,9 +401,6 @@ const withLoopDosingDecision = {
   expectedNormal: 6,
   insulinOnBoard: 2.654,
   dosingDecision: {
-    smbg: {
-      value: 192,
-    },
     insulinOnBoard: {
       amount: 2.2354,
     },

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1109,7 +1109,7 @@ describe('DataUtil', () => {
       expect(bolus2.insulinOnBoard).to.equal(4);
     });
 
-    it('should join loop dosing decisions, and associated pump settings, to boluses that are within a minute of each other if not definitive associations exist', () => {
+    it.only('should join loop dosing decisions, and associated pump settings, to boluses that are within a minute of each other if not definitive associations exist', () => {
       const uploadId = 'upload1';
       const upload = { type: 'upload', id: uploadId, dataSetType: 'continuous', uploadId, time: Date.parse('2024-02-02T10:05:59.000Z'), client: { name: 'org.tidepool.Loop' } };
       const bolus = { type: 'bolus', id: 'bolus1', uploadId, time: Date.parse('2024-02-02T10:05:59.000Z'), origin: { name: 'org.tidepool.Loop' } };
@@ -1124,6 +1124,7 @@ describe('DataUtil', () => {
         requestedBolus: { normal: 12 },
         insulinOnBoard: { amount: 4 },
         food: { nutrition: { carbohydrate: { net: 30 } } },
+        smbg: { value: 140 }, // When present, smbg should be used instead of last bgHistorical
         bgHistorical: [
           { value: 100 },
           { value: 110 },
@@ -1142,7 +1143,7 @@ describe('DataUtil', () => {
       // should translate relevant dosing decision data onto expected bolus fields
       expect(bolus.expectedNormal).to.equal(12);
       expect(bolus.carbInput).to.equal(30);
-      expect(bolus.bgInput).to.equal(110);
+      expect(bolus.bgInput).to.equal(140);
       expect(bolus.insulinOnBoard).to.equal(4);
     });
 

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1109,7 +1109,7 @@ describe('DataUtil', () => {
       expect(bolus2.insulinOnBoard).to.equal(4);
     });
 
-    it.only('should join loop dosing decisions, and associated pump settings, to boluses that are within a minute of each other if not definitive associations exist', () => {
+    it('should join loop dosing decisions, and associated pump settings, to boluses that are within a minute of each other if not definitive associations exist', () => {
       const uploadId = 'upload1';
       const upload = { type: 'upload', id: uploadId, dataSetType: 'continuous', uploadId, time: Date.parse('2024-02-02T10:05:59.000Z'), client: { name: 'org.tidepool.Loop' } };
       const bolus = { type: 'bolus', id: 'bolus1', uploadId, time: Date.parse('2024-02-02T10:05:59.000Z'), origin: { name: 'org.tidepool.Loop' } };


### PR DESCRIPTION
[WEB-3777] 

We were already setting the bgHistorical last entry to `bolus.bgInput` within the dataUtil.  We just weren't using that in the bolus tooltip for dosing decisions.

With this PR, we will use the value in `bolus.bgInput`.  I also moved the code giving precedence to `dosingDecision.smbg.value` out of the bolus tooltip component and into the dataUtil, mapping that to `bolus.bgInput` if it's available.

Related PR: https://github.com/tidepool-org/blip/pull/1657

[WEB-3777]: https://tidepool.atlassian.net/browse/WEB-3777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ