### PR TITLE
[WEB-3875] Ensure that Original Carb Value is Displayed with Bolus (in tooltip) when Carb is Later Edited (hotfix) to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.49.0",
+  "version": "1.49.1-rc.0",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -380,7 +380,9 @@ export class DataUtil {
         d.dosingDecision.pumpSettings = this.pumpSettingsDatumsByIdMap[associatedPumpSettingsId];
 
         // Translate relevant dosing decision data onto expected bolus fields
-        d.carbInput = d.dosingDecision.food?.nutrition?.carbohydrate?.net;
+        console.log(d.dosingDecision, 'dosing decision')
+        d.carbInput = d.dosingDecision.originalFood?.nutrition?.carbohydrate?.net ??
+              d.dosingDecision.food?.nutrition?.carbohydrate?.net; // use originalFood if present, as this is the original value present at time of bolus
         d.bgInput = d?.dosingDecision?.smbg?.value || _.last(d.dosingDecision.bgHistorical || [])?.value;
         d.insulinOnBoard = d.dosingDecision.insulinOnBoard?.amount;
 

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -380,7 +380,6 @@ export class DataUtil {
         d.dosingDecision.pumpSettings = this.pumpSettingsDatumsByIdMap[associatedPumpSettingsId];
 
         // Translate relevant dosing decision data onto expected bolus fields
-        console.log(d.dosingDecision, 'dosing decision')
         d.carbInput = d.dosingDecision.originalFood?.nutrition?.carbohydrate?.net ??
               d.dosingDecision.food?.nutrition?.carbohydrate?.net; // use originalFood if present, as this is the original value present at time of bolus
         d.bgInput = d?.dosingDecision?.smbg?.value || _.last(d.dosingDecision.bgHistorical || [])?.value;

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1255,7 +1255,7 @@ describe('DataUtil', () => {
       expect(bolus.dosingDecision).to.be.undefined;
     });
 
-    it('should use originalFood.carbs when present, and fall back to food.carbs otherwise, preserving the original carbs associated with the bolus', () => {
+    it('should use originalFood.nutrition.carbohydrate.net when present, and fall back to food.nutrition.carbohydrate.net otherwise, preserving the original carbs associated with the bolus', () => {
       const bolus = {
         type: 'bolus',
         id: 'bolus1',

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1170,6 +1170,7 @@ describe('DataUtil', () => {
 
       // should translate relevant dosing decision data onto expected bolus fields
       expect(bolus2.expectedNormal).to.equal(12);
+      expect(bolus2.carbInput).to.equal(30);
       expect(bolus2.bgInput).to.equal(110);
       expect(bolus2.insulinOnBoard).to.equal(4);
     });


### PR DESCRIPTION
for [WEB-3875]
This pull request updates the `DataUtil` utility to prioritize `originalFood` data when determining carbohydrate input for bolus calculations and adds corresponding test cases to ensure the functionality works as expected. This fixes a bug in WEB-3875, where later edits to the carb are displayed in connection with the bolus, even though the underlying dosing decision was based on the original carb value.

### Updates to carbohydrate input logic:
* In `src/utils/DataUtil.js`, modified the `carbInput` assignment to use `d.dosingDecision.originalFood?.nutrition?.carbohydrate?.net` as the primary source, falling back to `d.dosingDecision.food?.nutrition?.carbohydrate?.net` if `originalFood` is not present. This ensures the original carbohydrate value at the time of bolus is preserved when available. (Note that this is only present on a dosingDecision when the carb has been edited.)

### New test cases:
* In `test/utils/DataUtil.test.js`, added a test case to verify that `carbInput` prioritizes carbs in `originalFood` when present, falls back to carbs in the`food` object when `originalFood` is null, and honors explicit zero values in carbs in `originalFood`.