### PR TITLE
[WEB-3800][WEB-3801] tag wizards

### DIFF
--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -624,6 +624,20 @@ export class DataUtil {
       };
     }
 
+    if (d.type === 'wizard') {
+      d.tags = {
+        automated: isAutomated(d),
+        correction: isCorrection(d),
+        extended: hasExtended(d),
+        interrupted: isInterruptedBolus(d),
+        manual: !d.bolus,
+        override: isOverride(d),
+        underride: isUnderride(d),
+        loop: !!this.loopDataSetsByIdMap[d.uploadId],
+        oneButton: isOneButton(d),
+      };
+    }
+
     if (d.type === 'smbg') {
       d.tags = {
         manual: d.subType === 'manual',

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1413,6 +1413,70 @@ describe('DataUtil', () => {
       });
     });
 
+    context('wizard', () => {
+      const wizard = new Types.Wizard({ deviceTime: '2018-02-01T01:00:00', carbInput: 10, ...useRawData });
+      const correctionWizard = { ...wizard, recommended: { correction: 1, carb: 0 } };
+      const extendedWizard = { ...wizard, bolus: { extended: 1, duration: 1 } };
+      const interruptedWizard = { ...wizard, bolus: { normal: 1, expectedNormal: 2 } };
+      const manualWizard = { ...wizard, bolus: undefined };
+      const overrideWizard = { ...wizard, bolus: { normal: 2, recommended: { net: 1 } } };
+      const underrideWizard = { ...wizard, bolus: { normal: 1 }, recommended: { net: 2 } };
+      const loopWizard = { ...wizard, uploadId: 'upload-3' };
+      const oneButtonWizard = { ...wizard, bolus: { deliveryContext: 'oneButton' } };
+
+      beforeEach(() => {
+        dataUtil.loopDataSetsByIdMap = { 'upload-3': { id: 'upload-3' } };
+      });
+
+      it('should tag a correction wizard with `correction`', () => {
+        expect(correctionWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(correctionWizard);
+        expect(correctionWizard.tags.correction).to.be.true;
+      });
+
+      it('should tag an extended wizard with `extended`', () => {
+        expect(extendedWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(extendedWizard);
+        expect(extendedWizard.tags.extended).to.be.true;
+      });
+
+      it('should tag an interrupted wizard with `interrupted`', () => {
+        expect(interruptedWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(interruptedWizard);
+        expect(interruptedWizard.tags.interrupted).to.be.true;
+      });
+
+      it('should tag a manual wizard with `manual`', () => {
+        expect(manualWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(manualWizard);
+        expect(manualWizard.tags.manual).to.be.true;
+      });
+
+      it('should tag an override wizard with `override`', () => {
+        expect(overrideWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(overrideWizard);
+        expect(overrideWizard.tags.override).to.be.true;
+      });
+
+      it('should tag an underride wizard with `underride`', () => {
+        expect(underrideWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(underrideWizard);
+        expect(underrideWizard.tags.underride).to.be.true;
+      });
+
+      it('should tag a loop wizard with `loop`', () => {
+        expect(loopWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(loopWizard);
+        expect(loopWizard.tags.loop).to.be.true;
+      });
+
+      it('should tag a oneButton wizard with `oneButton`', () => {
+        expect(oneButtonWizard.tags).to.be.undefined;
+        dataUtil.tagDatum(oneButtonWizard);
+        expect(oneButtonWizard.tags.oneButton).to.be.true;
+      });
+    });
+
     context('smbg', () => {
       const smbg = new Types.SMBG({ deviceTime: '2018-02-01T01:00:00', ...useRawData });
       const manualSMBG = { ...smbg, subType: 'manual' };


### PR DESCRIPTION
Takes care of [WEB-3800] and [WEB-3801]
Since wizard rendering in tideline is now [looking for tags](https://github.com/tidepool-org/tideline/pull/477/files#diff-52851a90d24200b579e99591495b25d70e644f33b96a07424f544247ed28bdfc), we should tag em.