### PR TITLE
[WEB-4546] Ensure the override and underride bolus legend item displays for dosingDecision-based boluses instead of only wizard boluses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-rc.1",
+  "version": "1.55.1-rc.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-rc.2",
+  "version": "1.55.1-rc.8",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-web-4546-pdf-legend-dosing-decision.1",
+  "version": "1.55.1-web-4546-pdf-legend-dosing-decision.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.1-web-4546-pdf-legend-dosing-decision.2",
+  "version": "1.55.1-rc.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.0",
+  "version": "1.55.1-web-4546-pdf-legend-dosing-decision.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/modules/print/DailyPrintView.js
+++ b/src/modules/print/DailyPrintView.js
@@ -43,6 +43,8 @@ import {
   getMaxValue,
   getNormalPercentage,
   getWizardFromInsulinEvent,
+  isOverride,
+  isUnderride,
 } from '../../utils/bolus';
 import {
   formatLocalizedFromUTC,
@@ -269,10 +271,9 @@ class DailyPrintView extends PrintView {
       },
       {
         type: 'override',
-        show: _.some(this.aggregationsByDate?.dataByDate, dateData => _.some(dateData.bolus, event => {
-          const wizard = getWizardFromInsulinEvent(event);
-          return wizard && wizard.recommended;
-        })),
+        show: _.some(this.aggregationsByDate?.dataByDate, dateData =>
+          _.some(dateData.bolus, event => isOverride(event) || isUnderride(event))
+        ),
         labels: [t('Override'), t('up & down')],
       },
       {

--- a/test/modules/print/DailyPrintView.test.js
+++ b/test/modules/print/DailyPrintView.test.js
@@ -303,244 +303,99 @@ describe('DailyPrintView', () => {
     });
 
     context('override legend show logic for dosing decision boluses', () => {
+      function getLegendItemsWithBoluses(boluses) {
+        const bolusData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: boluses,
+                  },
+                },
+              },
+            },
+          },
+        });
+        return new DailyPrintView(new Doc({ margin: MARGIN }), bolusData, opts).getLegendItems();
+      }
+
       it('should not include override legend when no bolus is an override or underride', () => {
-        // Boluses with matching programmed/recommended amounts are NOT overrides/underrides
-        const bolusesWithMatchingAmounts = [
+        const legendItems = getLegendItemsWithBoluses([
           {
             type: 'wizard',
             normalTime: 1483313400000,
             threeHrBin: 21,
-            recommended: { net: 5, carb: 50, correction: 0 },
-            bolus: {
-              type: 'bolus',
-              normal: 5,
-              normalTime: 1483313400000,
-            },
+            recommended: { net: 5, carb: 5, correction: 0 },
+            bolus: { type: 'bolus', normal: 5, normalTime: 1483313400000 },
           },
-        ];
-
-        const overrideData = _.assign({}, data, {
-          data: {
-            current: {
-              ...data.data.current,
-              aggregationsByDate: {
-                statsByDate: {},
-                dataByDate: {
-                  '2017-01-02': {
-                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
-                    bolus: bolusesWithMatchingAmounts,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        doc = new Doc({ margin: MARGIN });
-        const matchRenderer = new DailyPrintView(doc, overrideData, opts);
-        const legendItems = matchRenderer.getLegendItems();
-
-        const itemIds = _.map(legendItems, item => item.type);
-        expect(itemIds).to.not.include('override');
+        ]);
+        expect(_.map(legendItems, item => item.type)).to.not.include('override');
       });
 
       it('should not include override legend for simple boluses without dosing decisions', () => {
-        const simpleBoluses = [
-          {
-            type: 'bolus',
-            normal: 2.5,
-            normalTime: 1483313400000,
-            threeHrBin: 21,
-          },
-          {
-            type: 'bolus',
-            normal: 1.0,
-            normalTime: 1483317000000,
-            threeHrBin: 24,
-          },
-        ];
-
-        const simpleData = _.assign({}, data, {
-          data: {
-            current: {
-              ...data.data.current,
-              aggregationsByDate: {
-                statsByDate: {},
-                dataByDate: {
-                  '2017-01-02': {
-                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
-                    bolus: simpleBoluses,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        doc = new Doc({ margin: MARGIN });
-        const simpleRenderer = new DailyPrintView(doc, simpleData, opts);
-        const legendItems = simpleRenderer.getLegendItems();
-
-        const itemIds = _.map(legendItems, item => item.type);
-        expect(itemIds).to.not.include('override');
+        const legendItems = getLegendItemsWithBoluses([
+          { type: 'bolus', normal: 2.5, normalTime: 1483313400000, threeHrBin: 21 },
+          { type: 'bolus', normal: 1.0, normalTime: 1483317000000, threeHrBin: 24 },
+        ]);
+        expect(_.map(legendItems, item => item.type)).to.not.include('override');
       });
 
       it('should include override legend when a bolus is an override (programmed > recommended)', () => {
-        const overrideBoluses = [
+        const legendItems = getLegendItemsWithBoluses([
           {
             type: 'wizard',
             carbInput: 20,
             normalTime: 1483313400000,
             threeHrBin: 21,
             recommended: { net: 0.5, carb: 2, correction: -1.5 },
-            bolus: {
-              type: 'bolus',
-              normal: 2,
-              normalTime: 1483313400000,
-            },
+            bolus: { type: 'bolus', normal: 2, normalTime: 1483313400000 },
           },
-        ];
-
-        const overrideData = _.assign({}, data, {
-          data: {
-            current: {
-              ...data.data.current,
-              aggregationsByDate: {
-                statsByDate: {},
-                dataByDate: {
-                  '2017-01-02': {
-                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
-                    bolus: overrideBoluses,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        doc = new Doc({ margin: MARGIN });
-        const overrideRenderer = new DailyPrintView(doc, overrideData, opts);
-        const legendItems = overrideRenderer.getLegendItems();
-
-        const itemIds = _.map(legendItems, item => item.type);
-        expect(itemIds).to.include('override');
+        ]);
+        expect(_.map(legendItems, item => item.type)).to.include('override');
       });
 
       it('should include override legend when a bolus is an underride (programmed < recommended)', () => {
-        const underrideBoluses = [
+        const legendItems = getLegendItemsWithBoluses([
           {
             type: 'wizard',
             carbInput: 80,
             normalTime: 1483313400000,
             threeHrBin: 21,
             recommended: { net: 10, carb: 8, correction: 2 },
-            bolus: {
-              type: 'bolus',
-              normal: 8,
-              normalTime: 1483313400000,
-            },
+            bolus: { type: 'bolus', normal: 8, normalTime: 1483313400000 },
           },
-        ];
-
-        const underrideData = _.assign({}, data, {
-          data: {
-            current: {
-              ...data.data.current,
-              aggregationsByDate: {
-                statsByDate: {},
-                dataByDate: {
-                  '2017-01-02': {
-                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
-                    bolus: underrideBoluses,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        doc = new Doc({ margin: MARGIN });
-        const underrideRenderer = new DailyPrintView(doc, underrideData, opts);
-        const legendItems = underrideRenderer.getLegendItems();
-
-        const itemIds = _.map(legendItems, item => item.type);
-        expect(itemIds).to.include('override');
+        ]);
+        expect(_.map(legendItems, item => item.type)).to.include('override');
       });
 
-      it('should include override legend when bolus uses dosingDecision with override', () => {
-        const dosingDecisionBoluses = [
+      it('should include override legend when a dosingDecision bolus is an override (programmed > recommended)', () => {
+        const legendItems = getLegendItemsWithBoluses([
           {
             type: 'bolus',
             normal: 3,
             normalTime: 1483313400000,
             threeHrBin: 21,
-            dosingDecision: {
-              recommendedBolus: { amount: 0.5 },
-            },
+            dosingDecision: { recommendedBolus: { amount: 0.5 } },
           },
-        ];
-
-        const ddData = _.assign({}, data, {
-          data: {
-            current: {
-              ...data.data.current,
-              aggregationsByDate: {
-                statsByDate: {},
-                dataByDate: {
-                  '2017-01-02': {
-                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
-                    bolus: dosingDecisionBoluses,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        doc = new Doc({ margin: MARGIN });
-        const ddRenderer = new DailyPrintView(doc, ddData, opts);
-        const legendItems = ddRenderer.getLegendItems();
-
-        const itemIds = _.map(legendItems, item => item.type);
-        expect(itemIds).to.include('override');
+        ]);
+        expect(_.map(legendItems, item => item.type)).to.include('override');
       });
 
-      it('should include override legend when bolus uses dosingDecision with underride', () => {
-        const underrideDDBoluses = [
+      it('should include override legend when a dosingDecision bolus is an underride (programmed < recommended)', () => {
+        const legendItems = getLegendItemsWithBoluses([
           {
             type: 'bolus',
             normal: 2,
             normalTime: 1483313400000,
             threeHrBin: 21,
-            dosingDecision: {
-              recommendedBolus: { amount: 5 },
-            },
+            dosingDecision: { recommendedBolus: { amount: 5 } },
           },
-        ];
-
-        const underrideDDData = _.assign({}, data, {
-          data: {
-            current: {
-              ...data.data.current,
-              aggregationsByDate: {
-                statsByDate: {},
-                dataByDate: {
-                  '2017-01-02': {
-                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
-                    bolus: underrideDDBoluses,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        doc = new Doc({ margin: MARGIN });
-        const underrideDDRenderer = new DailyPrintView(doc, underrideDDData, opts);
-        const legendItems = underrideDDRenderer.getLegendItems();
-
-        const itemIds = _.map(legendItems, item => item.type);
-        expect(itemIds).to.include('override');
+        ]);
+        expect(_.map(legendItems, item => item.type)).to.include('override');
       });
     });
   });

--- a/test/modules/print/DailyPrintView.test.js
+++ b/test/modules/print/DailyPrintView.test.js
@@ -301,6 +301,248 @@ describe('DailyPrintView', () => {
       const automatedBasalItem = _.find(legendItems, item => item.type === 'basals');
       expect(automatedBasalItem.labels).to.deep.equal(['Basals', 'automated &', 'manual']);
     });
+
+    context('override legend show logic for dosing decision boluses', () => {
+      it('should not include override legend when no bolus is an override or underride', () => {
+        // Boluses with matching programmed/recommended amounts are NOT overrides/underrides
+        const bolusesWithMatchingAmounts = [
+          {
+            type: 'wizard',
+            normalTime: 1483313400000,
+            threeHrBin: 21,
+            recommended: { net: 5, carb: 50, correction: 0 },
+            bolus: {
+              type: 'bolus',
+              normal: 5,
+              normalTime: 1483313400000,
+            },
+          },
+        ];
+
+        const overrideData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: bolusesWithMatchingAmounts,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        doc = new Doc({ margin: MARGIN });
+        const matchRenderer = new DailyPrintView(doc, overrideData, opts);
+        const legendItems = matchRenderer.getLegendItems();
+
+        const itemIds = _.map(legendItems, item => item.type);
+        expect(itemIds).to.not.include('override');
+      });
+
+      it('should not include override legend for simple boluses without dosing decisions', () => {
+        const simpleBoluses = [
+          {
+            type: 'bolus',
+            normal: 2.5,
+            normalTime: 1483313400000,
+            threeHrBin: 21,
+          },
+          {
+            type: 'bolus',
+            normal: 1.0,
+            normalTime: 1483317000000,
+            threeHrBin: 24,
+          },
+        ];
+
+        const simpleData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: simpleBoluses,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        doc = new Doc({ margin: MARGIN });
+        const simpleRenderer = new DailyPrintView(doc, simpleData, opts);
+        const legendItems = simpleRenderer.getLegendItems();
+
+        const itemIds = _.map(legendItems, item => item.type);
+        expect(itemIds).to.not.include('override');
+      });
+
+      it('should include override legend when a bolus is an override (programmed > recommended)', () => {
+        const overrideBoluses = [
+          {
+            type: 'wizard',
+            carbInput: 20,
+            normalTime: 1483313400000,
+            threeHrBin: 21,
+            recommended: { net: 0.5, carb: 2, correction: -1.5 },
+            bolus: {
+              type: 'bolus',
+              normal: 2,
+              normalTime: 1483313400000,
+            },
+          },
+        ];
+
+        const overrideData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: overrideBoluses,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        doc = new Doc({ margin: MARGIN });
+        const overrideRenderer = new DailyPrintView(doc, overrideData, opts);
+        const legendItems = overrideRenderer.getLegendItems();
+
+        const itemIds = _.map(legendItems, item => item.type);
+        expect(itemIds).to.include('override');
+      });
+
+      it('should include override legend when a bolus is an underride (programmed < recommended)', () => {
+        const underrideBoluses = [
+          {
+            type: 'wizard',
+            carbInput: 80,
+            normalTime: 1483313400000,
+            threeHrBin: 21,
+            recommended: { net: 10, carb: 8, correction: 2 },
+            bolus: {
+              type: 'bolus',
+              normal: 8,
+              normalTime: 1483313400000,
+            },
+          },
+        ];
+
+        const underrideData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: underrideBoluses,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        doc = new Doc({ margin: MARGIN });
+        const underrideRenderer = new DailyPrintView(doc, underrideData, opts);
+        const legendItems = underrideRenderer.getLegendItems();
+
+        const itemIds = _.map(legendItems, item => item.type);
+        expect(itemIds).to.include('override');
+      });
+
+      it('should include override legend when bolus uses dosingDecision with override', () => {
+        const dosingDecisionBoluses = [
+          {
+            type: 'bolus',
+            normal: 3,
+            normalTime: 1483313400000,
+            threeHrBin: 21,
+            dosingDecision: {
+              recommendedBolus: { amount: 0.5 },
+            },
+          },
+        ];
+
+        const ddData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: dosingDecisionBoluses,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        doc = new Doc({ margin: MARGIN });
+        const ddRenderer = new DailyPrintView(doc, ddData, opts);
+        const legendItems = ddRenderer.getLegendItems();
+
+        const itemIds = _.map(legendItems, item => item.type);
+        expect(itemIds).to.include('override');
+      });
+
+      it('should include override legend when bolus uses dosingDecision with underride', () => {
+        const underrideDDBoluses = [
+          {
+            type: 'bolus',
+            normal: 2,
+            normalTime: 1483313400000,
+            threeHrBin: 21,
+            dosingDecision: {
+              recommendedBolus: { amount: 5 },
+            },
+          },
+        ];
+
+        const underrideDDData = _.assign({}, data, {
+          data: {
+            current: {
+              ...data.data.current,
+              aggregationsByDate: {
+                statsByDate: {},
+                dataByDate: {
+                  '2017-01-02': {
+                    ...data.data.current.aggregationsByDate.dataByDate['2017-01-02'],
+                    bolus: underrideDDBoluses,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        doc = new Doc({ margin: MARGIN });
+        const underrideDDRenderer = new DailyPrintView(doc, underrideDDData, opts);
+        const legendItems = underrideDDRenderer.getLegendItems();
+
+        const itemIds = _.map(legendItems, item => item.type);
+        expect(itemIds).to.include('override');
+      });
+    });
   });
 
   describe('calculateChartMinimums', () => {


### PR DESCRIPTION
[WEB-4546]

Related PR: https://github.com/tidepool-org/blip/pull/1911

[WEB-4546]: https://tidepool.atlassian.net/browse/WEB-4546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ