### PR TITLE
[WEB-4562] Use the most recent upload in the datautil deviceUpload map.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.2-rc.2",
+  "version": "1.55.2-rc.3",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.2-rc.3",
+  "version": "1.55.2-rc.4",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -117,6 +117,7 @@ export class DataUtil {
     this.bolusDatumsByIdMap = this.bolusDatumsByIdMap || {};
     this.bolusToWizardIdMap = this.bolusToWizardIdMap || {};
     this.deviceUploadMap = this.deviceUploadMap || {};
+    this.deviceUploadTimeMap = this.deviceUploadTimeMap || {};
     this.latestDatumByType = this.latestDatumByType || {};
     this.pumpSettingsDatumsByIdMap = this.pumpSettingsDatumsByIdMap || {};
     this.wizardDatumsByIdMap = this.wizardDatumsByIdMap || {};
@@ -341,8 +342,9 @@ export class DataUtil {
       const dexDeviceId = ['Dexcom', d.uploadId.slice(0, 6)];
       d.deviceId = dexDeviceId.join(' ');
     }
-    if (d.deviceId && !this.deviceUploadMap[d.deviceId]) {
+    if (d.deviceId && d.time > _.get(this.deviceUploadTimeMap, d.deviceId, -1)) {
       this.deviceUploadMap[d.deviceId] = d.uploadId;
+      this.deviceUploadTimeMap[d.deviceId] = d.time;
     }
   };
 
@@ -1221,6 +1223,7 @@ export class DataUtil {
       this.bolusDatumsByIdMap = {};
       this.bolusToWizardIdMap = {};
       this.deviceUploadMap = {};
+      this.deviceUploadTimeMap = {};
       this.latestDatumByType = {};
       this.pumpSettingsDatumsByIdMap = {};
       this.wizardDatumsByIdMap = {};

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -5701,7 +5701,7 @@ describe('DataUtil', () => {
       expect(result.size).to.equal(38);
 
       expect(result.devices).to.eql([
-        { id: 'Test Page Data - 123' },
+        { bgm: false, cgm: false, oneMinCgmSampleInterval: false, id: 'Test Page Data - 123', label: 'Trio', pump: false, serialNumber: undefined },
         { id: 'AbbottFreeStyleLibre-XXX-XXXX' },
         { id: 'Dexcom-XXX-XXXX' },
         { id: 'OneTouch-XXX-XXXX' },
@@ -5736,7 +5736,7 @@ describe('DataUtil', () => {
       expect(result.size).to.equal(38);
 
       expect(result.devices).to.eql([
-        { id: 'Test Page Data - 123' },
+        { bgm: false, cgm: false, oneMinCgmSampleInterval: false, id: 'Test Page Data - 123', label: 'Trio', pump: false, serialNumber: undefined },
         { id: 'AbbottFreeStyleLibre-XXX-XXXX' },
         { id: 'Dexcom-XXX-XXXX' },
         { id: 'OneTouch-XXX-XXXX' },

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -804,6 +804,29 @@ describe('DataUtil', () => {
         dataUtil.normalizeDatumIn(newerDatum);
         expect(dataUtil.latestDatumByType.any.id).to.equal(3);
       });
+
+      it('should point `deviceUploadMap[deviceId]` at the uploadId of the newest datum seen for that device, regardless of ingestion order', () => {
+        dataUtil.validateDatumIn = sinon.stub().returns(true);
+        dataUtil.deviceUploadMap = {};
+        dataUtil.deviceUploadTimeMap = {};
+
+        const initialDatum = { type: 'any', deviceId: 'device-1', uploadId: 'upload-initial', time: '2018-02-01T01:00:00' };
+        dataUtil.normalizeDatumIn(initialDatum);
+        expect(dataUtil.deviceUploadMap['device-1']).to.equal('upload-initial');
+
+        const olderDatum = { type: 'any', deviceId: 'device-1', uploadId: 'upload-older', time: '2018-02-01T00:00:00' };
+        dataUtil.normalizeDatumIn(olderDatum);
+        expect(dataUtil.deviceUploadMap['device-1']).to.equal('upload-initial');
+
+        const newerDatum = { type: 'any', deviceId: 'device-1', uploadId: 'upload-newer', time: '2018-02-01T02:00:00' };
+        dataUtil.normalizeDatumIn(newerDatum);
+        expect(dataUtil.deviceUploadMap['device-1']).to.equal('upload-newer');
+
+        const otherDeviceDatum = { type: 'any', deviceId: 'device-2', uploadId: 'upload-other', time: '2018-02-01T00:30:00' };
+        dataUtil.normalizeDatumIn(otherDeviceDatum);
+        expect(dataUtil.deviceUploadMap['device-1']).to.equal('upload-newer');
+        expect(dataUtil.deviceUploadMap['device-2']).to.equal('upload-other');
+      });
     });
 
     context('basal', () => {
@@ -3209,6 +3232,7 @@ describe('DataUtil', () => {
         dataUtil.bolusDatumsByIdMap = { foo: 'bar' };
         dataUtil.bolusToWizardIdMap = { foo: 'bar' };
         dataUtil.deviceUploadMap = { foo: 'bar' };
+        dataUtil.deviceUploadTimeMap = { foo: 1 };
         dataUtil.latestDatumByType = { foo: 'bar' };
         dataUtil.pumpSettingsDatumsByIdMap = { foo: 'bar' };
         dataUtil.wizardDatumsByIdMap = { foo: 'bar' };
@@ -3220,6 +3244,7 @@ describe('DataUtil', () => {
         expect(dataUtil.bolusDatumsByIdMap).to.eql({});
         expect(dataUtil.bolusToWizardIdMap).to.eql({});
         expect(dataUtil.deviceUploadMap).to.eql({});
+        expect(dataUtil.deviceUploadTimeMap).to.eql({});
         expect(dataUtil.latestDatumByType).to.eql({});
         expect(dataUtil.pumpSettingsDatumsByIdMap).to.eql({});
         expect(dataUtil.wizardDatumsByIdMap).to.eql({});


### PR DESCRIPTION
[WEB-4562] 

Fixes a bug where deviceUploadMap retained the first upload seen for each deviceId during ingestion, ignoring newer uploads.

As a result, devices whose data referenced an older upload would resolve to that stale entry, or sometimes an upload that had not even been fetched, preventing the custom "Trio" label from being applied when the latest upload was the one carrying the Trio client metadata.

The map now tracks the upload from the most recent datum per deviceId.

Related PR: http://github.com/tidepool-org/blip/pull/1918

[WEB-4562]: https://tidepool.atlassian.net/browse/WEB-4562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ