### PR TITLE
[WEB-3836] Max basal precision update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.47.2-rc.1",
+  "version": "1.47.2-web-3836-max-basal-precision-update.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.47.2-web-3836-max-basal-precision-update.1",
+  "version": "1.47.2-web-3836-max-basal-precision-update.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.47.2-web-3836-max-basal-precision-update.2",
+  "version": "1.47.2-rc.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/modules/print/BasicsPrintView.js
+++ b/src/modules/print/BasicsPrintView.js
@@ -113,7 +113,7 @@ class BasicsPrintView extends PrintView {
   initLayout() {
     this.setLayoutColumns({
       width: this.chartArea.width,
-      gutter: 15,
+      gutter: 14,
       type: 'percentage',
       widths: [25.5, 49, 25.5],
     });
@@ -384,7 +384,7 @@ class BasicsPrintView extends PrintView {
 
     this.renderTable(tableColumns, rows, {
       showHeaders: false,
-      bottomMargin: 15,
+      bottomMargin: 14,
     });
 
     this.setFill();
@@ -496,7 +496,7 @@ class BasicsPrintView extends PrintView {
 
       this.renderTable(tableColumns, rows, {
         showHeaders: false,
-        bottomMargin: 15,
+        bottomMargin: 14,
       });
     }
   }
@@ -866,7 +866,7 @@ class BasicsPrintView extends PrintView {
           headerRenderer: this.renderCustomTextCell,
           headerHeight: 28,
         },
-        bottomMargin: 15,
+        bottomMargin: 14,
       });
     }
   }

--- a/src/modules/print/SettingsPrintView.js
+++ b/src/modules/print/SettingsPrintView.js
@@ -237,7 +237,7 @@ class SettingsPrintView extends PrintView {
     this.setLayoutColumns({
       width: this.chartArea.width,
       count: 3,
-      gutter: 15,
+      gutter: 14,
     });
 
     this.renderInsulinSettings(this.latestPumpUpload.settings);
@@ -246,7 +246,7 @@ class SettingsPrintView extends PrintView {
 
   renderInsulinSettings(settings, scheduleName) {
     const columnWidth = this.getActiveColumnWidth();
-    const valueWidth = 55;
+    const valueWidth = columnWidth / 3;
     const { rows: tableRows, columns } = insulinSettings(settings, this.manufacturer, scheduleName);
 
     const tableColumns = _.map(columns, (column, index) => ({
@@ -273,7 +273,7 @@ class SettingsPrintView extends PrintView {
     this.updateLayoutColumnPosition(this.layoutColumns.activeIndex);
 
     this.renderTable(tableColumns, tableRows, {
-      bottomMargin: 15,
+      bottomMargin: 14,
       columnDefaults: {
         zebra: true,
         headerFill: true,
@@ -291,7 +291,7 @@ class SettingsPrintView extends PrintView {
     this.setLayoutColumns({
       width: this.chartArea.width,
       count: 3,
-      gutter: 15,
+      gutter: 14,
     });
 
     const {
@@ -304,7 +304,7 @@ class SettingsPrintView extends PrintView {
 
     const tableColumns = _.map(startTimeAndValue('rate'), (column, index) => {
       const isValue = index === 1;
-      const valueWidth = 55;
+      const valueWidth = columnWidth / 3;
 
       return {
         id: column.key,
@@ -383,7 +383,7 @@ class SettingsPrintView extends PrintView {
             zebra: true,
             headerFill: true,
           },
-          bottomMargin: 15,
+          bottomMargin: 14,
         });
 
         this.updateLayoutColumnPosition(this.layoutColumns.activeIndex);
@@ -403,7 +403,7 @@ class SettingsPrintView extends PrintView {
     this.setLayoutColumns({
       width: this.chartArea.width,
       count: 3,
-      gutter: 15,
+      gutter: 14,
     });
 
     this.renderSensitivity();
@@ -422,7 +422,7 @@ class SettingsPrintView extends PrintView {
 
     const tableColumns = _.map(settings.columns, (column, index) => {
       const isValue = index > 0;
-      const valueWidth = 55;
+      const valueWidth = columnWidth / 3;
 
       return {
         id: column.key,

--- a/src/utils/settings/data.js
+++ b/src/utils/settings/data.js
@@ -430,7 +430,7 @@ export function insulinSettings(settings, manufacturer, scheduleName) {
   }
 
   const rows = [
-    { setting: deviceLabels[MAX_BASAL], value: maxBasal ? `${+(maxBasal.toFixed(DISPLAY_PRECISION_PLACES))} U/hr` : '-' },
+    { setting: deviceLabels[MAX_BASAL], value: maxBasal ? `${format.formatDecimalNumber(maxBasal, DISPLAY_PRECISION_PLACES)} U/hr` : '-' },
     { setting: deviceLabels[MAX_BOLUS], value: maxBolus ? `${maxBolus} U` : '-' },
     { setting: deviceLabels[INSULIN_DURATION] + (isControlIQ(settings) ? '*' : ''), value: insulinDuration ? `${insulinDuration} hrs` : '-' },
   ];

--- a/src/utils/settings/data.js
+++ b/src/utils/settings/data.js
@@ -31,7 +31,8 @@ import {
 } from '../../utils/constants';
 
 const t = i18next.t.bind(i18next);
-const DISPLAY_PRECISION_PLACES = 3;
+const BASAL_RATE_PRECISION_PLACES = 3;
+const MAX_BASAL_RATE_PRECISION_PLACES = 2;
 
 /**
  * noData
@@ -78,7 +79,7 @@ function getBasalRate(scheduleData, startTime) {
   if (noData(rate)) {
     return '';
   }
-  return format.formatDecimalNumber(rate, DISPLAY_PRECISION_PLACES);
+  return format.formatDecimalNumber(rate, BASAL_RATE_PRECISION_PLACES);
 }
 
 /**
@@ -149,10 +150,10 @@ export function getTotalBasalRates(scheduleData) {
       finish = scheduleData[next].start;
     }
     const hrs = (finish - start) / HOUR_IN_MILLISECONDS;
-    const amount = parseFloat(scheduleData[i].rate.toFixed(DISPLAY_PRECISION_PLACES)) * hrs;
-    total += parseFloat(amount.toFixed(DISPLAY_PRECISION_PLACES));
+    const amount = parseFloat(scheduleData[i].rate.toFixed(BASAL_RATE_PRECISION_PLACES)) * hrs;
+    total += parseFloat(amount.toFixed(BASAL_RATE_PRECISION_PLACES));
   }
-  return format.formatDecimalNumber(total, DISPLAY_PRECISION_PLACES);
+  return format.formatDecimalNumber(total, BASAL_RATE_PRECISION_PLACES);
 }
 
 /**
@@ -430,7 +431,7 @@ export function insulinSettings(settings, manufacturer, scheduleName) {
   }
 
   const rows = [
-    { setting: deviceLabels[MAX_BASAL], value: maxBasal ? `${format.formatDecimalNumber(maxBasal, DISPLAY_PRECISION_PLACES)} U/hr` : '-' },
+    { setting: deviceLabels[MAX_BASAL], value: maxBasal ? `${format.formatDecimalNumber(maxBasal, MAX_BASAL_RATE_PRECISION_PLACES)} U/hr` : '-' },
     { setting: deviceLabels[MAX_BOLUS], value: maxBolus ? `${maxBolus} U` : '-' },
     { setting: deviceLabels[INSULIN_DURATION] + (isControlIQ(settings) ? '*' : ''), value: insulinDuration ? `${insulinDuration} hrs` : '-' },
   ];

--- a/test/modules/print/SettingsPrintView.test.js
+++ b/test/modules/print/SettingsPrintView.test.js
@@ -454,7 +454,7 @@ describe('SettingsPrintView', () => {
         { id: 'setting', align: 'left', width: 200 }, // 2/3 of column width
         { id: 'value', align: 'right', width: 100 }, // 1/3 of column width
       ], [
-        { setting: 'Max Basal Rate', value: '2.000 U/hr' },
+        { setting: 'Max Basal Rate', value: '2.00 U/hr' },
         { setting: 'Maximum Bolus', value: '9.5 U' },
         { setting: 'Duration of Insulin Action', value: '4:05 hrs' },
       ]);

--- a/test/modules/print/SettingsPrintView.test.js
+++ b/test/modules/print/SettingsPrintView.test.js
@@ -434,8 +434,8 @@ describe('SettingsPrintView', () => {
       Renderer.renderInsulinSettings(data.tandemMultirate, 'Normal');
 
       sinon.assert.calledWith(Renderer.renderTable, [
-        { id: 'setting', align: 'left', width: 245 },
-        { id: 'value', align: 'right', width: 55 },
+        { id: 'setting', align: 'left', width: 200 }, // 2/3 of column width
+        { id: 'value', align: 'right', width: 100 }, // 1/3 of column width
       ], [
         { setting: 'Max Bolus', value: '12 U' },
         { setting: 'Insulin Duration', value: '5 hrs' },
@@ -451,10 +451,10 @@ describe('SettingsPrintView', () => {
       Renderer.renderInsulinSettings(data.omnipodMultirate);
 
       sinon.assert.calledWith(Renderer.renderTable, [
-        { id: 'setting', align: 'left', width: 245 },
-        { id: 'value', align: 'right', width: 55 },
+        { id: 'setting', align: 'left', width: 200 }, // 2/3 of column width
+        { id: 'value', align: 'right', width: 100 }, // 1/3 of column width
       ], [
-        { setting: 'Max Basal Rate', value: '2 U/hr' },
+        { setting: 'Max Basal Rate', value: '2.000 U/hr' },
         { setting: 'Maximum Bolus', value: '9.5 U' },
         { setting: 'Duration of Insulin Action', value: '4:05 hrs' },
       ]);

--- a/test/utils/settings/data.test.js
+++ b/test/utils/settings/data.test.js
@@ -383,7 +383,7 @@ describe('[settings] data utils', () => {
           { key: 'value' },
         ],
         rows: [
-          { setting: 'Max Basal Rate', value: '2 U/hr' },
+          { setting: 'Max Basal Rate', value: '2.000 U/hr' },
           { setting: 'Maximum Bolus', value: '9.5 U' },
           { setting: 'Duration of Insulin Action', value: '4:05 hrs' },
         ],
@@ -397,7 +397,7 @@ describe('[settings] data utils', () => {
           { key: 'value' },
         ],
         rows: [
-          { setting: 'Max Basal', value: '2 U/hr' },
+          { setting: 'Max Basal', value: '2.000 U/hr' },
           { setting: 'Max Bolus', value: '9.5 U' },
           { setting: 'Active Insulin Time', value: '4 hrs' },
         ],
@@ -416,7 +416,7 @@ describe('[settings] data utils', () => {
             setting: 'Glucose Safety Limit',
             value: '4.2 mmol/L',
           },
-          { setting: 'Maximum Basal Rate', value: '3.55 U/hr' },
+          { setting: 'Maximum Basal Rate', value: '3.550 U/hr' },
           { setting: 'Maximum Bolus', value: '10 U' },
           {
             annotations: [
@@ -442,7 +442,7 @@ describe('[settings] data utils', () => {
             setting: 'Glucose Safety Limit',
             value: '4.2 mmol/L',
           },
-          { setting: 'Maximum Basal Rate', value: '3.55 U/hr' },
+          { setting: 'Maximum Basal Rate', value: '3.550 U/hr' },
           { setting: 'Maximum Bolus', value: '10 U' },
           {
             annotations: [

--- a/test/utils/settings/data.test.js
+++ b/test/utils/settings/data.test.js
@@ -383,7 +383,7 @@ describe('[settings] data utils', () => {
           { key: 'value' },
         ],
         rows: [
-          { setting: 'Max Basal Rate', value: '2.000 U/hr' },
+          { setting: 'Max Basal Rate', value: '2.00 U/hr' },
           { setting: 'Maximum Bolus', value: '9.5 U' },
           { setting: 'Duration of Insulin Action', value: '4:05 hrs' },
         ],
@@ -397,7 +397,7 @@ describe('[settings] data utils', () => {
           { key: 'value' },
         ],
         rows: [
-          { setting: 'Max Basal', value: '2.000 U/hr' },
+          { setting: 'Max Basal', value: '2.00 U/hr' },
           { setting: 'Max Bolus', value: '9.5 U' },
           { setting: 'Active Insulin Time', value: '4 hrs' },
         ],
@@ -416,7 +416,7 @@ describe('[settings] data utils', () => {
             setting: 'Glucose Safety Limit',
             value: '4.2 mmol/L',
           },
-          { setting: 'Maximum Basal Rate', value: '3.550 U/hr' },
+          { setting: 'Maximum Basal Rate', value: '3.55 U/hr' },
           { setting: 'Maximum Bolus', value: '10 U' },
           {
             annotations: [
@@ -442,7 +442,7 @@ describe('[settings] data utils', () => {
             setting: 'Glucose Safety Limit',
             value: '4.2 mmol/L',
           },
-          { setting: 'Maximum Basal Rate', value: '3.550 U/hr' },
+          { setting: 'Maximum Basal Rate', value: '3.55 U/hr' },
           { setting: 'Maximum Bolus', value: '10 U' },
           {
             annotations: [


### PR DESCRIPTION
[WEB-3836] 

Also includes a few minor tweaks to gutter widths and column spacing to optimize being able to show values and labels without spilling over to new lines on the settings print view.

The 1px gutter witdh update was also applied to the basics view for consistency.

Related PR: https://github.com/tidepool-org/blip/pull/1685

[WEB-3836]: https://tidepool.atlassian.net/browse/WEB-3836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ