### PR TITLE
[WEB-4597] Hide edited time for deleted carbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.56.0-rc.7",
+  "version": "1.56.0-rc.8",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.56.0-rc.9",
+  "version": "1.56.0-rc.10",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/components/daily/foodtooltip/FoodTooltip.js
+++ b/src/components/daily/foodtooltip/FoodTooltip.js
@@ -66,7 +66,6 @@ const FoodTooltip = (props) => {
       const { dosingDecision, originalDosingDecision } = food;
       const absorptionTime = getAbsorptionTime(food);
       const name = getName(food);
-      const latestUpdatedTime = food.payload?.userUpdatedDate;
       const timeOfEntry = moment.utc(food.payload?.userCreatedDate).valueOf() !== food.normalTime ? food.payload?.userCreatedDate : undefined;
 
       if (absorptionTime > 0) {
@@ -147,13 +146,12 @@ const FoodTooltip = (props) => {
             );
           }
 
-          // Only show "Time Edited" when a genuine later edit decision exists. An
+          // Show "Time Edited" only when a genuine later edit decision exists. An
           // originalDosingDecision means a multi-decision chain, so `dosingDecision` is a
-          // real post-entry edit. For a single-decision edit -- e.g. a twiist deletion,
-          // which encodes the whole change in one decision -- `dosingDecision` IS the entry
-          // decision, so its time is the entry time, not the edit. The source doesn't carry
-          // the edit time on a linkable record there, so suppress rather than mislabel; the
-          // payload-based "Last Edited" row below still surfaces a real edit time if present.
+          // real post-entry edit. For a single-decision edit -- e.g. a twiist deletion that
+          // encodes the whole change in one decision -- `dosingDecision` IS the entry
+          // decision, so its time is the entry time, not the edit; omit the row rather than
+          // show the entry time as an edit.
           if (originalDosingDecision) {
             rows.push(
               <div key={'timeEdited'} className={styles.row}>
@@ -185,39 +183,24 @@ const FoodTooltip = (props) => {
         }
       }
 
-      // Skip the payload-based timestamp row only when the DD-driven "Time Edited" row
-      // above actually rendered (a multi-decision chain), to avoid a duplicate. For a
-      // single-decision edit we suppressed "Time Edited" above, so let the payload
-      // "Last Edited" row surface here when the source carries one.
-      const carbsEditedHandledAbove = !!originalDosingDecision && food.tags?.carbsEdited;
-      if (!carbsEditedHandledAbove && (latestUpdatedTime || timeOfEntry)) {
+      // Show "Time of Entry" for a back-logged entry (payload userCreatedDate differs from
+      // the eaten time), unless the dosing-decision rows above ("Time Entered"/"Time Edited")
+      // already convey an amount or time edit.
+      const editHandledAbove = !!dosingDecision
+        && ((food.tags?.carbsEdited && !!originalDosingDecision) || food.tags?.entryTimeDiffers);
+      if (!editHandledAbove && timeOfEntry) {
         rows.push(<div key={'divider'} className={styles.divider} />);
-
-        if (latestUpdatedTime) {
-          rows.push((
-            <div key={'latestUpdatedTime'} className={styles.row}>
-              <div className={styles.label}>{t('Last Edited')}</div>
-              <div className={styles.value}>
-                {formatLocalizedFromUTC(latestUpdatedTime, props.timePrefs, 'h:mm')}
-              </div>
-              <div className={styles.units}>
-                {formatLocalizedFromUTC(latestUpdatedTime, props.timePrefs, 'a')}
-              </div>
+        rows.push((
+          <div key={'timeOfEntry'} className={styles.row}>
+            <div className={styles.label}>{t('Time of Entry')}</div>
+            <div className={styles.value}>
+              {formatLocalizedFromUTC(timeOfEntry, props.timePrefs, 'h:mm')}
             </div>
-          ));
-        } else {
-          rows.push((
-            <div key={'timeOfEntry'} className={styles.row}>
-              <div className={styles.label}>{t('Time of Entry')}</div>
-              <div className={styles.value}>
-                {formatLocalizedFromUTC(timeOfEntry, props.timePrefs, 'h:mm')}
-              </div>
-              <div className={styles.units}>
-                {formatLocalizedFromUTC(timeOfEntry, props.timePrefs, 'a')}
-              </div>
+            <div className={styles.units}>
+              {formatLocalizedFromUTC(timeOfEntry, props.timePrefs, 'a')}
             </div>
-          ));
-        }
+          </div>
+        ));
       }
     }
 

--- a/src/components/daily/foodtooltip/FoodTooltip.js
+++ b/src/components/daily/foodtooltip/FoodTooltip.js
@@ -147,17 +147,26 @@ const FoodTooltip = (props) => {
             );
           }
 
-          rows.push(
-            <div key={'timeEdited'} className={styles.row}>
-              <div className={styles.label}>{t('Time Edited')}</div>
-              <div className={styles.value}>
-                {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'h:mm')}
+          // Only show "Time Edited" when a genuine later edit decision exists. An
+          // originalDosingDecision means a multi-decision chain, so `dosingDecision` is a
+          // real post-entry edit. For a single-decision edit -- e.g. a twiist deletion,
+          // which encodes the whole change in one decision -- `dosingDecision` IS the entry
+          // decision, so its time is the entry time, not the edit. The source doesn't carry
+          // the edit time on a linkable record there, so suppress rather than mislabel; the
+          // payload-based "Last Edited" row below still surfaces a real edit time if present.
+          if (originalDosingDecision) {
+            rows.push(
+              <div key={'timeEdited'} className={styles.row}>
+                <div className={styles.label}>{t('Time Edited')}</div>
+                <div className={styles.value}>
+                  {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'h:mm')}
+                </div>
+                <div className={styles.units}>
+                  {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'a')}
+                </div>
               </div>
-              <div className={styles.units}>
-                {formatLocalizedFromUTC(dosingDecision.time, props.timePrefs, 'a')}
-              </div>
-            </div>
-          );
+            );
+          }
         } else if (entryTimeDiffExceedsThreshold) {
           // Prefer the original-entry decision's time (a time edit's original entry);
           // fall back to the lone decision's time for a back-logged entry with no lineage.
@@ -176,10 +185,11 @@ const FoodTooltip = (props) => {
         }
       }
 
-      // Skip the payload-based timestamp row when carbs were edited — the DD-driven
-      // "Time Edited" row above already conveys the latest edit time,
-      // so emitting `food.payload.userUpdatedDate` here would produce a duplicate.
-      const carbsEditedHandledAbove = !!dosingDecision && food.tags?.carbsEdited;
+      // Skip the payload-based timestamp row only when the DD-driven "Time Edited" row
+      // above actually rendered (a multi-decision chain), to avoid a duplicate. For a
+      // single-decision edit we suppressed "Time Edited" above, so let the payload
+      // "Last Edited" row surface here when the source carries one.
+      const carbsEditedHandledAbove = !!originalDosingDecision && food.tags?.carbsEdited;
       if (!carbsEditedHandledAbove && (latestUpdatedTime || timeOfEntry)) {
         rows.push(<div key={'divider'} className={styles.divider} />);
 

--- a/test/components/daily/FoodTooltip.test.js
+++ b/test/components/daily/FoodTooltip.test.js
@@ -311,13 +311,37 @@ describe('FoodTooltip', () => {
       expect(initialCarbRow[0].querySelector(rowValue).textContent).to.equal('5');
     });
 
-    it('should show "Time Edited" for single dosingDecision with originalFood', () => {
+    it('should NOT show "Time Edited" for a single-decision edited carb (no later edit decision)', () => {
+      // The lone dosingDecision encodes the edit (food 10 / originalFood 5) but its time is
+      // the entry/bolus time, not an edit -> suppress rather than mislabel the entry time.
       const { container } = render(<FoodTooltip {...props} food={loopWithEditedCarbs} />);
       const rows = Array.from(container.querySelectorAll(row));
       const timeRow = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Time Edited'));
-      expect(timeRow).to.have.length(1);
-      expect(timeRow[0].querySelector(rowValue).textContent).to.contain('5:00');
-      expect(timeRow[0].querySelector(rowUnits).textContent).to.contain('pm');
+      expect(timeRow).to.have.length(0);
+      // Initial Carb Amount still renders.
+      const initial = rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'));
+      expect(initial).to.have.length(1);
+    });
+
+    it('should NOT show "Time Edited" for a single-decision deletion, but still labels it Deleted', () => {
+      // twiist deletion: one decision (food 0 / originalFood 30), no later decision, no
+      // payload -> the 2:26 edit time isn't in the data, so show no time row rather than
+      // the 2:15 entry decision time.
+      const deletedCarb = {
+        ...loop,
+        tags: { ...loop.tags, carbsEdited: true, entryTimeDiffers: false },
+        nutrition: { ...loop.nutrition, carbohydrate: { net: 0, units: 'grams' } },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T18:15:00.000Z'), // entry/bolus decision, not the edit
+          food: { time: '2024-02-02T18:14:48.000Z', nutrition: { carbohydrate: { net: 0 } } },
+          originalFood: { time: '2024-02-02T18:14:48.000Z', nutrition: { carbohydrate: { net: 30 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={deletedCarb} />);
+      expect(container.querySelector(carbLabel).textContent).to.contain('Deleted');
+      const rows = Array.from(container.querySelectorAll(row));
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'))).to.have.length(1);
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Time Edited'))).to.have.length(0);
     });
 
     it('should show "Time Entered" and "Time Edited" for multiple dosingDecisions', () => {

--- a/test/components/daily/FoodTooltip.test.js
+++ b/test/components/daily/FoodTooltip.test.js
@@ -344,6 +344,45 @@ describe('FoodTooltip', () => {
       expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Time Edited'))).to.have.length(0);
     });
 
+    it('time-only edit shows "Time Entered" and keeps the plain "Total Carbs" label', () => {
+      // Amount unchanged (carbsEdited false), eaten time edited (entryTimeDiffers true):
+      // a time-only edit shows "Time Entered" and is not labeled an amount edit.
+      const timeOnlyEdit = {
+        ...loop,
+        tags: { ...loop.tags, carbsEdited: false, entryTimeDiffers: true },
+        nutrition: { ...loop.nutrition, carbohydrate: { net: 31, units: 'grams' } },
+        payload: {
+          userCreatedDate: '2024-02-02T19:11:33.000Z',
+          userUpdatedDate: '2024-02-02T19:12:59.000Z',
+        },
+        originalDosingDecision: {
+          time: Date.parse('2024-02-02T19:11:45.000Z'),
+          food: { time: '2024-02-02T19:11:33.000Z', nutrition: { carbohydrate: { net: 31 } } },
+        },
+        dosingDecision: {
+          time: Date.parse('2024-02-02T19:13:23.000Z'),
+          food: { time: '2024-02-02T19:21:06.000Z', nutrition: { carbohydrate: { net: 31 } } },
+          originalFood: { time: '2024-02-02T19:01:06.000Z', nutrition: { carbohydrate: { net: 31 } } },
+        },
+      };
+      const { container } = render(<FoodTooltip {...props} food={timeOnlyEdit} />);
+      const rows = Array.from(container.querySelectorAll(row));
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Entered')).to.have.length(1);
+      expect(container.querySelector(carbLabel).textContent).to.contain('Total Carbs');
+      expect(container.querySelector(carbLabel).textContent).to.not.contain('Edited');
+    });
+
+    it('combined amount + time edit shows BOTH Initial Carb Amount and Time Entered + Time Edited', () => {
+      // loopWithMultipleDosingDecisions: carbsEdited true AND entryTimeDiffers true, with
+      // lineage -> the amount-edit block renders Initial Carb Amount AND the time rows.
+      const { container } = render(<FoodTooltip {...props} food={loopWithMultipleDosingDecisions} />);
+      const rows = Array.from(container.querySelectorAll(row));
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'))).to.have.length(1);
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Entered')).to.have.length(1);
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Edited')).to.have.length(1);
+      expect(container.querySelector(carbLabel).textContent).to.contain('Edited');
+    });
+
     it('should show "Time Entered" and "Time Edited" for multiple dosingDecisions', () => {
       const { container } = render(<FoodTooltip {...props} food={loopWithMultipleDosingDecisions} />);
       const rows = Array.from(container.querySelectorAll(row));
@@ -445,7 +484,6 @@ describe('FoodTooltip', () => {
       expect(container.querySelector(carbLabel).textContent).to.equal('Total Carbs');
       const rows = Array.from(container.querySelectorAll(row));
       expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Initial Carb Amount'))).to.have.length(0);
-      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent.includes('Last Edited'))).to.have.length(0);
     });
 
     it('deleted entry (carbsEdited && carbs === 0) renders "Total Carbs (Deleted)" label', () => {
@@ -482,19 +520,16 @@ describe('FoodTooltip', () => {
       expect(container.querySelector(carbValue).textContent).to.equal('0.1');
     });
 
-    it('does not render the payload-based "Last Edited" row when the DD-based "Time Edited" row already shows', () => {
-      const editedWithPayload = {
-        ...fourEditChain,
-        payload: { userUpdatedDate: '2024-02-02T20:00:00.000Z' },
+    it('renders "Time of Entry" for a back-logged entry (userCreatedDate differs from eaten time)', () => {
+      const backLogged = {
+        ...loop,
+        normalTime: Date.parse('2024-02-02T18:00:00.000Z'), // eaten time
+        tags: { ...loop.tags, carbsEdited: false, entryTimeDiffers: false },
+        payload: { userCreatedDate: '2024-02-02T19:30:00.000Z' }, // logged 90 min later
       };
-      const { container } = render(<FoodTooltip {...props} food={editedWithPayload} />);
+      const { container } = render(<FoodTooltip {...props} food={backLogged} />);
       const rows = Array.from(container.querySelectorAll(row));
-      // The payload-derived "Last Edited" row must be suppressed.
-      const payloadLastEditedRows = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Last Edited');
-      expect(payloadLastEditedRows).to.have.length(0);
-      // Only the DD-derived "Time Edited" row should remain.
-      const timeEditedRows = rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time Edited');
-      expect(timeEditedRows).to.have.length(1);
+      expect(rows.filter(n => n.querySelector(rowLabel)?.textContent === 'Time of Entry')).to.have.length(1);
     });
   });
 


### PR DESCRIPTION
[WEB-4597] 

One more small revision - we need to, due to a lack of proper data from twiist, hide edited time for deleted carbs.

Related PR:  https://github.com/tidepool-org/blip/pull/1941

[WEB-4597]: https://tidepool.atlassian.net/browse/WEB-4597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ