### PR TITLE
[WEB-4562] Use the most recent upload in the datautil deviceUpload map - part 2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.2-rc.4",
+  "version": "1.55.2-rc.5",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -118,6 +118,7 @@ export class DataUtil {
     this.bolusToWizardIdMap = this.bolusToWizardIdMap || {};
     this.deviceUploadMap = this.deviceUploadMap || {};
     this.deviceUploadTimeMap = this.deviceUploadTimeMap || {};
+    this.uploadToDeviceIdMap = this.uploadToDeviceIdMap || {};
     this.latestDatumByType = this.latestDatumByType || {};
     this.pumpSettingsDatumsByIdMap = this.pumpSettingsDatumsByIdMap || {};
     this.wizardDatumsByIdMap = this.wizardDatumsByIdMap || {};
@@ -341,6 +342,9 @@ export class DataUtil {
     if (!d.deviceId && _.get(d, 'payload.transmitterId', false)) {
       const dexDeviceId = ['Dexcom', d.uploadId.slice(0, 6)];
       d.deviceId = dexDeviceId.join(' ');
+    }
+    if (d.deviceId && d.uploadId && !this.uploadToDeviceIdMap[d.uploadId]) {
+      this.uploadToDeviceIdMap[d.uploadId] = d.deviceId;
     }
     if (d.deviceId && d.time > _.get(this.deviceUploadTimeMap, d.deviceId, -1)) {
       this.deviceUploadMap[d.deviceId] = d.uploadId;
@@ -1694,8 +1698,19 @@ export class DataUtil {
     this.startTimer('setDevices');
     const uploadsById = _.keyBy(this.sort.byTime(this.filter.byType('upload').top(Infinity)), 'uploadId');
 
+    // Fallback: when a device's primary uploadId in deviceUploadMap points at an upload datum
+    // we don't have (e.g. it wasn't fetched), pick the newest fetched upload that maps back to
+    // the same deviceId via uploadToDeviceIdMap, so we can still derive a label.
+    const newestFetchedUploadByDeviceId = _.reduce(uploadsById, (acc, upload) => {
+      const deviceId = this.uploadToDeviceIdMap[upload.uploadId];
+      if (deviceId && (!acc[deviceId] || upload.time > acc[deviceId].time)) {
+        acc[deviceId] = upload;
+      }
+      return acc;
+    }, {});
+
     this.devices = _.reduce(this.deviceUploadMap, (result, value, key) => {
-      const upload = uploadsById[value];
+      const upload = uploadsById[value] || newestFetchedUploadByDeviceId[key];
       let device = { id: key };
 
       if (upload) {

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -4479,6 +4479,46 @@ describe('DataUtil', () => {
         },
       ]);
     });
+
+    it('should fall back to a fetched upload via uploadToDeviceIdMap when deviceUploadMap points at an unfetched upload', () => {
+      const trioUpload = {
+        ...uploadData[3],
+        uploadId: 'trio-upload-id',
+        origin: { name: 'org.nightscout.Trio' },
+        deviceId: 'MyTrio123',
+        dataSetType: 'continuous',
+        deviceTime: '2018-02-01T00:00:00',
+      };
+
+      // A more recent datum that references an upload we don't have in the data set.
+      // Its newer time makes it win in deviceUploadMap, pointing the device at an
+      // unfetched uploadId — which would yield no label without the fallback.
+      const newerDatumReferencingUnfetchedUpload = new Types.Basal({
+        ...useRawData,
+        deviceTime: '2018-02-05T00:00:00',
+        deviceId: 'MyTrio123',
+        uploadId: 'unfetched-upload-id',
+      });
+
+      initDataUtil([trioUpload, newerDatumReferencingUnfetchedUpload]);
+      delete(dataUtil.devices);
+      dataUtil.setDevices();
+
+      expect(dataUtil.deviceUploadMap.MyTrio123).to.equal('unfetched-upload-id');
+      expect(dataUtil.uploadToDeviceIdMap['trio-upload-id']).to.equal('MyTrio123');
+
+      expect(dataUtil.devices).to.eql([
+        {
+          bgm: false,
+          cgm: false,
+          oneMinCgmSampleInterval: false,
+          id: 'MyTrio123',
+          label: 'Trio',
+          pump: false,
+          serialNumber: undefined,
+        },
+      ]);
+    });
   });
 
   describe('setDataAnnotations', () => {


### PR DESCRIPTION
[WEB-4562]  A second edge case with the Trio data we have to test with meant I had to expand on the previous PR.

Some data types (e.g. basal, dosingDecision) are ingested without a deviceId, so deviceUploadMap can end up pinned to an older uploadId referenced by data that does carry deviceId. When that older upload hasn't been fetched, setDevices couldn't resolve a label — most visibly, Trio devices fell back to a bare { id } entry instead of the 'Trio' label.

setDevices now builds a deviceId → newest fetched upload lookup from uploadToDeviceIdMap and uses it as a fallback when the primary uploadsById lookup misses, so labels resolve as long as any fetched upload is associated with the deviceId.

Related PR: https://github.com/tidepool-org/blip/pull/1919

[WEB-4562]: https://tidepool.atlassian.net/browse/WEB-4562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ