### PR TITLE
[WEB-4562] Fix device name not being correct after switching to device view and back to a data view.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "20.8.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.55.2-rc.5",
+  "version": "1.55.2-rc.6",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -1698,9 +1698,9 @@ export class DataUtil {
     this.startTimer('setDevices');
     const uploadsById = _.keyBy(this.sort.byTime(this.filter.byType('upload').top(Infinity)), 'uploadId');
 
-    // Fallback: when a device's primary uploadId in deviceUploadMap points at an upload datum
-    // we don't have (e.g. it wasn't fetched), pick the newest fetched upload that maps back to
-    // the same deviceId via uploadToDeviceIdMap, so we can still derive a label.
+    // Build a map of the newest fetched upload per deviceId via uploadToDeviceIdMap, used as
+    // a fallback when neither the latest-pumpSettings pointer nor the deviceUploadMap entry
+    // resolves to a fetched upload.
     const newestFetchedUploadByDeviceId = _.reduce(uploadsById, (acc, upload) => {
       const deviceId = this.uploadToDeviceIdMap[upload.uploadId];
       if (deviceId && (!acc[deviceId] || upload.time > acc[deviceId].time)) {
@@ -1709,8 +1709,23 @@ export class DataUtil {
       return acc;
     }, {});
 
+    // The latest pumpSettings's uploadId is the most authoritative signal for which upload
+    // represents the "current" device/app, since pumpSettings is the canonical record of the
+    // device's active configuration. When multiple fetched uploads share a deviceId (e.g.
+    // Trio + Loop on the same iPhone), upload datums often lack `deviceId` so they don't
+    // populate deviceUploadMap themselves, and a newer upload session doesn't necessarily
+    // mean a new configuration — so neither the deviceUploadMap entry nor an upload-time
+    // tiebreak reliably picks the upload that owns the current settings.
+    const latestPumpSettingsUploadId = _.get(this.latestDatumByType, 'pumpSettings.uploadId');
+    const latestPumpSettingsDeviceId = latestPumpSettingsUploadId
+      ? this.uploadToDeviceIdMap[latestPumpSettingsUploadId]
+      : null;
+
     this.devices = _.reduce(this.deviceUploadMap, (result, value, key) => {
-      const upload = uploadsById[value] || newestFetchedUploadByDeviceId[key];
+      const pumpSettingsUpload = (latestPumpSettingsDeviceId === key)
+        ? uploadsById[latestPumpSettingsUploadId]
+        : null;
+      const upload = pumpSettingsUpload || newestFetchedUploadByDeviceId[key] || uploadsById[value];
       let device = { id: key };
 
       if (upload) {

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -4519,6 +4519,87 @@ describe('DataUtil', () => {
         },
       ]);
     });
+
+    it('should resolve a device via the latest pumpSettings uploadId when multiple fetched uploads share a deviceId', () => {
+      // Mirrors the real-world scenario where a patient's data carries both a Trio upload and
+      // a Loop upload for the same physical device. Both upload datums lack `deviceId`, so
+      // neither directly populates deviceUploadMap; the map gets pointed at the Loop upload by
+      // an older non-upload datum. The Loop upload also happens to be chronologically newer than
+      // the Trio upload (in the user's real case, this came from `time` being stamped at
+      // ingestion via `if (!d.time) d.time = moment.utc()`), which would otherwise let it win
+      // the reverse-lookup tiebreak. The latest pumpSettings references the Trio uploadId and
+      // is the authoritative signal — it should win regardless of the other two paths.
+      const trioUpload = {
+        type: 'upload',
+        id: 'trio-upload',
+        uploadId: 'trio-upload-id',
+        dataSetType: 'continuous',
+        client: { name: 'org.nightscout.Trio' },
+        time: '2026-05-08T21:18:15.000Z',
+      };
+
+      const loopUpload = {
+        type: 'upload',
+        id: 'loop-upload',
+        uploadId: 'loop-upload-id',
+        dataSetType: 'continuous',
+        client: { name: 'com.loopkit.Loop' },
+        time: '2026-05-08T21:19:47.000Z',
+      };
+
+      const datumLinkingTrioUploadToDeviceId = new Types.Basal({
+        ...useRawData,
+        deviceTime: '2026-05-01T00:00:00',
+        deviceId: 'Apple Inc._iPhone',
+        uploadId: 'trio-upload-id',
+      });
+
+      const datumLinkingLoopUploadToDeviceId = new Types.Basal({
+        ...useRawData,
+        deviceTime: '2026-05-04T00:00:00',
+        deviceId: 'Apple Inc._iPhone',
+        uploadId: 'loop-upload-id',
+      });
+
+      const latestPumpSettings = {
+        ...loopMultirate,
+        id: 'latest-pumpSettings',
+        uploadId: 'trio-upload-id',
+        deviceTime: '2026-05-03T12:00:00',
+        time: '2026-05-03T12:00:00.000Z',
+        origin: { name: 'org.nightscout.Trio' },
+      };
+
+      initDataUtil([
+        trioUpload,
+        loopUpload,
+        datumLinkingTrioUploadToDeviceId,
+        datumLinkingLoopUploadToDeviceId,
+        latestPumpSettings,
+      ]);
+      delete(dataUtil.devices);
+      dataUtil.setDevices();
+
+      // Confirm the ambiguous setup that should otherwise resolve to Loop:
+      // deviceUploadMap was pointed at Loop by the later linking datum, and Loop's upload time
+      // is the newest among fetched uploads, so the reverse-lookup tiebreak would also pick it.
+      expect(dataUtil.deviceUploadMap['Apple Inc._iPhone']).to.equal('loop-upload-id');
+      expect(dataUtil.uploadToDeviceIdMap['trio-upload-id']).to.equal('Apple Inc._iPhone');
+      expect(dataUtil.uploadToDeviceIdMap['loop-upload-id']).to.equal('Apple Inc._iPhone');
+      expect(dataUtil.latestDatumByType.pumpSettings.uploadId).to.equal('trio-upload-id');
+
+      expect(dataUtil.devices).to.eql([
+        {
+          bgm: false,
+          cgm: false,
+          oneMinCgmSampleInterval: false,
+          id: 'Apple Inc._iPhone',
+          label: 'Trio',
+          pump: false,
+          serialNumber: undefined,
+        },
+      ]);
+    });
   });
 
   describe('setDataAnnotations', () => {
@@ -5741,7 +5822,7 @@ describe('DataUtil', () => {
       expect(result.size).to.equal(38);
 
       expect(result.devices).to.eql([
-        { bgm: false, cgm: false, oneMinCgmSampleInterval: false, id: 'Test Page Data - 123', label: 'Trio', pump: false, serialNumber: undefined },
+        { bgm: false, cgm: false, oneMinCgmSampleInterval: false, id: 'Test Page Data - 123', label: 'Test Page Data - 123', pump: false, serialNumber: undefined },
         { id: 'AbbottFreeStyleLibre-XXX-XXXX' },
         { id: 'Dexcom-XXX-XXXX' },
         { id: 'OneTouch-XXX-XXXX' },
@@ -5776,7 +5857,7 @@ describe('DataUtil', () => {
       expect(result.size).to.equal(38);
 
       expect(result.devices).to.eql([
-        { bgm: false, cgm: false, oneMinCgmSampleInterval: false, id: 'Test Page Data - 123', label: 'Trio', pump: false, serialNumber: undefined },
+        { bgm: false, cgm: false, oneMinCgmSampleInterval: false, id: 'Test Page Data - 123', label: 'Test Page Data - 123', pump: false, serialNumber: undefined },
         { id: 'AbbottFreeStyleLibre-XXX-XXXX' },
         { id: 'Dexcom-XXX-XXXX' },
         { id: 'OneTouch-XXX-XXXX' },


### PR DESCRIPTION
[WEB-4562] 

As discussed, we're just putting a bandaid over an edge case we have in the current Trio dataset we're testing against, rather than a more comprehensive refactor.

I am planning, after a little rubber-ducking with claude in light of other related changes coming in 1.56.0, do do a small PR that refactors a little when I go to back-merge this hotfix into the `1.56.0` release branch.

Related PR: https://github.com/tidepool-org/blip/pull/1923

[WEB-4562]: https://tidepool.atlassian.net/browse/WEB-4562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ