### PR TITLE
[WEB-4278] Fix NaN values in horizontal bar chart data causing missing bar rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-rc.2",
+  "version": "1.55.1-rc.3",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -634,12 +634,17 @@ class Stat extends PureComponent {
           alignment: 'middle',
           containerComponent: <VictoryContainer responsive={false} style={{ touchAction: 'auto' }} />,
           cornerRadius: { topLeft: 2, bottomLeft: 2, topRight: 2, bottomRight: 2 },
-          data: _.map(chartData, (d, i) => ({
-            ...d,
-            _x: Math.round(i + 1),
-            _y: total > 0 ? d.value / total : d.value,
-            index: i,
-          })),
+          data: _.map(chartData, (d, i) => {
+            const value = _.isFinite(d.value) ? d.value : 0;
+            const safeTotal = _.isFinite(total) && total > 0 ? total : 0;
+            return {
+              ...d,
+              value,
+              _x: Math.round(i + 1),
+              _y: safeTotal > 0 ? value / safeTotal : 0,
+              index: i,
+            };
+          }),
           x: '_x',
           y: '_y',
           dataComponent: (

--- a/src/components/common/stat/Stat.js
+++ b/src/components/common/stat/Stat.js
@@ -634,17 +634,12 @@ class Stat extends PureComponent {
           alignment: 'middle',
           containerComponent: <VictoryContainer responsive={false} style={{ touchAction: 'auto' }} />,
           cornerRadius: { topLeft: 2, bottomLeft: 2, topRight: 2, bottomRight: 2 },
-          data: _.map(chartData, (d, i) => {
-            const value = _.isFinite(d.value) ? d.value : 0;
-            const safeTotal = _.isFinite(total) && total > 0 ? total : 0;
-            return {
-              ...d,
-              value,
-              _x: Math.round(i + 1),
-              _y: safeTotal > 0 ? value / safeTotal : 0,
-              index: i,
-            };
-          }),
+          data: _.map(chartData, (d, i) => ({
+            ...d,
+            _x: Math.round(i + 1),
+            _y: total > 0 ? d.value / total : d.value,
+            index: i,
+          })),
           x: '_x',
           y: '_y',
           dataComponent: (

--- a/src/utils/stat.js
+++ b/src/utils/stat.js
@@ -351,6 +351,9 @@ export const reconcileTIRDatumValues = (statTIRDatum) => {
   const ranges = {};
   const total = statTIRDatum.data?.total?.value;
 
+  // If there's no valid total, reconciliation would produce NaN values, so return as-is
+  if (!_.isFinite(total) || total <= 0) return statTIRDatum;
+
   _.forEach(statTIRDatum.data.data, datum => {
     ranges[datum.id] = datum.value / total;
   });


### PR DESCRIPTION
[WEB-4278]

When navigating to a date range before data has been fetched, the Time In Range / Readings In Range bar charts fail to render and never recover, even after valid data arrives. The numeric labels (e.g. "99%") render correctly because they look up values directly from the current chart data array by index, bypassing Victory's animation state. The bars, however, depend on Victory's animated `_y` values, which get stuck on NaN because Victory cannot interpolate from NaN to a valid number.

The root cause is `reconcileTIRDatumValues()`, which divides each datum value by `total` to compute percentages. When there's no data, `total` is `0`, producing `NaN` that overwrites the datum values. The fix adds an early return when `total` is not a positive finite number, avoiding the division by zero and preserving the original `-1` placeholder values that the Stat component already treats as "no data" (rendering empty bars and `--` labels).

Related PR: https://github.com/tidepool-org/blip/pull/1890

[WEB-4278]: https://tidepool.atlassian.net/browse/WEB-4278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ