### PR TITLE
WEB-4556 add glycemic ranges util exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "24.15.0"
   },
   "packageManager": "yarn@3.6.4",
-  "version": "1.58.0",
+  "version": "1.59.0-web-4556-glycemic-ranges.1",
   "description": "Tidepool data visualization for diabetes device data.",
   "keywords": [
     "data visualization"

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ import {
   statFetchMethods,
 } from './utils/stat';
 
-import { getGlycemicRangesPreset } from './utils/glycemicRanges';
+import { getGlycemicRangesPreset, getBgBoundsForGlycemicRanges } from './utils/glycemicRanges';
 
 import { bgLogText } from './utils/bgLog/data';
 import { trendsText } from './utils/trends/data';
@@ -196,6 +196,8 @@ const utils = {
   },
   glycemicRanges: {
     getGlycemicRangesPreset,
+    getBgBoundsForGlycemicRanges,
+    DEFAULT_BG_BOUNDS,
   }
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -45,78 +45,15 @@ export const BG_DISPLAY_MINIMUM_INCREMENTS = {
   [MMOLL_UNITS]: 0.1,
 };
 
-export const GLYCEMIC_RANGES_PRESET = {
-  ADA_STANDARD: 'adaStandard',
-  ADA_OLDER_HIGH_RISK: 'adaHighRisk',
-  ADA_PREGNANCY_T1: 'adaPregnancyType1',
-  ADA_GESTATIONAL_T2: 'adaPregnancyType2',
-};
-
-export const GLYCEMIC_RANGES_TYPE = {
-  PRESET: 'preset',
-  CUSTOM: 'custom',
-};
-
-export const DEFAULT_BG_BOUNDS = {
-  [MGDL_UNITS]: {
-    veryLowThreshold: 54,
-    targetLowerBound: 70,
-    targetUpperBound: 180,
-    veryHighThreshold: 250,
-    extremeHighThreshold: 350,
-    clampThreshold: 600,
-  },
-  [MMOLL_UNITS]: {
-    veryLowThreshold: 3.0,
-    targetLowerBound: 3.9,
-    targetUpperBound: 10.0,
-    veryHighThreshold: 13.9,
-    extremeHighThreshold: 19.4,
-    clampThreshold: 33.3,
-  },
-};
-
-export const ADA_STANDARD_BG_BOUNDS = DEFAULT_BG_BOUNDS;
-
-export const ADA_OLDER_HIGH_RISK_BG_BOUNDS = {
-  [MGDL_UNITS]: {
-    veryLowThreshold: null,
-    targetLowerBound: 70,
-    targetUpperBound: 180,
-    veryHighThreshold: 250,
-    extremeHighThreshold: null,
-    clampThreshold: 600,
-  },
-  [MMOLL_UNITS]: {
-    veryLowThreshold: null,
-    targetLowerBound: 3.9,
-    targetUpperBound: 10.0,
-    veryHighThreshold: 13.9,
-    extremeHighThreshold: null,
-    clampThreshold: 33.3,
-  },
-};
-
-export const ADA_PREGNANCY_T1_BG_BOUNDS = {
-  [MGDL_UNITS]: {
-    veryLowThreshold: 54,
-    targetLowerBound: 63,
-    targetUpperBound: 140,
-    veryHighThreshold: null,
-    extremeHighThreshold: null,
-    clampThreshold: 600,
-  },
-  [MMOLL_UNITS]: {
-    veryLowThreshold: 3.0,
-    targetLowerBound: 3.5,
-    targetUpperBound: 7.8,
-    veryHighThreshold: null,
-    extremeHighThreshold: null,
-    clampThreshold: 33.3,
-  },
-};
-
-export const ADA_GESTATIONAL_T2_BG_BOUNDS = ADA_PREGNANCY_T1_BG_BOUNDS;
+export {
+  ADA_GESTATIONAL_T2_BG_BOUNDS,
+  ADA_OLDER_HIGH_RISK_BG_BOUNDS,
+  ADA_PREGNANCY_T1_BG_BOUNDS,
+  ADA_STANDARD_BG_BOUNDS,
+  DEFAULT_BG_BOUNDS,
+  GLYCEMIC_RANGES_PRESET,
+  GLYCEMIC_RANGES_TYPE,
+} from './glycemicRangeConstants';
 
 export const LBS_PER_KG = 2.2046226218;
 

--- a/src/utils/glycemicRangeConstants.js
+++ b/src/utils/glycemicRangeConstants.js
@@ -21,8 +21,8 @@
 // Do not import i18next, lodash, or anything else from here — keeping this
 // module side-effect-free is what lets it load in plain Node.
 
-const MGDL_UNITS = 'mg/dL';
-const MMOLL_UNITS = 'mmol/L';
+export const MGDL_UNITS = 'mg/dL';
+export const MMOLL_UNITS = 'mmol/L';
 
 export const GLYCEMIC_RANGES_PRESET = {
   ADA_STANDARD: 'adaStandard',

--- a/src/utils/glycemicRangeConstants.js
+++ b/src/utils/glycemicRangeConstants.js
@@ -1,0 +1,98 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2026, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+// Glycemic-range constants extracted from utils/constants.js into their own
+// dependency-free module so they can be exposed via a Node-friendly bundle
+// (dist/glycemicRanges.js) for non-browser consumers (e.g. data-export-service).
+// Do not import i18next, lodash, or anything else from here — keeping this
+// module side-effect-free is what lets it load in plain Node.
+
+const MGDL_UNITS = 'mg/dL';
+const MMOLL_UNITS = 'mmol/L';
+
+export const GLYCEMIC_RANGES_PRESET = {
+  ADA_STANDARD: 'adaStandard',
+  ADA_OLDER_HIGH_RISK: 'adaHighRisk',
+  ADA_PREGNANCY_T1: 'adaPregnancyType1',
+  ADA_GESTATIONAL_T2: 'adaPregnancyType2',
+};
+
+export const GLYCEMIC_RANGES_TYPE = {
+  PRESET: 'preset',
+  CUSTOM: 'custom',
+};
+
+export const DEFAULT_BG_BOUNDS = {
+  [MGDL_UNITS]: {
+    veryLowThreshold: 54,
+    targetLowerBound: 70,
+    targetUpperBound: 180,
+    veryHighThreshold: 250,
+    extremeHighThreshold: 350,
+    clampThreshold: 600,
+  },
+  [MMOLL_UNITS]: {
+    veryLowThreshold: 3.0,
+    targetLowerBound: 3.9,
+    targetUpperBound: 10.0,
+    veryHighThreshold: 13.9,
+    extremeHighThreshold: 19.4,
+    clampThreshold: 33.3,
+  },
+};
+
+export const ADA_STANDARD_BG_BOUNDS = DEFAULT_BG_BOUNDS;
+
+export const ADA_OLDER_HIGH_RISK_BG_BOUNDS = {
+  [MGDL_UNITS]: {
+    veryLowThreshold: null,
+    targetLowerBound: 70,
+    targetUpperBound: 180,
+    veryHighThreshold: 250,
+    extremeHighThreshold: null,
+    clampThreshold: 600,
+  },
+  [MMOLL_UNITS]: {
+    veryLowThreshold: null,
+    targetLowerBound: 3.9,
+    targetUpperBound: 10.0,
+    veryHighThreshold: 13.9,
+    extremeHighThreshold: null,
+    clampThreshold: 33.3,
+  },
+};
+
+export const ADA_PREGNANCY_T1_BG_BOUNDS = {
+  [MGDL_UNITS]: {
+    veryLowThreshold: 54,
+    targetLowerBound: 63,
+    targetUpperBound: 140,
+    veryHighThreshold: null,
+    extremeHighThreshold: null,
+    clampThreshold: 600,
+  },
+  [MMOLL_UNITS]: {
+    veryLowThreshold: 3.0,
+    targetLowerBound: 3.5,
+    targetUpperBound: 7.8,
+    veryHighThreshold: null,
+    extremeHighThreshold: null,
+    clampThreshold: 33.3,
+  },
+};
+
+export const ADA_GESTATIONAL_T2_BG_BOUNDS = ADA_PREGNANCY_T1_BG_BOUNDS;

--- a/src/utils/glycemicRanges.js
+++ b/src/utils/glycemicRanges.js
@@ -22,6 +22,8 @@ export {
   DEFAULT_BG_BOUNDS,
   GLYCEMIC_RANGES_PRESET,
   GLYCEMIC_RANGES_TYPE,
+  MGDL_UNITS,
+  MMOLL_UNITS,
 } from './glycemicRangeConstants';
 
 /**

--- a/src/utils/glycemicRanges.js
+++ b/src/utils/glycemicRanges.js
@@ -1,4 +1,28 @@
-import { GLYCEMIC_RANGES_PRESET, GLYCEMIC_RANGES_TYPE } from './constants';
+import {
+  ADA_GESTATIONAL_T2_BG_BOUNDS,
+  ADA_OLDER_HIGH_RISK_BG_BOUNDS,
+  ADA_PREGNANCY_T1_BG_BOUNDS,
+  ADA_STANDARD_BG_BOUNDS,
+  GLYCEMIC_RANGES_PRESET,
+  GLYCEMIC_RANGES_TYPE,
+} from './glycemicRangeConstants';
+
+const PRESET_BOUNDS = {
+  [GLYCEMIC_RANGES_PRESET.ADA_STANDARD]: ADA_STANDARD_BG_BOUNDS,
+  [GLYCEMIC_RANGES_PRESET.ADA_OLDER_HIGH_RISK]: ADA_OLDER_HIGH_RISK_BG_BOUNDS,
+  [GLYCEMIC_RANGES_PRESET.ADA_PREGNANCY_T1]: ADA_PREGNANCY_T1_BG_BOUNDS,
+  [GLYCEMIC_RANGES_PRESET.ADA_GESTATIONAL_T2]: ADA_GESTATIONAL_T2_BG_BOUNDS,
+};
+
+export {
+  ADA_GESTATIONAL_T2_BG_BOUNDS,
+  ADA_OLDER_HIGH_RISK_BG_BOUNDS,
+  ADA_PREGNANCY_T1_BG_BOUNDS,
+  ADA_STANDARD_BG_BOUNDS,
+  DEFAULT_BG_BOUNDS,
+  GLYCEMIC_RANGES_PRESET,
+  GLYCEMIC_RANGES_TYPE,
+} from './glycemicRangeConstants';
 
 /**
  * Extracts the glycemic ranges preset value from the glycemicRanges object of the
@@ -20,4 +44,31 @@ export const getGlycemicRangesPreset = glycemicRanges => {
     default: // eslint-disable-line no-fallthrough
       return GLYCEMIC_RANGES_PRESET.ADA_STANDARD;
   }
+};
+
+/**
+ * Resolve the BG bounds table for a patient's assigned glycemic range.
+ * Single source of truth used by both blip (browser PDFs) and the
+ * data-export-service (EHR PDFs) so the two stay in lockstep.
+ *
+ * @param {Object|null} glycemicRanges the glycemicRanges object of the clinicPatient record
+ * @param {string} bgUnits 'mg/dL' or 'mmol/L'
+ *
+ * @return {Object} bgBounds, e.g. { veryLowThreshold, targetLowerBound, targetUpperBound, veryHighThreshold, extremeHighThreshold, clampThreshold }
+ */
+export const getBgBoundsForGlycemicRanges = (glycemicRanges, bgUnits) => {
+  const preset = getGlycemicRangesPreset(glycemicRanges);
+  // Own-property checks: `preset` comes straight from patient data and `bgUnits`
+  // from the caller, so a value like "constructor"/"toString" would otherwise
+  // resolve an inherited prototype member — skipping the ADA_STANDARD fallback
+  // and defeating the TypeError guard below.
+  const bounds = Object.prototype.hasOwnProperty.call(PRESET_BOUNDS, preset)
+    ? PRESET_BOUNDS[preset]
+    : ADA_STANDARD_BG_BOUNDS;
+  if (!Object.prototype.hasOwnProperty.call(bounds, bgUnits)) {
+    throw new TypeError(
+      `getBgBoundsForGlycemicRanges: invalid bgUnits "${bgUnits}". Expected "mg/dL" or "mmol/L".`
+    );
+  }
+  return bounds[bgUnits];
 };

--- a/test/utils/glycemicRanges.test.js
+++ b/test/utils/glycemicRanges.test.js
@@ -1,0 +1,109 @@
+/*
+ * == BSD2 LICENSE ==
+ * Copyright (c) 2026, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ * == BSD2 LICENSE ==
+ */
+
+import {
+  getBgBoundsForGlycemicRanges,
+  getGlycemicRangesPreset,
+} from '../../src/utils/glycemicRanges';
+
+import {
+  ADA_GESTATIONAL_T2_BG_BOUNDS,
+  ADA_OLDER_HIGH_RISK_BG_BOUNDS,
+  ADA_PREGNANCY_T1_BG_BOUNDS,
+  ADA_STANDARD_BG_BOUNDS,
+} from '../../src/utils/glycemicRangeConstants';
+
+import { MGDL_UNITS, MMOLL_UNITS } from '../../src/utils/constants';
+
+describe('glycemicRanges', () => {
+  describe('getGlycemicRangesPreset', () => {
+    it('returns ADA standard when glycemicRanges is missing', () => {
+      expect(getGlycemicRangesPreset(null)).to.equal('adaStandard');
+      expect(getGlycemicRangesPreset(undefined)).to.equal('adaStandard');
+    });
+
+    it('returns the preset for type=preset', () => {
+      expect(getGlycemicRangesPreset({ type: 'preset', preset: 'adaPregnancyType1' })).to.equal('adaPregnancyType1');
+      expect(getGlycemicRangesPreset({ type: 'preset', preset: 'adaHighRisk' })).to.equal('adaHighRisk');
+    });
+
+    it('falls back to ADA standard for type=custom (not yet implemented)', () => {
+      expect(getGlycemicRangesPreset({ type: 'custom' })).to.equal('adaStandard');
+    });
+
+    it('falls back to ADA standard for unknown type', () => {
+      expect(getGlycemicRangesPreset({ type: 'somethingElse' })).to.equal('adaStandard');
+    });
+  });
+
+  describe('getBgBoundsForGlycemicRanges', () => {
+    it('returns ADA standard bounds when glycemicRanges is missing', () => {
+      expect(getBgBoundsForGlycemicRanges(null, MGDL_UNITS)).to.deep.equal(ADA_STANDARD_BG_BOUNDS[MGDL_UNITS]);
+      expect(getBgBoundsForGlycemicRanges(undefined, MMOLL_UNITS)).to.deep.equal(ADA_STANDARD_BG_BOUNDS[MMOLL_UNITS]);
+    });
+
+    it('returns ADA pregnancy type 1 bounds in mg/dL', () => {
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'preset', preset: 'adaPregnancyType1' }, MGDL_UNITS),
+      ).to.deep.equal(ADA_PREGNANCY_T1_BG_BOUNDS[MGDL_UNITS]);
+    });
+
+    it('returns ADA pregnancy type 2 (gestational) bounds in mmol/L', () => {
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'preset', preset: 'adaPregnancyType2' }, MMOLL_UNITS),
+      ).to.deep.equal(ADA_GESTATIONAL_T2_BG_BOUNDS[MMOLL_UNITS]);
+    });
+
+    it('returns ADA older/high-risk bounds in mg/dL', () => {
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'preset', preset: 'adaHighRisk' }, MGDL_UNITS),
+      ).to.deep.equal(ADA_OLDER_HIGH_RISK_BG_BOUNDS[MGDL_UNITS]);
+    });
+
+    it('returns ADA standard bounds when preset is unrecognized', () => {
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'preset', preset: 'noSuchPreset' }, MGDL_UNITS),
+      ).to.deep.equal(ADA_STANDARD_BG_BOUNDS[MGDL_UNITS]);
+    });
+
+    it('returns ADA standard bounds for type=custom', () => {
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'custom' }, MMOLL_UNITS),
+      ).to.deep.equal(ADA_STANDARD_BG_BOUNDS[MMOLL_UNITS]);
+    });
+
+    it('throws a TypeError when bgUnits is invalid', () => {
+      expect(() => getBgBoundsForGlycemicRanges(null, 'badUnits')).to.throw(TypeError);
+      expect(() => getBgBoundsForGlycemicRanges(null, undefined)).to.throw(TypeError);
+    });
+
+    it('does not resolve inherited Object.prototype keys as bgUnits', () => {
+      expect(() => getBgBoundsForGlycemicRanges(null, 'constructor')).to.throw(TypeError);
+      expect(() => getBgBoundsForGlycemicRanges(null, 'toString')).to.throw(TypeError);
+      expect(() => getBgBoundsForGlycemicRanges(null, 'hasOwnProperty')).to.throw(TypeError);
+    });
+
+    it('falls back to ADA standard when preset is an inherited Object.prototype key', () => {
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'preset', preset: 'constructor' }, MGDL_UNITS),
+      ).to.deep.equal(ADA_STANDARD_BG_BOUNDS[MGDL_UNITS]);
+      expect(
+        getBgBoundsForGlycemicRanges({ type: 'preset', preset: 'toString' }, MMOLL_UNITS),
+      ).to.deep.equal(ADA_STANDARD_BG_BOUNDS[MMOLL_UNITS]);
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ const entry = {
   data: [path.join(__dirname, '/src/modules/data/index')],
   print: [path.join(__dirname, '/src/modules/print/index')],
   getAGPFigures: [path.join(__dirname, '/src/utils/print/plotly')],
+  glycemicRanges: [path.join(__dirname, '/src/utils/glycemicRanges')],
 };
 
 const output = {


### PR DESCRIPTION
for [WEB-4556] related export PR: https://github.com/tidepool-org/export/pull/91
This pull request refactors how glycemic range constants and utilities are organized and exposed, making them available in a dependency-free module suitable for both browser and Node.js environments. It also introduces a new utility function for resolving blood glucose (BG) bounds for a patient's glycemic range, ensures robust property checks, and adds comprehensive tests. The package version is incremented to reflect these changes.

**Glycemic Range Constants Refactor and Export:**

* Extracted all glycemic range-related constants from `src/utils/constants.js` into a new, dependency-free module `src/utils/glycemicRangeConstants.js`, and updated all imports to use this new module. This allows these constants to be bundled for Node.js consumers (e.g., data-export-service) without browser-specific dependencies. [[1]](diffhunk://#diff-bd2e652035adaf33b6125f14a823cf76feae0c1c1a592e9a6c14a14951a52a28L48-R56) [[2]](diffhunk://#diff-f479ded1de7e06a2e12d991e0acac18a7651b78e5685696fbe57d85fa65c648bR1-R98) [[3]](diffhunk://#diff-40a34648d57b38407237f9a0d64b27bd001039d615e87441757238b52cc729e5L1-R25)

**Utility Function Enhancements:**

* Added a new function `getBgBoundsForGlycemicRanges` to `src/utils/glycemicRanges.js`, which robustly resolves the correct BG bounds for a patient, with defensive checks against prototype pollution and invalid units. This function is now exported and available for both browser and Node.js usage. [[1]](diffhunk://#diff-40a34648d57b38407237f9a0d64b27bd001039d615e87441757238b52cc729e5R48-R74) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L84-R84) [[3]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R199-R200)

**Testing Improvements:**

* Added comprehensive unit tests for both `getGlycemicRangesPreset` and the new `getBgBoundsForGlycemicRanges` in `test/utils/glycemicRanges.test.js`, covering edge cases like missing data, invalid units, and prototype pollution.

**Build and Packaging:**

* Updated `webpack.config.js` to expose `glycemicRanges` as a standalone bundle entry, enabling external Node.js consumers to import glycemic range utilities directly.
* Bumped the package version to `1.59.0-web-4556-glycemic-ranges.1` to reflect these functional and structural changes.

[WEB-4556]: https://tidepool.atlassian.net/browse/WEB-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ