### PR TITLE
WEB-4406 - Guard from addBasalOverlappingStart if active days filtered out

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-web-4406-fix-prepend.1",
+  "version": "1.55.1-web-4406-fix-prepend.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-rc.6",
+  "version": "1.55.1-web-4406-fix-prepend.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -2383,6 +2383,12 @@ export class DataUtil {
       if (!d.normalTime) this.normalizeDatumOut(d, normalizeFields);
     });
 
+    // Skip prepending if the start of the endpoints range falls on a non-active day,
+    // as any overlapping basal from that day would not be relevant to the active days
+    const startDay = moment.utc(this.activeEndpoints.range[0])
+      .tz(_.get(this, 'timePrefs.timezoneName', 'UTC')).day();
+    if (!_.includes(this.activeDays, startDay)) return basalData;
+
     // We need to ensure all the days of the week are active to ensure we get all basals
     this.filter.byActiveDays([0, 1, 2, 3, 4, 5, 6]);
 

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -2378,6 +2378,12 @@ export class DataUtil {
     return generatedData;
   };
 
+  getEndpointStartDayOfWeek = () => (
+    moment.utc(this.activeEndpoints.range[0])
+      .tz(_.get(this, 'timePrefs.timezoneName', 'UTC'))
+      .day()
+  );
+
   addBasalOverlappingStart = (basalData = [], normalizeFields) => {
     _.each(basalData, d => {
       if (!d.normalTime) this.normalizeDatumOut(d, normalizeFields);
@@ -2385,9 +2391,7 @@ export class DataUtil {
 
     // Skip prepending if the start of the endpoints range falls on a non-active day,
     // as any overlapping basal from that day would not be relevant to the active days
-    const startDay = moment.utc(this.activeEndpoints.range[0])
-      .tz(_.get(this, 'timePrefs.timezoneName', 'UTC')).day();
-    if (!_.includes(this.activeDays, startDay)) return basalData;
+    if (!_.includes(this.activeDays, this.getEndpointStartDayOfWeek())) return basalData;
 
     // We need to ensure all the days of the week are active to ensure we get all basals
     this.filter.byActiveDays([0, 1, 2, 3, 4, 5, 6]);
@@ -2426,6 +2430,10 @@ export class DataUtil {
     _.each(pumpSettingsOverrideData, d => {
       if (!d.normalTime) this.normalizeDatumOut(d, normalizeFields);
     });
+
+    // Skip prepending if the start of the endpoints range falls on a non-active day,
+    // as any overlapping override from that day would not be relevant to the active days
+    if (!_.includes(this.activeDays, this.getEndpointStartDayOfWeek())) return pumpSettingsOverrideData;
 
     // We need to ensure all the days of the week are active to ensure we get all override datums
     this.filter.byActiveDays([0, 1, 2, 3, 4, 5, 6]);

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -357,6 +357,7 @@ describe('DataUtil', () => {
     nextDays: 1,
     prevDays: 1,
     timePrefs: defaultTimePrefs,
+    activeDays: [0, 1, 2, 3, 4, 5, 6],
   };
 
   const defaultPatientId = 'abc123';
@@ -6065,6 +6066,29 @@ describe('DataUtil', () => {
         expect(result).to.be.an('array').and.have.lengthOf(4);
         expect(result).to.eql(expectedNormalizedBasalData);
       });
+
+      it('should not add the overlapping basal datum when the endpoints start day is not in activeDays', () => {
+        const basalDataClone = _.cloneDeep(basalData);
+        const basalDatumOverlappingStartClone = _.cloneDeep(basalDatumOverlappingStart);
+
+        const expectedNormalizedBasalData = _.map(basalDataClone, normalizeExpectedDatum);
+
+        dataUtil.addData([basalDatumOverlappingStartClone.asObject()], defaultPatientId);
+
+        // dayEndpoints[0] is 2018-02-01 (Thursday = day 4); activeDays is set to Wednesday (3) only
+        dataUtil.query(createQuery({
+          timePrefs: { timeZoneAware: false },
+          endpoints: dayEndpoints,
+          activeDays: [3],
+        }));
+
+        dataUtil.activeEndpoints = dataUtil.endpoints.current;
+
+        const result = dataUtil.addBasalOverlappingStart(basalDataClone);
+
+        expect(result).to.be.an('array').and.have.lengthOf(3);
+        expect(result).to.eql(expectedNormalizedBasalData);
+      });
     });
   });
 
@@ -6135,6 +6159,29 @@ describe('DataUtil', () => {
         const result = dataUtil.addPumpSettingsOverrideOverlappingStart(deviceEventDataClone);
 
         expect(result).to.be.an('array').and.have.lengthOf(4);
+        expect(result).to.eql(expectedNormalizedDeviceEventData);
+      });
+
+      it('should not add the overlapping pump settings override datum when the endpoints start day is not in activeDays', () => {
+        const deviceEventDataClone = _.cloneDeep(deviceEventData);
+        const settingsOverrideDatumOverlappingStartClone = _.cloneDeep(settingsOverrideDatumOverlappingStart);
+
+        const expectedNormalizedDeviceEventData = _.map(deviceEventDataClone, normalizeExpectedDatum);
+
+        dataUtil.addData([settingsOverrideDatumOverlappingStartClone.asObject()], defaultPatientId);
+
+        // dayEndpoints[0] is 2018-02-01 (Thursday = day 4); activeDays is set to Wednesday (3) only
+        dataUtil.query(createQuery({
+          timePrefs: { timeZoneAware: false },
+          endpoints: dayEndpoints,
+          activeDays: [3],
+        }));
+
+        dataUtil.activeEndpoints = dataUtil.endpoints.current;
+
+        const result = dataUtil.addPumpSettingsOverrideOverlappingStart(deviceEventDataClone);
+
+        expect(result).to.be.an('array').and.have.lengthOf(3);
         expect(result).to.eql(expectedNormalizedDeviceEventData);
       });
     });


### PR DESCRIPTION
[WEB-4406]

Blip: https://github.com/tidepool-org/blip/pull/1907

[WEB-4406]: https://tidepool.atlassian.net/browse/WEB-4406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

We came across an existing bug that impacts insulin calculation accuracy.

In Trends view, when a user filters to specific days of the week (e.g., Wednesdays only), the stats calculation searches for any basal delivery that was ongoing at the start of the time window and includes it in the total (`addBasalOverlappingStart`).

However, the time window starts at the beginning of the period, not at the start of the filtered day. This means that if the overlapping data will still be added even if the start date of the window is filtered out.

Scenario
- Trends View for 1 week period, Monday - Sunday
- There is an overlapping basal datum extending from Sunday Night into the first day of the period (Monday) 
- User toggles `activeDays` filter to only show data from Wednesday
- `addOverlappingBasalStart` still adds the overlapping basal datum insulin to the calculation, resulting in: Total = (Weds data + Overlapping portion of monday).

The fix prevents this by checking whether the start of the time window falls on a selected day before searching for overlapping basals. If it doesn't, the overlapping delivery is irrelevant to the selected days and is skipped entirely. This has no impact on Daily view, where the time window always starts on the day being viewed.