### PR TITLE
[WEB-3796] extended 0 handling

### DIFF
--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -228,16 +228,22 @@ export class DataUtil {
 
     if (d.type === 'dosingDecision') {
       // Use `normal` instead of deprecated `amount` for requestedBolus
-      if (!d.requestedBolus?.normal && d.requestedBolus?.amount) {
+      if (d.requestedBolus?.normal == null && d.requestedBolus?.amount != null) {
         d.requestedBolus.normal = d.requestedBolus.amount;
         delete d.requestedBolus.amount;
       }
 
-      // Use `amount` field instead of `normal` and/or `extended | duration` for recommendedBolus
-      if (!d.recommendedBolus?.amount && (d.recommendedBolus?.extended || d.recommendedBolus?.normal)) {
-        d.recommendedBolus.amount = (d.recommendedBolus.extended || 0) + (d.recommendedBolus.normal || 0);
-        delete d.recommendedBolus.extended;
+      // Use `amount` field for recommendedBolus if not present, but normal/extended are
+      if (
+        d.recommendedBolus &&
+        d.recommendedBolus.amount == null &&
+        (d.recommendedBolus.normal != null || d.recommendedBolus.extended != null)
+      ) {
+        // Both normal and extended can be zero, so check for null/undefined only
+        d.recommendedBolus.amount =
+          (d.recommendedBolus.normal ?? 0) + (d.recommendedBolus.extended ?? 0);
         delete d.recommendedBolus.normal;
+        delete d.recommendedBolus.extended;
         delete d.recommendedBolus.duration;
       }
     }

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -328,7 +328,7 @@ export function isInterruptedBolus(insulinEvent) {
   );
 
   if (_.inRange(bolus.normal, Infinity)) {
-    if (!bolus.extended) {
+    if (!_.isFinite(bolus.extended)) {
       return cancelledDuringNormal;
     }
     return cancelledDuringNormal || cancelledDuringExtended;

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1013,6 +1013,72 @@ describe('DataUtil', () => {
       });
     });
 
+    context('dosingDecision normalization', () => {
+      const dosingDecisionBuilder = (requestedBolus, recommendedBolus) => ({
+        type: 'dosingDecision',
+        requestedBolus,
+        recommendedBolus,
+      });
+
+      beforeEach(() => {
+        dataUtil.validateDatumIn = sinon.stub().returns(true);
+      });
+
+      it('should move `requestedBolus.amount` to `requestedBolus.normal` if `normal` is not present', () => {
+        const dosingDecision = dosingDecisionBuilder({ amount: 5 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.requestedBolus.normal).to.equal(5);
+        expect(dosingDecision.requestedBolus.amount).to.be.undefined;
+      });
+
+      it('should not overwrite an existing `requestedBolus.normal` value', () => {
+        const dosingDecision = dosingDecisionBuilder({ amount: 5, normal: 2 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.requestedBolus.normal).to.equal(2);
+        expect(dosingDecision.requestedBolus.amount).to.equal(5);
+      });
+
+      it('should create `recommendedBolus.amount` from `normal` and `extended` if not present', () => {
+        const dosingDecision = dosingDecisionBuilder(undefined, { normal: 2, extended: 3 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.recommendedBolus.amount).to.equal(5);
+        expect(dosingDecision.recommendedBolus.normal).to.be.undefined;
+        expect(dosingDecision.recommendedBolus.extended).to.be.undefined;
+      });
+
+      it('should create `recommendedBolus.amount` from `normal` if `extended` is not present', () => {
+        const dosingDecision = dosingDecisionBuilder(undefined, { normal: 2 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.recommendedBolus.amount).to.equal(2);
+        expect(dosingDecision.recommendedBolus.normal).to.be.undefined;
+        expect(dosingDecision.recommendedBolus.extended).to.be.undefined;
+      });
+
+      it('should create `recommendedBolus.amount` from `extended` if `normal` is not present', () => {
+        const dosingDecision = dosingDecisionBuilder(undefined, { extended: 3 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.recommendedBolus.amount).to.equal(3);
+        expect(dosingDecision.recommendedBolus.normal).to.be.undefined;
+        expect(dosingDecision.recommendedBolus.extended).to.be.undefined;
+      });
+
+      it('should handle `0` values when creating `recommendedBolus.amount`', () => {
+        const dosingDecision = dosingDecisionBuilder(undefined, { normal: 0, extended: 0 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.recommendedBolus.amount).to.equal(0);
+        expect(dosingDecision.recommendedBolus.normal).to.be.undefined;
+        expect(dosingDecision.recommendedBolus.extended).to.be.undefined;
+      });
+
+      it('should not overwrite an existing `recommendedBolus.amount` value', () => {
+        const dosingDecision = dosingDecisionBuilder(undefined, { amount: 5, normal: 2, extended: 3 });
+        dataUtil.normalizeDatumIn(dosingDecision);
+        expect(dosingDecision.recommendedBolus.amount).to.equal(5);
+        expect(dosingDecision.recommendedBolus.normal).to.equal(2);
+        expect(dosingDecision.recommendedBolus.extended).to.equal(3);
+      });
+    });
+
     context('pumpSettings', () => {
       it('should add the datum to the `pumpSettingsDatumsByIdMap`', () => {
         dataUtil.validateDatumIn = sinon.stub().returns(true);

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1071,11 +1071,11 @@ describe('DataUtil', () => {
       });
 
       it('should not overwrite an existing `recommendedBolus.amount` value', () => {
-        const dosingDecision = dosingDecisionBuilder(undefined, { amount: 5, normal: 2, extended: 3 });
+        const dosingDecision = dosingDecisionBuilder(undefined, { amount: 5, normal: 3, extended: 4 });
         dataUtil.normalizeDatumIn(dosingDecision);
         expect(dosingDecision.recommendedBolus.amount).to.equal(5);
-        expect(dosingDecision.recommendedBolus.normal).to.equal(2);
-        expect(dosingDecision.recommendedBolus.extended).to.equal(3);
+        expect(dosingDecision.recommendedBolus.normal).to.equal(3);
+        expect(dosingDecision.recommendedBolus.extended).to.equal(4);
       });
     });
 

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -345,6 +345,21 @@ const withDosingDecisionCorrection = {
   },
 };
 
+const normalOnlyDeliveredCombo = {
+  type: 'bolus',
+  normal: 10.45,
+  extended: 0,
+  expectedExtended: 10.45,
+  duration: 0,
+  expectedDuration: 3600000,
+  dosingDecision: {
+    recommendedBolus: { amount: 20.9 },
+    requestedBolusNormal: 10.45,
+    requestedBolusExtended: 10.45,
+    requestedBolusDuration: 3600000,
+  },
+};
+
 describe('bolus utilities', () => {
   describe('getBolusFromInsulinEvent', () => {
     it('should be a function', () => {
@@ -977,6 +992,10 @@ describe('bolus utilities', () => {
       expect(bolusUtils.isInterruptedBolus(underride)).to.be.false;
       expect(bolusUtils.isInterruptedBolus(comboOverride)).to.be.false;
       expect(bolusUtils.isInterruptedBolus(extendedUnderride)).to.be.false;
+    });
+
+    it('should return true for a combo bolus where only the normal portion was delivered and extended was not delivered (but expected)', () => {
+      expect(bolusUtils.isInterruptedBolus(normalOnlyDeliveredCombo)).to.be.true;
     });
   });
 

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -354,9 +354,11 @@ const normalOnlyDeliveredCombo = {
   expectedDuration: 3600000,
   dosingDecision: {
     recommendedBolus: { amount: 20.9 },
-    requestedBolusNormal: 10.45,
-    requestedBolusExtended: 10.45,
-    requestedBolusDuration: 3600000,
+    requestedBolus: {
+      normal: 10.45,
+      extended: 10.45,
+      duration: 3600000,
+    },
   },
 };
 


### PR DESCRIPTION
For [WEB-3796], allows for handling the case that bolus.extended is 0. Additionally updates some optional chaining uses that are coerced to booleans but can have valid 0 values.

[WEB-3796]: https://tidepool.atlassian.net/browse/WEB-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ