### PR TITLE
[WEB-4597] Fix edited-carb display in tooltips + daily print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ package-lock.json
 
 .codegpt
 .claude/settings.local.json
+.pi
+.pi-lens
+.apo

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.56.0-web-4597-edited-carb-qa-feedback.2",
+  "version": "1.56.0-rc.6",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.56.0-web-4597-edited-carb-qa-feedback.1",
+  "version": "1.56.0-web-4597-edited-carb-qa-feedback.2",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.56.0-rc.6",
+  "version": "1.56.0-rc.7",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.56.0-rc.5",
+  "version": "1.56.0-web-4597-edited-carb-qa-feedback.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/bolustooltip/BolusTooltip.js
+++ b/src/components/daily/bolustooltip/BolusTooltip.js
@@ -126,6 +126,10 @@ export const getTarget = (bolus, bgPrefs, timePrefs, unitStyles) => {
     // loop / trio
     const schedules = _.get(bolus, 'dosingDecision.bgTargetSchedule', []);
     const range = _.findLast(_.sortBy(schedules, 'start'), ({ start }) => start < msPer24);
+    if (!range || (!_.isFinite(range.low) && !_.isFinite(range.high))) {
+      // no dosing decision / no target schedule -> nothing to show
+      return null;
+    }
     const label = isTrio(bolus) ? t('Glucose Targets') : t('Correction Range');
     return (
       <div className={styles.target}>
@@ -265,7 +269,7 @@ const BolusTooltip = (props) => {
         <div className={unitStyles} />
       </div>
     );
-    const foodTime = wizard?.dosingDecision?.food?.time;
+    const foodTime = wizard?.foodTime ?? wizard?.dosingDecision?.food?.time;
     const carbsLabel = wizard?.tags?.foodTimeDiffers
       ? t('Carbs (eaten at {{time}})', { time: formatLocalizedFromUTC(foodTime, props.timePrefs, 'h:mm a') })
       : t('Carbs');
@@ -306,6 +310,8 @@ const BolusTooltip = (props) => {
         <div className={unitStyles} />
       </div>
     );
+    const targetLine = (!!bg || isLoop(wizard) || isTrio(wizard))
+      && getTarget(wizard, props.bgPrefs, props.timePrefs, unitStyles);
 
     return (
       <div className={styles.container}>
@@ -318,12 +324,12 @@ const BolusTooltip = (props) => {
         {overrideLine}
         {interruptedLine}
         {deliveredLine}
-        {(icRatioLine || isfLine || bg || isAnimasExtendedValue || isMedronicDeconvertedExchangeValue) && (
+        {(icRatioLine || isfLine || targetLine || isAnimasExtendedValue || isMedronicDeconvertedExchangeValue) && (
           <div className={styles.divider} />
         )}
         {icRatioLine}
         {isfLine}
-        {!!bg && getTarget(wizard, props.bgPrefs, unitStyles)}
+        {targetLine}
         {animasExtendedAnnotationMessage(wizard)}
         {medronicDeconvertedExchangeMessage(wizard)}
       </div>

--- a/src/components/daily/foodtooltip/FoodTooltip.js
+++ b/src/components/daily/foodtooltip/FoodTooltip.js
@@ -94,8 +94,14 @@ const FoodTooltip = (props) => {
 
       if (dosingDecision) {
         const currentCarbs = getCarbs(food);
-        const originalCarbs = dosingDecision.originalFood?.nutrition?.carbohydrate?.net
-          ?? originalDosingDecision?.food?.nutrition?.carbohydrate?.net;
+        // Initial carb amount comes from the earliest DD in the edit chain,
+        // preferring its immutable `originalFood` snapshot over `food`. On
+        // multi-edit chains the latest DD has no originalFood, and intermediate
+        // DDs' food has been rewritten to the final value -- so reading either
+        // of those would surface the post-edit number.
+        const earliestDosingDecision = originalDosingDecision || dosingDecision;
+        const originalCarbs = earliestDosingDecision.originalFood?.nutrition?.carbohydrate?.net
+          ?? earliestDosingDecision.food?.nutrition?.carbohydrate?.net;
         const carbsWereEdited = food.tags?.carbsEdited;
         const editedLabel = currentCarbs === 0 ? t('Deleted') : t('Edited');
         const entryTimeDiffExceedsThreshold = food.tags?.entryTimeDiffers;
@@ -142,8 +148,8 @@ const FoodTooltip = (props) => {
           }
 
           rows.push(
-            <div key={originalDosingDecision ? 'timeLastEdited' : 'timeEdited'} className={styles.row}>
-              <div className={styles.label}>{originalDosingDecision ? t('Time Last Edited') : t('Time Edited')}</div>
+            <div key={'timeEdited'} className={styles.row}>
+              <div className={styles.label}>{t('Time Edited')}</div>
               <div className={styles.value}>
                 {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'h:mm')}
               </div>
@@ -153,21 +159,28 @@ const FoodTooltip = (props) => {
             </div>
           );
         } else if (entryTimeDiffExceedsThreshold) {
+          // Prefer the original-entry decision's time (a time edit's original entry);
+          // fall back to the lone decision's time for a back-logged entry with no lineage.
+          const enteredTimeDecision = originalDosingDecision || dosingDecision;
           rows.push(
             <div key={'timeEntered'} className={styles.row}>
               <div className={styles.label}>{t('Time Entered')}</div>
               <div className={styles.value}>
-                {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'h:mm')}
+                {formatLocalizedFromUTC(enteredTimeDecision.time, props.timePrefs, 'h:mm')}
               </div>
               <div className={styles.units}>
-                {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'a')}
+                {formatLocalizedFromUTC(enteredTimeDecision.time, props.timePrefs, 'a')}
               </div>
             </div>
           );
         }
       }
 
-      if (latestUpdatedTime || timeOfEntry) {
+      // Skip the payload-based timestamp row when carbs were edited — the DD-driven
+      // "Time Edited" row above already conveys the latest edit time,
+      // so emitting `food.payload.userUpdatedDate` here would produce a duplicate.
+      const carbsEditedHandledAbove = !!dosingDecision && food.tags?.carbsEdited;
+      if (!carbsEditedHandledAbove && (latestUpdatedTime || timeOfEntry)) {
         rows.push(<div key={'divider'} className={styles.divider} />);
 
         if (latestUpdatedTime) {

--- a/src/modules/print/DailyPrintView.js
+++ b/src/modules/print/DailyPrintView.js
@@ -1211,8 +1211,14 @@ class DailyPrintView extends PrintView {
       if (carbsEdited) {
         const isDeleted = !carbs;
         const fillColor = isDeleted ? this.colors.carbsDeleted : this.colors.carbs;
-        const originalCarbs = _.get(foodEvent, 'dosingDecision.originalFood.nutrition.carbohydrate.net')
-          ?? _.get(foodEvent, 'originalDosingDecision.food.nutrition.carbohydrate.net');
+        // Initial value comes from the earliest DD in the edit chain. Prefer
+        // its immutable `originalFood` snapshot over `food`; on multi-edit
+        // chains the latest DD has no originalFood and intermediate DDs' food
+        // is rewritten to the final value, so neither would label correctly.
+        const earliestDosingDecision = _.get(foodEvent, 'originalDosingDecision')
+          ?? _.get(foodEvent, 'dosingDecision');
+        const originalCarbs = _.get(earliestDosingDecision, 'originalFood.nutrition.carbohydrate.net')
+          ?? _.get(earliestDosingDecision, 'food.nutrition.carbohydrate.net');
         const originalValue = String(Math.round(originalCarbs ?? 0));
         const currentValue = isDeleted ? '0' : String(Math.round(carbs));
 

--- a/src/utils/DataUtil.js
+++ b/src/utils/DataUtil.js
@@ -116,6 +116,8 @@ export class DataUtil {
     this.startTimer('addData');
 
     this.bolusDatumsByIdMap = this.bolusDatumsByIdMap || {};
+    this.foodDatumTimes = this.foodDatumTimes || new Set();
+    this.canonicalFoodTimeByDecisionId = this.canonicalFoodTimeByDecisionId || {};
     this.bolusToWizardIdMap = this.bolusToWizardIdMap || {};
     this.knownDeviceIds = this.knownDeviceIds || new Set();
     this.uploadToDeviceIdMap = this.uploadToDeviceIdMap || {};
@@ -331,6 +333,12 @@ export class DataUtil {
       this.bolusDatumsByIdMap[d.id] = d;
     }
 
+    // Track surviving food eat-times so joinFoodAndDosingDecision can recognize a
+    // dosing decision whose food.time was superseded by an edit (matches no surviving food).
+    if (d.type === 'food' && _.isFinite(d.time)) {
+      this.foodDatumTimes.add(d.time);
+    }
+
     if (d.type === 'pumpSettings') {
       this.pumpSettingsDatumsByIdMap[d.id] = d;
     }
@@ -396,9 +404,17 @@ export class DataUtil {
         const proximateDosingDecisions = _.filter(
           _.mapValues(this.bolusDosingDecisionDatumsByIdMap),
           ({ time, associations }) => {
-            // If there is a definitive association, we skip this decision, as it would have been
-            // associated with the bolus already in the code above if the id matched
-            if (_.some(associations, { reason: 'bolus' })) return false;
+            // Skip a decision only if it is already claimed by a DIFFERENT, real bolus —
+            // that bolus would have matched it via the definitive association above. We
+            // must NOT skip on a dangling `bolus` association whose id resolves to no
+            // normalized bolus datum (e.g. twiist references an original-entry bolus by an
+            // id that doesn't survive normalization); otherwise the carb's original-entry
+            // bolus can never match its decision and renders with no carbs/IOB.
+            const claimedByOtherBolus = _.some(
+              associations,
+              a => a.reason === 'bolus' && a.id !== d.id && !!this.bolusDatumsByIdMap[a.id]
+            );
+            if (claimedByOtherBolus) return false;
 
             const timeOffset = Math.abs(time - d.time);
             return timeOffset <= timeThreshold;
@@ -425,8 +441,20 @@ export class DataUtil {
         const associatedPumpSettingsId = _.find(d.dosingDecision.associations, { reason: 'pumpSettings' })?.id;
         d.dosingDecision.pumpSettings = this.pumpSettingsDatumsByIdMap[associatedPumpSettingsId];
 
-        // Translate relevant dosing decision data onto expected bolus fields
-        d.carbInput = d.dosingDecision.food?.nutrition?.carbohydrate?.net;
+        // Carbs the bolus was computed on — the field differs by device:
+        //   • twiist rewrites every prior decision's `food` to the FINAL value and stores
+        //     the at-bolus snapshot in `originalFood`, so `originalFood` is the value at
+        //     this bolus's decision (prefer it).
+        //   • Tidepool / DIY Loop instead leave each decision's `food` at the value that
+        //     decision (and its bolus) was computed on, with `originalFood` holding the
+        //     PRIOR value — so prefer `food`, else an interim-edit bolus surfaces the
+        //     pre-edit count (e.g. 25g on a bolus actually dosed for 35g).
+        const carbsFromFoodFirst = isTidepoolLoop(d) || isDIYLoop(d);
+        d.carbInput = carbsFromFoodFirst
+          ? (d.dosingDecision.food?.nutrition?.carbohydrate?.net
+            ?? d.dosingDecision.originalFood?.nutrition?.carbohydrate?.net)
+          : (d.dosingDecision.originalFood?.nutrition?.carbohydrate?.net
+            ?? d.dosingDecision.food?.nutrition?.carbohydrate?.net);
 
         d.bgInput = d?.dosingDecision?.smbg?.value || _.last(d.dosingDecision.bgHistorical || [])?.value;
         d.insulinOnBoard = d.dosingDecision.insulinOnBoard?.amount;
@@ -444,9 +472,37 @@ export class DataUtil {
 
   joinFoodAndDosingDecision = d => {
     if (d.type === 'food' && !!this.dosingDecisionDataSetsByIdMap[d.uploadId]) {
+      // Each carb edit creates a new food datum (new id), but only the final
+      // one survives, so matching by the surviving food id alone collapses an
+      // edit lineage to a single (often arbitrary) decision. The eat-time
+      // (food.time / originalFood.time) is stable across edits because the
+      // platform rewrites every prior DD's nested food to the final value and
+      // preserves the pre-edit snapshot in originalFood, so group by it too.
+      // Nested food.time is still an ISO string here.
       const matchingDosingDecisions = _.filter(
         _.values(this.bolusDosingDecisionDatumsByIdMap),
-        ({ associations = [] }) => _.some(associations, { reason: 'food', id: d.id })
+        (dd) => {
+          if (_.some(dd.associations || [], { reason: 'food', id: d.id })) return true;
+          const ddFoodTime = dd.food?.time ? Date.parse(dd.food.time) : null;
+          const ddOriginalFoodTime = dd.originalFood?.time ? Date.parse(dd.originalFood.time) : null;
+          if (ddFoodTime === d.time || ddOriginalFoodTime === d.time) return true;
+
+          // Time-only edit: eat-time is the join key above, but a time edit changes
+          // exactly that key, so the pre-edit decision never matches directly. Treat a
+          // decision as a pre-edit version of THIS entry when it shares the upload and
+          // carb amount and its eat-time was superseded -- i.e. matches no surviving food
+          // datum (only the final food survives an edit, so a genuinely distinct same-size
+          // entry keeps its own food and won't look orphaned). Window-bounded to the
+          // largest eaten-time edit we'll attribute to one entry (30 min); a larger edit
+          // simply isn't recovered and the entry falls back to its post-edit time. This is
+          // best-effort recovery of the original entry time, which the source doesn't carry
+          // on a linkable record.
+          const sameUpload = dd.uploadId === d.uploadId;
+          const sameCarbs = dd.food?.nutrition?.carbohydrate?.net === d.nutrition?.carbohydrate?.net;
+          const orphanedEatTime = _.isFinite(ddFoodTime) && !this.foodDatumTimes.has(ddFoodTime);
+          const withinWindow = _.isFinite(ddFoodTime) && Math.abs(ddFoodTime - d.time) <= 30 * MS_IN_MIN;
+          return sameUpload && sameCarbs && orphanedEatTime && withinWindow;
+        }
       );
 
       if (matchingDosingDecisions.length) {
@@ -455,6 +511,13 @@ export class DataUtil {
         if (sorted.length > 1) {
           d.originalDosingDecision = sorted[0];
         }
+        // Map every decision in this carb's edit lineage to the surviving food's eaten
+        // time, so each bolus in the lineage can display the meal's canonical (final)
+        // eaten time rather than its own at-bolus snapshot, which diverges after a time
+        // edit. Lets a clinician trace every dose back to the one food datum.
+        _.each(matchingDosingDecisions, (dd) => {
+          this.canonicalFoodTimeByDecisionId[dd.id] = d.time;
+        });
       }
     }
   };
@@ -686,7 +749,13 @@ export class DataUtil {
       const isWizardOrDosingDecision = d.wizard || d.dosingDecision?.food;
       const carbInputGeneratedFromFoodData = _.isFinite(d.carbInput) && !!d.dosingDecision;
 
-      const foodTimeMs = d.dosingDecision?.food?.time ? Date.parse(d.dosingDecision.food.time) : null;
+      // Prefer the meal's canonical (final) eaten time -- shared across every bolus in the
+      // carb's edit lineage -- so a time edit shows consistently on all of a meal's boluses;
+      // fall back to this bolus's own decision snapshot when no lineage was resolved.
+      const ownFoodTimeMs = d.dosingDecision?.food?.time ? Date.parse(d.dosingDecision.food.time) : null;
+      const canonicalFoodTimeMs = this.canonicalFoodTimeByDecisionId?.[d.dosingDecision?.id];
+      const foodTimeMs = _.isFinite(canonicalFoodTimeMs) ? canonicalFoodTimeMs : ownFoodTimeMs;
+      d.foodTime = foodTimeMs;
       const foodTimeDiffers = _.isFinite(foodTimeMs)
         && Math.abs(foodTimeMs - d.time) > 5 * MS_IN_MIN;
 
@@ -732,13 +801,26 @@ export class DataUtil {
     if (d.type === 'food') {
       const { dosingDecision, originalDosingDecision } = d;
       const currentCarbs = d.nutrition?.carbohydrate?.net;
-      const originalCarbs = dosingDecision?.originalFood?.nutrition?.carbohydrate?.net
-        ?? originalDosingDecision?.food?.nutrition?.carbohydrate?.net;
+      // True initial value lives in the EARLIEST DD's originalFood. The latest
+      // DD has no originalFood, and on multi-edit chains intermediate DDs'
+      // .food has been rewritten to the final value -- so reading either of
+      // those would mis-detect edits or surface the post-edit number.
+      const earliestDosingDecision = originalDosingDecision || dosingDecision;
+      const originalCarbs = earliestDosingDecision?.originalFood?.nutrition?.carbohydrate?.net
+        ?? earliestDosingDecision?.food?.nutrition?.carbohydrate?.net;
       const carbsEdited = originalCarbs != null && originalCarbs !== currentCarbs;
 
-      const entryTimeDiffExceedsThreshold = dosingDecision
+      // A time-only edit changes the eaten time: the earliest decision's food.time
+      // (original eat-time) differs from the surviving food's time. The decision-vs-food
+      // check below still flags back-logged entries that have no edit lineage.
+      const originalEatTimeMs = originalDosingDecision?.food?.time
+        ? Date.parse(originalDosingDecision.food.time)
+        : null;
+      const eatTimeEdited = _.isFinite(originalEatTimeMs)
+        && Math.abs(originalEatTimeMs - d.time) > 5 * MS_IN_MIN;
+      const entryTimeDiffExceedsThreshold = eatTimeEdited || (dosingDecision
         && Math.abs(dosingDecision.time - d.time) > 5 * MS_IN_MIN
-        && (!originalDosingDecision || Math.abs(originalDosingDecision.time - d.time) > 5 * MS_IN_MIN);
+        && (!originalDosingDecision || Math.abs(originalDosingDecision.time - d.time) > 5 * MS_IN_MIN));
 
       d.tags = {
         loop: isLoopDatum,
@@ -1260,6 +1342,8 @@ export class DataUtil {
     } else {
       this.log('Reinitializing');
       this.bolusDatumsByIdMap = {};
+      this.foodDatumTimes = new Set();
+      this.canonicalFoodTimeByDecisionId = {};
       this.bolusToWizardIdMap = {};
       this.knownDeviceIds?.clear();
       this.latestDatumByType = {};

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -378,7 +378,13 @@ export function isCorrection(insulinEvent) {
   const recommended = insulinEvent.dosingDecision
     ? {
       correction: _.get(insulinEvent, 'dosingDecision.recommendedBolus.amount'),
-      carb: _.get(insulinEvent, 'dosingDecision.food.nutrition.carbohydrate.net', 0),
+      // Prefer originalFood (immutable pre-edit snapshot) over food, which may be a
+      // post-edit value on intermediate DDs in an edit chain.
+      carb: _.get(
+        insulinEvent,
+        'dosingDecision.originalFood.nutrition.carbohydrate.net',
+        _.get(insulinEvent, 'dosingDecision.food.nutrition.carbohydrate.net', 0)
+      ),
     }
     : _.get(insulinEvent, 'wizard.recommended', insulinEvent.recommended);
   return !!(recommended && recommended.correction > 0 && recommended.carb === 0);

--- a/src/utils/bolus.js
+++ b/src/utils/bolus.js
@@ -375,16 +375,22 @@ export function isUnderride(insulinEvent) {
  * @return {Boolean} whether the bolus programmed a recommended bg correction without carb entry
  */
 export function isCorrection(insulinEvent) {
+  // The per-bolus carb amount is already device-gated onto `carbInput` by DataUtil
+  // (food-first for Loop/DIY, originalFood-first for twiist), so prefer it -- it reflects
+  // what THIS bolus was dosed on and stays consistent with getCarbs. Fall back to the
+  // decision snapshot only when carbInput isn't annotated (e.g. a raw bolus not run through
+  // DataUtil), preferring originalFood over a possibly-rewritten intermediate food.
+  const carbInput = getCarbs(insulinEvent);
   const recommended = insulinEvent.dosingDecision
     ? {
       correction: _.get(insulinEvent, 'dosingDecision.recommendedBolus.amount'),
-      // Prefer originalFood (immutable pre-edit snapshot) over food, which may be a
-      // post-edit value on intermediate DDs in an edit chain.
-      carb: _.get(
-        insulinEvent,
-        'dosingDecision.originalFood.nutrition.carbohydrate.net',
-        _.get(insulinEvent, 'dosingDecision.food.nutrition.carbohydrate.net', 0)
-      ),
+      carb: _.isFinite(carbInput)
+        ? carbInput
+        : _.get(
+          insulinEvent,
+          'dosingDecision.originalFood.nutrition.carbohydrate.net',
+          _.get(insulinEvent, 'dosingDecision.food.nutrition.carbohydrate.net', 0)
+        ),
     }
     : _.get(insulinEvent, 'wizard.recommended', insulinEvent.recommended);
   return !!(recommended && recommended.correction > 0 && recommended.carb === 0);

--- a/test/components/daily/BolusTooltip.test.js
+++ b/test/components/daily/BolusTooltip.test.js
@@ -504,6 +504,16 @@ const withLoopDosingDecisionFoodTimeWithinThreshold = {
   tags: { ...(withLoopDosingDecision.tags || {}), foodTimeDiffers: false },
 };
 
+// Entry bolus delivered concurrently with its own decision snapshot (food.time 4:00am ≈ bolus
+// 4:00am), but the meal's eaten time was edited later; DataUtil stamps the canonical foodTime
+// (4:15am) + foodTimeDiffers=true. The label must reflect the canonical time, not the snapshot.
+const withLoopCanonicalFoodTime = {
+  ...withLoopDosingDecision,
+  normalTime: Date.parse('2017-11-11T04:00:00.000Z'),
+  foodTime: Date.parse('2017-11-11T04:15:00.000Z'),
+  tags: { ...(withLoopDosingDecision.tags || {}), foodTimeDiffers: true },
+};
+
 // dosingDecision has no food field — plain "Carbs" label
 const withLoopDosingDecisionNoFoodTime = {
   ...withLoopDosingDecision,
@@ -770,6 +780,13 @@ describe('BolusTooltip', () => {
       const { container } = rtlRender(<BolusTooltip {...props} bolus={withLoopDosingDecisionFoodTimeWithinThreshold} />);
       expect(container.querySelector(carbsLabel).textContent).to.equal('Carbs');
     });
+
+    it('should show the canonical eaten time from bolus.foodTime, not the bolus\'s own decision snapshot', () => {
+      const { container } = rtlRender(<BolusTooltip {...props} bolus={withLoopCanonicalFoodTime} />);
+      const label = container.querySelector(carbsLabel).textContent;
+      expect(label).to.contain('Carbs (eaten at');
+      expect(label).to.contain('4:15'); // the canonical foodTime, not the 4:00 snapshot
+    });
   });
 
   it('should render appropriate fields for a bolus with a Trio dosing decision', () => {
@@ -789,6 +806,93 @@ describe('BolusTooltip', () => {
     expect(container.querySelector(formatClassesAsSelector(styles.actingType)).textContent).to.contain('Short-acting insulin');
     expect(container.querySelectorAll(formatClassesAsSelector(styles.source))).to.have.length(1);
     expect(container.querySelector(formatClassesAsSelector(styles.source)).textContent).to.contain('Manual');
+  });
+
+  // Edited-carb bolus hovers.
+  // BolusTooltip reads `bolus.carbInput`, which DataUtil annotates as
+  // dosingDecision.originalFood?.nutrition?.carbohydrate?.net ?? dosingDecision.food?…
+  describe('edited-carb dosing decisions', () => {
+    const carbsValue = `${formatClassesAsSelector(styles.carbs)} ${formatClassesAsSelector(styles.value)}`;
+
+    const makeLoopBolus = (overrides = {}) => ({
+      ...withLoopDosingDecision,
+      ...overrides,
+      dosingDecision: {
+        ...withLoopDosingDecision.dosingDecision,
+        ...(overrides.dosingDecision || {}),
+      },
+    });
+
+    it('first bolus on an upward edit shows the original (pre-edit) grams', () => {
+      const firstBolus = makeLoopBolus({
+        carbInput: 20,
+        dosingDecision: {
+          food: { nutrition: { carbohydrate: { net: 80 } } },
+          originalFood: { nutrition: { carbohydrate: { net: 20 } } },
+        },
+      });
+      const { container } = rtlRender(<BolusTooltip {...props} bolus={firstBolus} />);
+      expect(container.querySelector(carbsValue).textContent).to.equal('20');
+    });
+
+    it('second bolus on a single edit shows the final (post-edit) grams', () => {
+      const secondBolus = makeLoopBolus({
+        carbInput: 80,
+        dosingDecision: {
+          food: { nutrition: { carbohydrate: { net: 80 } } },
+          // post-edit DD: no originalFood -> falls back to food
+        },
+      });
+      const { container } = rtlRender(<BolusTooltip {...props} bolus={secondBolus} />);
+      expect(container.querySelector(carbsValue).textContent).to.equal('80');
+    });
+
+    it('4-edit chain shows each bolus\'s live grams on its own DD (20→40→60→80)', () => {
+      const ladder = [
+        { carbInput: 20, original: 20, food: 80 },
+        { carbInput: 40, original: 40, food: 80 },
+        { carbInput: 60, original: 60, food: 80 },
+        { carbInput: 80, original: undefined, food: 80 },
+      ];
+      ladder.forEach(({ carbInput, original, food }) => {
+        const bolus = makeLoopBolus({
+          carbInput,
+          dosingDecision: {
+            food: { nutrition: { carbohydrate: { net: food } } },
+            ...(original !== undefined && { originalFood: { nutrition: { carbohydrate: { net: original } } } }),
+          },
+        });
+        const { container } = rtlRender(<BolusTooltip {...props} bolus={bolus} />);
+        expect(container.querySelector(carbsValue).textContent).to.equal(`${carbInput}`);
+      });
+    });
+
+    it('edited-carb bolus hover renders the Correction Range row even when bgInput is absent', () => {
+      const noBgEditedBolus = makeLoopBolus({
+        bgInput: null,
+        carbInput: 20,
+        dosingDecision: {
+          food: { nutrition: { carbohydrate: { net: 80 } } },
+          originalFood: { nutrition: { carbohydrate: { net: 20 } } },
+        },
+      });
+      const { container } = rtlRender(<BolusTooltip {...props} bolus={noBgEditedBolus} />);
+      expect(container.querySelectorAll(formatClassesAsSelector(styles.target))).to.have.length(1);
+      expect(container.querySelector(formatClassesAsSelector(styles.target)).textContent).to.contain('Correction Range');
+    });
+
+    it('Loop bolus with no dosing decision renders no target row (no NaN, no Correction Range)', () => {
+      const loopBolusNoDD = {
+        type: 'bolus',
+        origin: { name: 'com.loopkit.Loop' },
+        normal: 1,
+        normalTime: Date.parse('2017-11-11T05:45:52.000Z'),
+      };
+      const { container } = rtlRender(<BolusTooltip {...props} bolus={loopBolusNoDD} />);
+      expect(container.querySelectorAll(formatClassesAsSelector(styles.target))).to.have.length(0);
+      expect(container.textContent).to.not.contain('Correction Range');
+      expect(container.textContent).to.not.contain('NaN');
+    });
   });
 
   describe('getTarget', () => {
@@ -848,6 +952,14 @@ describe('BolusTooltip', () => {
       const result = getTarget(withAutoTarget, props.bgPrefs, props.timePrefs);
       expect(result.type).to.equal('div');
       expect(container.querySelector(targetValue).textContent).to.equal('Auto');
+    });
+    it('should return null for a Loop bolus with no target schedule', () => {
+      const loopNoSchedule = {
+        type: 'bolus',
+        origin: { name: 'com.loopkit.Loop' },
+        normalTime: Date.parse('2017-11-11T05:45:52.000Z'),
+      };
+      expect(getTarget(loopNoSchedule, props.bgPrefs, props.timePrefs)).to.equal(null);
     });
   });
 

--- a/test/components/daily/FoodTooltip.test.js
+++ b/test/components/daily/FoodTooltip.test.js
@@ -129,13 +129,13 @@ const loopWithMultipleDosingDecisions = {
     food: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 40 } } },
   },
   dosingDecision: {
-    time: Date.parse('2024-02-02T19:00:00.000Z'), // Time Last Edited (7:00 pm UTC)
+    time: Date.parse('2024-02-02T19:00:00.000Z'), // Time Edited (7:00 pm UTC)
     food: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 80 } } },
     originalFood: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 40 } } },
   },
 };
 
-// No name/absorption so row[0]=Initial Carb Amount, row[1]=Time Entered, row[2]=Time Last Edited
+// No name/absorption so row[0]=Initial Carb Amount, row[1]=Time Entered, row[2]=Time Edited
 const loopEdited = {
   type: 'food',
   origin: { name: 'com.loopkit.Loop' },
@@ -254,7 +254,7 @@ describe('FoodTooltip', () => {
 
     it('should include the edited time for an edited Loop food value', () => {
       const { container } = render(<FoodTooltip {...props} food={loopEdited} />);
-      expect(container.querySelectorAll(row)[2].querySelector(rowLabel).textContent).to.contain('Last Edited');
+      expect(container.querySelectorAll(row)[2].querySelector(rowLabel).textContent).to.contain('Time Edited');
       expect(container.querySelectorAll(row)[2].querySelector(rowValue).textContent).to.contain('3:00');
       expect(container.querySelectorAll(row)[2].querySelector(rowUnits).textContent).to.contain('am');
     });
@@ -266,6 +266,29 @@ describe('FoodTooltip', () => {
       expect(timeRow).to.have.length(1);
       expect(timeRow[0].querySelector(rowValue).textContent).to.contain('5:00');
       expect(timeRow[0].querySelector(rowUnits).textContent).to.contain('pm');
+    });
+
+    it('should show the original-entry decision time for "Time Entered" on a time-only edit with lineage', () => {
+      // Backdate: entered 31g at 4:33pm UTC, edited eat-time later; the heuristic attaches
+      // the original-entry decision so "Time Entered" shows 4:33, not the 4:45 edit time.
+      const timeEditedWithLineage = {
+        ...loop,
+        tags: { carbsEdited: false, entryTimeDiffers: true },
+        nutrition: { ...loop.nutrition, carbohydrate: { net: 31, units: 'grams' } },
+        originalDosingDecision: {
+          time: Date.parse('2024-02-02T16:33:00.000Z'), // original entry, 4:33 pm UTC
+          food: { time: '2024-02-02T16:33:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+        },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T16:45:00.000Z'), // edit decision, 4:45 pm UTC
+          food: { time: '2024-02-02T16:23:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={timeEditedWithLineage} />);
+      const rows = Array.from(container.querySelectorAll(row));
+      const timeRow = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Entered');
+      expect(timeRow).to.have.length(1);
+      expect(timeRow[0].querySelector(rowValue).textContent).to.contain('4:33'); // original entry, not the 4:45 edit
     });
 
     it('should not show "Time Entered" when dosingDecision time is within 5min of normalTime', () => {
@@ -297,13 +320,13 @@ describe('FoodTooltip', () => {
       expect(timeRow[0].querySelector(rowUnits).textContent).to.contain('pm');
     });
 
-    it('should show "Time Entered" and "Time Last Edited" for multiple dosingDecisions', () => {
+    it('should show "Time Entered" and "Time Edited" for multiple dosingDecisions', () => {
       const { container } = render(<FoodTooltip {...props} food={loopWithMultipleDosingDecisions} />);
       const rows = Array.from(container.querySelectorAll(row));
-      const timeEnteredRow = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Time Entered'));
-      const timeLastEditedRow = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Time Last Edited'));
+      const timeEnteredRow = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Entered');
+      const timeEditedRow = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Edited');
       expect(timeEnteredRow).to.have.length(1);
-      expect(timeLastEditedRow).to.have.length(1);
+      expect(timeEditedRow).to.have.length(1);
     });
 
     it('should not show time/edit rows when dosingDecisions are absent', () => {
@@ -313,6 +336,141 @@ describe('FoodTooltip', () => {
       const timeEditedRow = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Time Edited'));
       expect(timeEnteredRow).to.have.length(0);
       expect(timeEditedRow).to.have.length(0);
+    });
+  });
+
+  // Edited-carb food hovers.
+  describe('edited-carb chains', () => {
+    const row = formatClassesAsSelector(styles.row);
+    const rowLabel = formatClassesAsSelector(styles.label);
+    const rowValue = formatClassesAsSelector(styles.value);
+    const carbLabel = `${formatClassesAsSelector(styles.carb)} ${formatClassesAsSelector(styles.label)}`;
+    const carbValue = `${formatClassesAsSelector(styles.carb)} ${formatClassesAsSelector(styles.value)}`;
+
+    const fourEditChain = {
+      type: 'food',
+      origin: { name: 'com.loopkit.Loop' },
+      normalTime: Date.parse('2024-02-02T17:30:00.000Z'),
+      tags: { carbsEdited: true, entryTimeDiffers: false },
+      nutrition: { carbohydrate: { net: 80, units: 'grams' } },
+      // earliest DD captures the 20g entry
+      originalDosingDecision: {
+        time: Date.parse('2024-02-02T17:30:00.000Z'),
+        food: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 20 } } },
+        originalFood: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 20 } } },
+      },
+      // latest DD captures the final 80g state; its originalFood reflects the
+      // immediate predecessor (60g), so the tooltip must NOT read initial from here.
+      dosingDecision: {
+        time: Date.parse('2024-02-02T20:00:00.000Z'),
+        food: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 80 } } },
+        originalFood: { time: '2024-02-02T17:30:00.000Z', nutrition: { carbohydrate: { net: 60 } } },
+      },
+    };
+
+    it('4-edit chain shows initial = earliest DD value (20), final = 80, Time Edited from latest DD', () => {
+      const { container } = render(<FoodTooltip {...props} food={fourEditChain} />);
+      expect(container.querySelector(carbValue).textContent).to.equal('80');
+      const rows = Array.from(container.querySelectorAll(row));
+      const initial = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'));
+      expect(initial).to.have.length(1);
+      expect(initial[0].querySelector(rowValue).textContent).to.equal('20');
+      const lastEdited = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Edited');
+      expect(lastEdited).to.have.length(1);
+      expect(lastEdited[0].querySelector(rowValue).textContent).to.contain('8:00');
+    });
+
+    it('single decrease edit (25→35→45) shows initial = 25 and final = 45', () => {
+      // Two edits — originalDosingDecision present.
+      const decreaseChain = {
+        type: 'food',
+        origin: { name: 'com.loopkit.Loop' },
+        normalTime: Date.parse('2024-02-02T08:53:00.000Z'),
+        tags: { carbsEdited: true, entryTimeDiffers: false },
+        nutrition: { carbohydrate: { net: 45, units: 'grams' } },
+        originalDosingDecision: {
+          time: Date.parse('2024-02-02T08:53:00.000Z'),
+          food: { time: '2024-02-02T08:53:00.000Z', nutrition: { carbohydrate: { net: 25 } } },
+        },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T09:10:00.000Z'),
+          food: { time: '2024-02-02T08:53:00.000Z', nutrition: { carbohydrate: { net: 45 } } },
+          originalFood: { time: '2024-02-02T08:53:00.000Z', nutrition: { carbohydrate: { net: 35 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={decreaseChain} />);
+      expect(container.querySelector(carbValue).textContent).to.equal('45');
+      const rows = Array.from(container.querySelectorAll(row));
+      const initial = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'));
+      expect(initial[0].querySelector(rowValue).textContent).to.equal('25');
+    });
+
+    it('unedited entry renders only the standard "Total Carbs" row (no Initial / Last-Edited)', () => {
+      const unedited = {
+        type: 'food',
+        origin: { name: 'com.loopkit.Loop' },
+        normalTime: Date.parse('2024-02-02T18:00:00.000Z'),
+        tags: {},
+        nutrition: { carbohydrate: { net: 45, units: 'grams' } },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T18:00:00.000Z'),
+          food: { time: '2024-02-02T18:00:00.000Z', nutrition: { carbohydrate: { net: 45 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={unedited} />);
+      expect(container.querySelector(carbLabel).textContent).to.equal('Total Carbs');
+      const rows = Array.from(container.querySelectorAll(row));
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'))).to.have.length(0);
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Last Edited'))).to.have.length(0);
+    });
+
+    it('deleted entry (carbsEdited && carbs === 0) renders "Total Carbs (Deleted)" label', () => {
+      const deleted = {
+        type: 'food',
+        origin: { name: 'com.loopkit.Loop' },
+        normalTime: Date.parse('2024-02-02T18:00:00.000Z'),
+        tags: { carbsEdited: true },
+        nutrition: { carbohydrate: { net: 0, units: 'grams' } },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T18:30:00.000Z'),
+          food: { time: '2024-02-02T18:00:00.000Z', nutrition: { carbohydrate: { net: 0 } } },
+          originalFood: { time: '2024-02-02T18:00:00.000Z', nutrition: { carbohydrate: { net: 30 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={deleted} />);
+      expect(container.querySelector(carbLabel).textContent).to.contain('Total Carbs (Deleted)');
+    });
+
+    it('0.1g entry renders the normal "Total Carbs" row and a 0.1 value (NOT "Deleted")', () => {
+      const tinyEntry = {
+        type: 'food',
+        origin: { name: 'com.loopkit.Loop' },
+        normalTime: Date.parse('2024-02-02T18:00:00.000Z'),
+        tags: {},
+        nutrition: { carbohydrate: { net: 0.1, units: 'grams' } },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T18:00:00.000Z'),
+          food: { time: '2024-02-02T18:00:00.000Z', nutrition: { carbohydrate: { net: 0.1 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={tinyEntry} />);
+      expect(container.querySelector(carbLabel).textContent).to.equal('Total Carbs');
+      expect(container.querySelector(carbValue).textContent).to.equal('0.1');
+    });
+
+    it('does not render the payload-based "Last Edited" row when the DD-based "Time Edited" row already shows', () => {
+      const editedWithPayload = {
+        ...fourEditChain,
+        payload: { userUpdatedDate: '2024-02-02T20:00:00.000Z' },
+      };
+      const { container } = render(<FoodTooltip {...props} food={editedWithPayload} />);
+      const rows = Array.from(container.querySelectorAll(row));
+      // The payload-derived "Last Edited" row must be suppressed.
+      const payloadLastEditedRows = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Last Edited');
+      expect(payloadLastEditedRows).to.have.length(0);
+      // Only the DD-derived "Time Edited" row should remain.
+      const timeEditedRows = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Edited');
+      expect(timeEditedRows).to.have.length(1);
     });
   });
 

--- a/test/modules/print/DailyPrintView.test.js
+++ b/test/modules/print/DailyPrintView.test.js
@@ -1129,6 +1129,69 @@ describe('DailyPrintView', () => {
       sinon.assert.notCalled(Renderer.doc.circle);
       sinon.assert.notCalled(Renderer.doc.roundedRect);
     });
+
+    // Edited-carb obround initial-value priority.
+    it('should prefer originalDosingDecision.originalFood for the initial value on a multi-edit chain', () => {
+      const chart = {
+        ...Renderer.chartsByDate[sampleDate],
+        data: {
+          ...Renderer.chartsByDate[sampleDate].data,
+          food: [
+            {
+              normalTime: 0,
+              nutrition: { carbohydrate: { net: 80 } },
+              tags: { carbsEdited: true },
+              // earliest DD records the 20g entry (must win)
+              originalDosingDecision: {
+                originalFood: { nutrition: { carbohydrate: { net: 20 } } },
+                food: { nutrition: { carbohydrate: { net: 20 } } },
+              },
+              // latest DD's originalFood points to immediate predecessor (60g) — must NOT win
+              dosingDecision: {
+                originalFood: { nutrition: { carbohydrate: { net: 60 } } },
+                food: { nutrition: { carbohydrate: { net: 80 } } },
+              },
+            },
+          ],
+        },
+      };
+
+      Renderer.renderFoodCarbs(chart);
+
+      sinon.assert.calledTwice(Renderer.doc.roundedRect);
+      sinon.assert.calledWith(Renderer.doc.text, '20');
+      sinon.assert.calledWith(Renderer.doc.text, '80');
+      sinon.assert.neverCalledWith(Renderer.doc.text, '60');
+    });
+
+    it('should fall back to originalDosingDecision.food when its originalFood is absent', () => {
+      const chart = {
+        ...Renderer.chartsByDate[sampleDate],
+        data: {
+          ...Renderer.chartsByDate[sampleDate].data,
+          food: [
+            {
+              normalTime: 0,
+              nutrition: { carbohydrate: { net: 45 } },
+              tags: { carbsEdited: true },
+              originalDosingDecision: {
+                food: { nutrition: { carbohydrate: { net: 25 } } },
+              },
+              dosingDecision: {
+                originalFood: { nutrition: { carbohydrate: { net: 35 } } },
+                food: { nutrition: { carbohydrate: { net: 45 } } },
+              },
+            },
+          ],
+        },
+      };
+
+      Renderer.renderFoodCarbs(chart);
+
+      sinon.assert.calledWith(Renderer.doc.text, '25');
+      sinon.assert.calledWith(Renderer.doc.text, '45');
+      sinon.assert.neverCalledWith(Renderer.doc.text, '35');
+    });
   });
 
   describe('renderBolusDetails', () => {

--- a/test/utils/DataUtil.test.js
+++ b/test/utils/DataUtil.test.js
@@ -1230,6 +1230,9 @@ describe('DataUtil', () => {
       dataUtil.bolusDosingDecisionDatumsByIdMap = { dosingDecision1: dosingDecision };
       dataUtil.pumpSettingsDatumsByIdMap = { pumpSettings1: pumpSettings };
       dataUtil.dosingDecisionDataSetsByIdMap = { [uploadId]: upload };
+      // Mirrors production: normalizeDatumIn populates bolusDatumsByIdMap for every bolus
+      // before joins run, so the decision is recognized as claimed by the real bolus2.
+      dataUtil.bolusDatumsByIdMap = { bolus1: bolus, bolus2 };
 
       _.each([bolus, bolus2], dataUtil.joinBolusAndDosingDecision);
       // should not attach dosing decision to bolus that is not associated
@@ -1326,6 +1329,57 @@ describe('DataUtil', () => {
       expect(bolus.dosingDecision).to.be.undefined;
     });
 
+    it('should join a proximate, normal-matching bolus to a dosing decision whose `bolus` association is dangling (resolves to no bolus datum)', () => {
+      // Reproduces the twiist original-entry bolus: the decision references a bolus by an
+      // id that does not survive normalization, so the definitive match fails and the
+      // dangling association must not block the time+normal proximity match.
+      const uploadId = 'upload1';
+      const bolus = { type: 'bolus', id: 'realBolus', uploadId, time: Date.parse('2024-02-02T10:05:59.000Z'), normal: 1.17, origin: { name: 'com.dekaresearch.twiist' } };
+
+      const dosingDecision = {
+        type: 'dosingDecision',
+        id: 'dosingDecision1',
+        time: Date.parse('2024-02-02T10:05:53.000Z'),
+        origin: { name: 'com.dekaresearch.twiist' },
+        associations: [{ reason: 'bolus', id: 'ghostBolusThatDoesNotExist' }],
+        requestedBolus: { normal: 1.17 },
+        insulinOnBoard: { amount: 3.4 },
+        food: { nutrition: { carbohydrate: { net: 31 } } },
+      };
+
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { dosingDecision1: dosingDecision };
+      dataUtil.bolusDatumsByIdMap = { realBolus: bolus };
+      dataUtil.dosingDecisionDataSetsByIdMap = { [uploadId]: { client: { name: 'com.dekaresearch.twiist' } } };
+
+      dataUtil.joinBolusAndDosingDecision(bolus);
+      expect(bolus.dosingDecision).to.eql(dosingDecision);
+      expect(bolus.carbInput).to.equal(31);
+      expect(bolus.insulinOnBoard).to.equal(3.4);
+    });
+
+    it('should not steal a dosing decision already claimed by a different, real bolus', () => {
+      const uploadId = 'upload1';
+      const bolusA = { type: 'bolus', id: 'bolusA', uploadId, time: Date.parse('2024-02-02T10:05:59.000Z'), normal: 0.5, origin: { name: 'com.dekaresearch.twiist' } };
+      const bolusB = { type: 'bolus', id: 'bolusB', uploadId, time: Date.parse('2024-02-02T10:05:50.000Z'), normal: 0.5, origin: { name: 'com.dekaresearch.twiist' } };
+
+      const dosingDecision = {
+        type: 'dosingDecision',
+        id: 'dosingDecision1',
+        time: Date.parse('2024-02-02T10:05:53.000Z'),
+        origin: { name: 'com.dekaresearch.twiist' },
+        associations: [{ reason: 'bolus', id: 'bolusB' }],
+        requestedBolus: { normal: 0.5 },
+        food: { nutrition: { carbohydrate: { net: 20 } } },
+      };
+
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { dosingDecision1: dosingDecision };
+      dataUtil.bolusDatumsByIdMap = { bolusA, bolusB }; // bolusB exists → decision is genuinely claimed
+      dataUtil.dosingDecisionDataSetsByIdMap = { [uploadId]: { client: { name: 'com.dekaresearch.twiist' } } };
+
+      dataUtil.joinBolusAndDosingDecision(bolusA);
+      expect(bolusA.dosingDecision).to.be.undefined;
+    });
+
     it('should use food.nutrition.carbohydrate.net for carbInput', () => {
       const bolus = {
         type: 'bolus',
@@ -1354,7 +1408,93 @@ describe('DataUtil', () => {
       expect(bolus.carbInput).to.equal(30);
     });
 
-    it('should use food.nutrition.carbohydrate.net even when originalFood is present', () => {
+    it('should prefer originalFood over food for a twiist bolus (originalFood is the at-bolus snapshot)', () => {
+      // twiist rewrites a prior decision's food to the final value and stores the
+      // at-bolus value in originalFood, so carbInput must come from originalFood.
+      const bolus = {
+        type: 'bolus',
+        id: 'bolus1',
+        uploadId: 'upload1',
+        time: Date.parse('2024-02-02T10:05:59.000Z'),
+        origin: { name: 'com.dekaresearch.twiist' },
+      };
+
+      dataUtil.dosingDecisionDataSetsByIdMap = {
+        upload1: { client: { name: 'com.dekaresearch.twiist' } },
+      };
+
+      const dd = {
+        type: 'dosingDecision',
+        id: 'dosingDecision1',
+        time: Date.parse('2024-02-02T10:05:00.000Z'),
+        associations: [],
+        food: { nutrition: { carbohydrate: { net: 30 } } },
+        originalFood: { nutrition: { carbohydrate: { net: 42 } } },
+      };
+
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { dosingDecision1: dd };
+      dataUtil.joinBolusAndDosingDecision(bolus);
+      expect(bolus.carbInput).to.equal(42);
+    });
+
+    it('should prefer food over originalFood for a Tidepool Loop interim-edit bolus (value at this bolus, not the prior)', () => {
+      // Tidepool/DIY Loop keeps each decision's food at the value that decision's bolus
+      // was computed on, with originalFood holding the PRIOR value. The 2nd bolus of a
+      // 25→35 edit must read 35, not the pre-edit 25.
+      const bolus = {
+        type: 'bolus',
+        id: 'bolus2',
+        uploadId: 'upload1',
+        time: Date.parse('2024-02-02T10:05:59.000Z'),
+        origin: { name: 'org.tidepool.diy.Loop' },
+      };
+
+      dataUtil.dosingDecisionDataSetsByIdMap = {
+        upload1: { client: { name: 'org.tidepool.diy.Loop' } },
+      };
+
+      const dd = {
+        type: 'dosingDecision',
+        id: 'dd2',
+        time: Date.parse('2024-02-02T10:05:00.000Z'),
+        associations: [],
+        food: { nutrition: { carbohydrate: { net: 35 } } },
+        originalFood: { nutrition: { carbohydrate: { net: 25 } } },
+      };
+
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { dd2: dd };
+      dataUtil.joinBolusAndDosingDecision(bolus);
+      expect(bolus.carbInput).to.equal(35);
+    });
+
+    it('should prefer food over originalFood for a DIY Loop (loopkit) interim-edit bolus', () => {
+      const bolus = {
+        type: 'bolus',
+        id: 'bolus2',
+        uploadId: 'upload1',
+        time: Date.parse('2024-02-02T10:05:59.000Z'),
+        origin: { name: 'com.loopkit.Loop' },
+      };
+
+      dataUtil.dosingDecisionDataSetsByIdMap = {
+        upload1: { client: { name: 'com.loopkit.Loop' } },
+      };
+
+      const dd = {
+        type: 'dosingDecision',
+        id: 'dd2',
+        time: Date.parse('2024-02-02T10:05:00.000Z'),
+        associations: [],
+        food: { nutrition: { carbohydrate: { net: 35 } } },
+        originalFood: { nutrition: { carbohydrate: { net: 25 } } },
+      };
+
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { dd2: dd };
+      dataUtil.joinBolusAndDosingDecision(bolus);
+      expect(bolus.carbInput).to.equal(35);
+    });
+
+    it('should fall back to food.nutrition.carbohydrate.net when originalFood is absent', () => {
       const bolus = {
         type: 'bolus',
         id: 'bolus1',
@@ -1373,7 +1513,6 @@ describe('DataUtil', () => {
         time: Date.parse('2024-02-02T10:05:00.000Z'),
         associations: [],
         food: { nutrition: { carbohydrate: { net: 30 } } },
-        originalFood: { nutrition: { carbohydrate: { net: 42 } } },
       };
 
       dataUtil.bolusDosingDecisionDatumsByIdMap = { dosingDecision1: dd };
@@ -1486,6 +1625,137 @@ describe('DataUtil', () => {
       dataUtil.joinFoodAndDosingDecision(food);
 
       expect(food.dosingDecision).to.be.undefined;
+    });
+
+    it('should attach an orphaned pre-edit decision as originalDosingDecision on a time-only edit', () => {
+      // Backdate: entered 31g eaten at 18:33, edited eat-time to 18:23. Only the final
+      // food (18:23) survives; the original-entry decision keeps food.time 18:33.
+      const food = {
+        type: 'food',
+        id: 'foodFinal',
+        uploadId,
+        time: Date.parse('2024-02-02T18:23:00.000Z'),
+        nutrition: { carbohydrate: { net: 31 } },
+      };
+      const editDd = {
+        id: 'ddEdit',
+        uploadId,
+        time: Date.parse('2024-02-02T18:45:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodFinal' }],
+        food: { time: '2024-02-02T18:23:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+      const origDd = {
+        id: 'ddOrig',
+        uploadId,
+        time: Date.parse('2024-02-02T18:33:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodSuperseded' }],
+        food: { time: '2024-02-02T18:33:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+
+      dataUtil.foodDatumTimes = new Set([Date.parse('2024-02-02T18:23:00.000Z')]);
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { ddEdit: editDd, ddOrig: origDd };
+      dataUtil.joinFoodAndDosingDecision(food);
+
+      expect(food.dosingDecision.id).to.equal('ddEdit');
+      expect(food.originalDosingDecision.id).to.equal('ddOrig');
+    });
+
+    it('should map every lineage decision to the surviving food time in canonicalFoodTimeByDecisionId', () => {
+      // Same shape as the orphan-attach case: food survives at 18:23; the original-entry
+      // decision keeps food.time 18:33. Both decisions must point at the surviving food's
+      // time so a bolus on either shows the meal's canonical eaten time.
+      const food = {
+        type: 'food', id: 'foodFinal', uploadId,
+        time: Date.parse('2024-02-02T18:23:00.000Z'),
+        nutrition: { carbohydrate: { net: 31 } },
+      };
+      const editDd = {
+        id: 'ddEdit', uploadId,
+        time: Date.parse('2024-02-02T18:45:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodFinal' }],
+        food: { time: '2024-02-02T18:23:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+      const origDd = {
+        id: 'ddOrig', uploadId,
+        time: Date.parse('2024-02-02T18:33:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodSuperseded' }],
+        food: { time: '2024-02-02T18:33:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+
+      dataUtil.foodDatumTimes = new Set([Date.parse('2024-02-02T18:23:00.000Z')]);
+      dataUtil.canonicalFoodTimeByDecisionId = {};
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { ddEdit: editDd, ddOrig: origDd };
+      dataUtil.joinFoodAndDosingDecision(food);
+
+      expect(dataUtil.canonicalFoodTimeByDecisionId.ddEdit).to.equal(food.time);
+      expect(dataUtil.canonicalFoodTimeByDecisionId.ddOrig).to.equal(food.time);
+    });
+
+    it('should NOT merge two distinct same-size entries (each keeps its own surviving food)', () => {
+      const foodA = {
+        type: 'food', id: 'foodA', uploadId,
+        time: Date.parse('2024-02-02T18:00:00.000Z'),
+        nutrition: { carbohydrate: { net: 31 } },
+      };
+      const ddA = {
+        id: 'ddA', uploadId,
+        time: Date.parse('2024-02-02T18:00:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodA' }],
+        food: { time: '2024-02-02T18:00:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+      // A separate 31g entry 30 min later — it has its OWN surviving food, so its decision's
+      // eat-time is NOT orphaned and must not be pulled into foodA's lineage.
+      const ddB = {
+        id: 'ddB', uploadId,
+        time: Date.parse('2024-02-02T18:30:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodB' }],
+        food: { time: '2024-02-02T18:30:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+
+      dataUtil.foodDatumTimes = new Set([
+        Date.parse('2024-02-02T18:00:00.000Z'),
+        Date.parse('2024-02-02T18:30:00.000Z'),
+      ]);
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { ddA, ddB };
+      dataUtil.joinFoodAndDosingDecision(foodA);
+
+      expect(foodA.dosingDecision.id).to.equal('ddA');
+      expect(foodA.originalDosingDecision).to.be.undefined;
+    });
+
+    it('should pick the earliest decision as originalDosingDecision across a multi-time-edit chain', () => {
+      // Entered eaten 11:47, backdated to 11:37, postdated to 11:57 (final/surviving).
+      const food = {
+        type: 'food', id: 'foodFinal', uploadId,
+        time: Date.parse('2024-02-02T11:57:00.000Z'),
+        nutrition: { carbohydrate: { net: 31 } },
+      };
+      const ddOrig = {
+        id: 'ddOrig', uploadId,
+        time: Date.parse('2024-02-02T11:47:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodV1' }],
+        food: { time: '2024-02-02T11:47:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+      const ddBack = {
+        id: 'ddBack', uploadId,
+        time: Date.parse('2024-02-02T11:58:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodV2' }],
+        food: { time: '2024-02-02T11:37:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+      const ddFinal = {
+        id: 'ddFinal', uploadId,
+        time: Date.parse('2024-02-02T12:09:00.000Z'),
+        associations: [{ reason: 'food', id: 'foodFinal' }],
+        food: { time: '2024-02-02T11:57:00.000Z', nutrition: { carbohydrate: { net: 31 } } },
+      };
+
+      dataUtil.foodDatumTimes = new Set([Date.parse('2024-02-02T11:57:00.000Z')]);
+      dataUtil.bolusDosingDecisionDatumsByIdMap = { ddBack, ddFinal, ddOrig };
+      dataUtil.joinFoodAndDosingDecision(food);
+
+      expect(food.dosingDecision.id).to.equal('ddFinal');
+      expect(food.originalDosingDecision.id).to.equal('ddOrig');
+      expect(food.originalDosingDecision.food.time).to.equal('2024-02-02T11:47:00.000Z');
     });
 
     it('should join trio dosing decisions to boluses from trio uploads', () => {
@@ -1810,6 +2080,26 @@ describe('DataUtil', () => {
         };
         dataUtil.tagDatum(bolusWithDD);
         expect(bolusWithDD.tags.foodTimeDiffers).to.be.false;
+      });
+
+      it('should use the canonical lineage food time (and stamp `foodTime`) even when the bolus snapshot is concurrent', () => {
+        const bolusTime = Date.parse('2024-02-02T18:00:00.000Z');
+        // This bolus's own decision snapshot eaten time equals its delivery time (a concurrent
+        // entry bolus), but the meal's eaten time was edited later. The canonical lineage time
+        // (18:10) differs by >5min, so the eaten-at must surface consistently on this bolus too.
+        const bolusWithDD = {
+          ...bolus,
+          time: bolusTime,
+          carbInput: 30,
+          dosingDecision: {
+            id: 'ddEntry',
+            food: { time: '2024-02-02T18:00:00.000Z', nutrition: { carbohydrate: { net: 30 } } },
+          },
+        };
+        dataUtil.canonicalFoodTimeByDecisionId = { ddEntry: Date.parse('2024-02-02T18:10:00.000Z') };
+        dataUtil.tagDatum(bolusWithDD);
+        expect(bolusWithDD.tags.foodTimeDiffers).to.be.true;
+        expect(bolusWithDD.foodTime).to.equal(Date.parse('2024-02-02T18:10:00.000Z'));
       });
     });
 

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -1131,6 +1131,30 @@ describe('bolus utilities', () => {
         wizard: correctionUnderride,
       })).to.be.true;
     });
+
+    it('should prefer dosingDecision.originalFood over food when reading carbs', () => {
+      const withOriginalFoodCarbs = {
+        type: 'bolus',
+        dosingDecision: {
+          recommendedBolus: { amount: 1.5 },
+          // post-edit DD has been zeroed out, but originalFood still holds the
+          // pre-edit carb count -> NOT a correction-only bolus
+          food: { nutrition: { carbohydrate: { net: 0 } } },
+          originalFood: { nutrition: { carbohydrate: { net: 40 } } },
+        },
+      };
+      expect(bolusUtils.isCorrection(withOriginalFoodCarbs)).to.be.false;
+
+      const withOriginalFoodZeroCarbs = {
+        type: 'bolus',
+        dosingDecision: {
+          recommendedBolus: { amount: 1.5 },
+          // originalFood absent -> fall back to food, which is zero -> correction
+          food: { nutrition: { carbohydrate: { net: 0 } } },
+        },
+      };
+      expect(bolusUtils.isCorrection(withOriginalFoodZeroCarbs)).to.be.true;
+    });
   });
 
   describe('isAutomated', () => {

--- a/test/utils/bolus.test.js
+++ b/test/utils/bolus.test.js
@@ -338,6 +338,7 @@ const withDosingDecisionUnderride = {
 
 const withDosingDecisionCorrection = {
   ...withDosingDecision,
+  carbInput: 0, // correction-only bolus: no carbs (consistent with food.net 0)
   dosingDecision: {
     ...withDosingDecision.dosingDecision,
     recommendedBolus: { amount: 0.5 },
@@ -1132,13 +1133,41 @@ describe('bolus utilities', () => {
       })).to.be.true;
     });
 
-    it('should prefer dosingDecision.originalFood over food when reading carbs', () => {
+    it('should prefer the device-gated carbInput over the dosingDecision snapshot when present', () => {
+      // Loop interim bolus: DataUtil annotates carbInput 0 (device food-first) even though
+      // originalFood still holds a pre-edit 40. The bolus dosed for 0 carbs -> correction.
+      const loopZeroCarbInput = {
+        type: 'bolus',
+        carbInput: 0,
+        dosingDecision: {
+          recommendedBolus: { amount: 1.5 },
+          food: { nutrition: { carbohydrate: { net: 0 } } },
+          originalFood: { nutrition: { carbohydrate: { net: 40 } } },
+        },
+      };
+      expect(bolusUtils.isCorrection(loopZeroCarbInput)).to.be.true;
+
+      // carbInput annotated non-zero -> dosed for carbs -> NOT a correction, regardless
+      // of the decision snapshots.
+      const loopNonZeroCarbInput = {
+        type: 'bolus',
+        carbInput: 35,
+        dosingDecision: {
+          recommendedBolus: { amount: 1.5 },
+          food: { nutrition: { carbohydrate: { net: 35 } } },
+          originalFood: { nutrition: { carbohydrate: { net: 25 } } },
+        },
+      };
+      expect(bolusUtils.isCorrection(loopNonZeroCarbInput)).to.be.false;
+    });
+
+    it('should fall back to dosingDecision originalFood over food when carbInput is absent', () => {
+      // No carbInput annotated (e.g. a raw bolus not run through DataUtil): prefer
+      // originalFood (immutable pre-edit snapshot) over a possibly-rewritten food.
       const withOriginalFoodCarbs = {
         type: 'bolus',
         dosingDecision: {
           recommendedBolus: { amount: 1.5 },
-          // post-edit DD has been zeroed out, but originalFood still holds the
-          // pre-edit carb count -> NOT a correction-only bolus
           food: { nutrition: { carbohydrate: { net: 0 } } },
           originalFood: { nutrition: { carbohydrate: { net: 40 } } },
         },


### PR DESCRIPTION
[WEB-4597] 

Related PRs:
https://github.com/tidepool-org/blip/pull/1940
https://github.com/tidepool-org/tideline/pull/543

Fixes QA defects in how carb **edits** (amount, eaten-time, deletion) show in the daily bolus/carb tooltips and PDF.

## Mental model for review

A carb entry is a **`food`** datum (the thing the carb icon draws). Each bolus and the pump's reasoning are **`dosingDecision`** datums, each carrying a nested **`food`** snapshot and — once an edit has happened — an **`originalFood`** snapshot. So the carbs/time for any given moment live on *snapshots inside decisions*, not just on the food datum.

When a carb is **edited**, the platform mints a **new `food` id each time and only the final one survives**; the prior decisions stick around. So an edit chain is **one surviving `food` + N `dosingDecision`s**, and those decisions reference `food`/`bolus` ids that no longer resolve (dangling) — which is why several fixes are about *re-linking* a bolus/food to the right decision rather than trusting the stored association.

The crux: **the two devices store the snapshots inverted.**

| | `dosingDecision.food` | `dosingDecision.originalFood` |
|---|---|---|
| **twiist** | rewritten to the **final** value | the **at-bolus** snapshot (value when this bolus fired) |
| **Tidepool/DIY Loop** | the **at-decision** value (what this bolus dosed on) | the **prior** value |

Worked example — carbs entered 25 g, edited to 35 g, then 34 g, with a bolus at each:

- The bolus that dosed for 35 g: on **Loop** that's `decision.food = 35` (read `food`); on **twiist** that's `decision.originalFood = 35` while `decision.food` has been rewritten to the final 34 (read `originalFood`).
- The struck-through "initial" 25 g is always on the **earliest** decision (`originalDosingDecision`), regardless of device.

So "which carbs/eaten-time does *this* bolus or decision relate to?" depends on **device + position in the edit chain** — no single field is universally right. This PR resolves that **once, in `DataUtil.js`**, annotating each datum with the device-correct values (`carbInput`, `originalDosingDecision`, a canonical `foodTime`, and `tags.carbsEdited`/`entryTimeDiffers`/`foodTimeDiffers`); the tooltips and print view just read those annotations. **Review the data layer first — the rest follows from it.**


**Changes:**
- **Per-bolus carb amount** device-gated in `joinBolusAndDosingDecision` (Loop/DIY → `food` first; twiist → `originalFood` first) so each bolus shows the carbs *it* was dosed on.
- **Original-entry bolus** no longer skipped over a *dangling* bolus association (was rendering "only Delivered" instead of carbs + IOB).
- **Edited/deleted carbs** tagged `carbsEdited` from the earliest decision → "Total Carbs (Edited/Deleted)" + "Initial Carb Amount"; net-0 still renders.
- **Time-edit lineage** recovered via a bounded heuristic (same upload + carb net + orphaned eat-time within **30 min**) → "Time Entered/Edited" + dashed icon. *Best-effort; worst case is a wrong display timestamp, never a dose.*
- **Bolus "(eaten at …)"** now reads the meal's **canonical** eaten time (surviving food's time, shared across the lineage) so all of a meal's boluses agree — matches Figma `5827-161`.
- **`getTarget`** returns `null` (not `NaN–NaN`) with no Loop/Trio schedule; arg-order fix.

**Follow-ups (not in this PR):** deleted Loop carbs render nothing — upstream data gap (no surviving food/deletion record, unlike twiist)

[WEB-4597]: https://tidepool.atlassian.net/browse/WEB-4597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ